### PR TITLE
fix: wire dead mobile controls to real actions/feedback

### DIFF
--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { MapPinned, Navigation, PencilLine, X } from 'lucide-react';
+import { toast } from 'sonner';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
 import { cn } from '@/lib/utils';
@@ -33,7 +34,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
               <X className="h-8 w-8" />
             </button>
             <h1 className="absolute left-1/2 -translate-x-1/2 text-[28px] font-semibold">Account Details</h1>
-            <button className="min-w-14 text-right text-[24px]">Edit</button>
+            <button type="button" onClick={() => toast.message('Account editing is coming soon')} className="min-w-14 text-right text-[24px]">Edit</button>
           </div>
           <SegmentedControl
             value="detail"
@@ -67,8 +68,8 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
         <div className="fixed bottom-[92px] left-0 right-0 z-[5100]">
           <div className="mx-auto grid max-w-[480px] grid-cols-4 border-t border-[#c6c7cb] bg-[#f2f2f5] py-3 text-[#5a96e8]">
             <ActionButton label={routeSelected ? 'remove' : 'add to...'} onClick={() => onAddToRoute(store.id)} icon={<MapPinned className="h-6 w-6" />} />
-            <ActionButton label="check-in" onClick={() => {}} icon={<PencilLine className="h-6 w-6" />} />
-            <ActionButton label="center" onClick={() => {}} icon={<MapPinned className="h-6 w-6" />} />
+            <ActionButton label="check-in" onClick={() => toast.message('Check-in flow is coming soon')} icon={<PencilLine className="h-6 w-6" />} />
+            <ActionButton label="center" onClick={() => window.open(`https://www.google.com/maps/search/?api=1&query=${store.lat},${store.lng}`, '_blank', 'noopener,noreferrer')} icon={<MapPinned className="h-6 w-6" />} />
             <a href={navigateUrl} target="_blank" rel="noreferrer" className={cn(actionBaseClass, 'text-center')}>
               <Navigation className="h-6 w-6" />
               <span>navigate</span>

--- a/components/mobile/accounts-mobile.tsx
+++ b/components/mobile/accounts-mobile.tsx
@@ -3,6 +3,7 @@
 import { Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { AccountDetailSheet } from '@/components/mobile/account-detail-sheet';
 import { AlphabetRail } from '@/components/mobile/alphabet-rail';
 import { MobileHeader } from '@/components/mobile/mobile-header';
@@ -76,7 +77,19 @@ export function AccountsMobile() {
 
   return (
     <div className="min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
-      <MobileHeader title="Accounts" right={<button className="text-[42px] leading-none"><Plus className="ml-auto h-9 w-9" /></button>}>
+      <MobileHeader
+        title="Accounts"
+        right={(
+          <button
+            type="button"
+            onClick={() => toast.message('New account flow is coming soon')}
+            aria-label="Add account"
+            className="text-[42px] leading-none"
+          >
+            <Plus className="ml-auto h-9 w-9" />
+          </button>
+        )}
+      >
         <SegmentedControl
           value={scope}
           onChange={(value) => setScope(value as 'all' | 'recent' | 'follow-ups')}

--- a/components/mobile/calendar-mobile.tsx
+++ b/components/mobile/calendar-mobile.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ChevronLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 
 const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
@@ -20,12 +21,14 @@ const aprilRows = [
 ];
 
 export function CalendarMobile() {
+  const router = useRouter();
+
   return (
     <div className="min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
       <MobileHeader
         title="March - 2026"
         left={
-          <button className="flex items-center gap-1 text-[22px]">
+          <button type="button" onClick={() => router.back()} className="flex items-center gap-1 text-[22px]">
             <ChevronLeft className="h-8 w-8" />
             <span>Calendar</span>
           </button>

--- a/components/mobile/route-mobile.tsx
+++ b/components/mobile/route-mobile.tsx
@@ -109,7 +109,13 @@ export function RouteMobile() {
       <MobileHeader
         title="Route"
         right={
-          tab === 'saved' ? <button className="text-[24px]">Edit</button> : <Plus className="ml-auto h-10 w-10" />
+          tab === 'saved' ? (
+            <button type="button" onClick={() => toast.message('Saved route editing is coming soon')} className="text-[24px]">Edit</button>
+          ) : (
+            <button type="button" onClick={() => setShowAddModal(true)} aria-label="Add location" className="leading-none">
+              <Plus className="ml-auto h-10 w-10" />
+            </button>
+          )
         }
       >
         <SegmentedControl

--- a/components/mobile/settings-mobile.tsx
+++ b/components/mobile/settings-mobile.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ChevronRight } from 'lucide-react';
+import { toast } from 'sonner';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 
 const items = [
@@ -20,7 +21,12 @@ export function SettingsMobile() {
       <MobileHeader title="Settings" />
       <div className="border-t border-[#c7c8ce]">
         {items.map((item) => (
-          <button key={item} className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-5 py-4 text-left">
+          <button
+            key={item}
+            type="button"
+            onClick={() => toast.message(`${item} settings are coming soon`)}
+            className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-5 py-4 text-left"
+          >
             <span className="text-[23px] text-[#2a2c31]">{item}</span>
             <ChevronRight className="h-7 w-7 text-[#bcc0c7]" />
           </button>

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 import { ListFilter, MapPinned, MessageCircleMore, Navigation, Plus, Search, SlidersHorizontal } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
@@ -124,7 +125,18 @@ export function TerritoryMobile() {
           />
 
           <div className="absolute left-3 top-6 z-[1500] flex flex-col gap-3">
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow">
+            <button
+              type="button"
+              onClick={() => {
+                if (focusedStore) {
+                  setDetailStoreId(focusedStore.id);
+                  return;
+                }
+                toast.message('Select a pin to view details');
+              }}
+              className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow"
+              aria-label="Open focused location"
+            >
               <MapPinned className="h-6 w-6 text-[#7f828a]" />
             </button>
             <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setRefreshNonce((v) => v + 1)}>
@@ -136,10 +148,20 @@ export function TerritoryMobile() {
             <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setView('list')}>
               <Search className="h-6 w-6 text-[#7f828a]" />
             </button>
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow">
+            <button
+              type="button"
+              onClick={() => toast.message('Map filters are coming soon')}
+              className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow"
+              aria-label="Filter map locations"
+            >
               <ListFilter className="h-6 w-6 text-[#7f828a]" />
             </button>
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow">
+            <button
+              type="button"
+              onClick={() => toast.message('Messaging tools are coming soon')}
+              className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow"
+              aria-label="Open messaging"
+            >
               <MessageCircleMore className="h-6 w-6 text-[#d25a3f]" />
             </button>
           </div>
@@ -191,7 +213,7 @@ export function TerritoryMobile() {
               <p className="truncate text-[17px] text-[#b6bac3]">{focusedStore.locationAddress ?? focusedStore.locationLabel ?? 'No address'}</p>
             </button>
             <div className="grid grid-cols-[1fr_72px_72px] border-b border-[#30333b]">
-              <button type="button" className="flex items-center gap-2 px-4 py-2 text-[17px] text-[#d5d9e1]">
+              <button type="button" onClick={() => setDetailStoreId(focusedStore.id)} className="flex items-center gap-2 px-4 py-2 text-[17px] text-[#d5d9e1]">
                 <span className="inline-block h-4 w-4 rounded-full bg-[#f45a34]" />
                 {focusedStore.repNames[0] ?? 'Unassigned'}
               </button>


### PR DESCRIPTION
## Summary
Small UI pass focused on dead/no-op controls in active mobile surfaces.

### Fixed controls
- Accounts mobile header: `+` button now responds (toast) instead of no-op.
- Account detail sheet: `Edit` now responds (toast) instead of no-op.
- Account detail sheet actions: `check-in` now responds (toast) and `center` now opens Maps at the account coordinates.
- Route mobile header: current-tab `+` now opens Add Location modal; saved-tab `Edit` now responds (toast) instead of no-op.
- Settings mobile list rows now respond with contextual feedback instead of no-op buttons.
- Calendar mobile back control now calls `router.back()` instead of being inert.
- Territory mobile map controls: map-pin button opens focused account detail; filter/message buttons now provide feedback to avoid silent no-op.
- Territory map card rep row is now actionable (opens account detail).

## Validation
- `npm run lint` ✅
- `npm run typecheck` ✅
