### PR TITLE
chore: stabilize typecheck across parallel branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "analyze": "ANALYZE=true next build",
     "start": "next start",
     "lint": "eslint app components lib prisma --ext .ts,.tsx",
+    "pretypecheck": "node -e \"require('node:fs').rmSync('.next/types',{ recursive: true, force: true })\"",
     "typecheck": "tsc --noEmit",
     "perf:collect": "lhci collect --config=.lighthouserc.json",
     "perf:assert": "lhci assert --config=.lighthouserc.json",


### PR DESCRIPTION
## Summary
- add a pretypecheck script to remove stale .next/types before running tsc --noEmit
- prevents false typecheck failures when switching branches/worktrees that add/remove route files

## Validation
- Node v22.22.0
- npm run typecheck passed
- npm run lint passed
- npm run build passed

## Notes
- no runtime behavior change; this only affects local and CI build hygiene
