### PR TITLE
Mobile UI pass 2: tap target and overflow fixes

### DIFF
--- a/app/(main)/conversations/page.tsx
+++ b/app/(main)/conversations/page.tsx
@@ -50,7 +50,7 @@ export default async function ConversationsPage({
             <Link
               key={value}
               href={`/conversations?channel=${value}`}
-              className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition ${
+              className={`inline-flex min-h-11 items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition ${
                 active
                   ? 'border-primary bg-primary text-white'
                   : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200'

--- a/components/crm/account-hero.tsx
+++ b/components/crm/account-hero.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Badge, Button, Card, CardContent } from '@/components/ui';
 
 type Props = {
@@ -20,7 +21,7 @@ export function AccountHero({ title, subtitle, status, onQuickLogHref = '#' }: P
         </div>
         <div className="flex flex-wrap gap-2">
           <Button asChild>
-            <a href={onQuickLogHref}>Quick Log</a>
+            <Link href={onQuickLogHref === '#' ? '/conversations' : onQuickLogHref}>Quick Log</Link>
           </Button>
           <Button variant="secondary">New Task</Button>
           <Button variant="outline">Schedule Appointment</Button>

--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -70,7 +70,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
       <div className="mx-auto h-full max-w-[480px] bg-[#e6e6e9]">
         <div className="bg-[#c93412] px-4 pb-2 pt-[max(10px,env(safe-area-inset-top))] text-white">
           <div className="relative flex items-center justify-between py-1.5">
-            <button onClick={onClose} className="grid h-10 w-10 place-items-center rounded-lg" aria-label="Close">
+            <button type="button" onClick={onClose} className="grid h-11 w-11 place-items-center rounded-lg" aria-label="Close">
               <X className="h-6 w-6" />
             </button>
             <h1 className="absolute left-1/2 -translate-x-1/2 text-[18px] font-semibold">Account Details</h1>
@@ -103,7 +103,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
           ))}
         </div>
 
-        <div className="fixed bottom-[84px] left-0 right-0 z-[5100]">
+        <div className="fixed bottom-[calc(84px+env(safe-area-inset-bottom))] left-0 right-0 z-[5100]">
           <div className="mx-auto grid max-w-[480px] grid-cols-4 border-t border-[#c6c7cb] bg-[#f2f2f5] py-2 text-[#5a96e8]">
             <ActionButton
               label={routeSelected ? 'remove' : 'add to...'}

--- a/components/mobile/accounts-mobile.tsx
+++ b/components/mobile/accounts-mobile.tsx
@@ -99,7 +99,7 @@ export function AccountsMobile() {
       <div className="px-4 pb-28 pt-3">
         <div className="flex items-center gap-2">
           <MobileSearch value={search} onChange={setSearch} placeholder="Search Accounts" className="flex-1" />
-          <button type="button" onClick={() => setShowFilters(true)} className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-[#c8c9cf] bg-white">
+          <button type="button" onClick={() => setShowFilters(true)} className="grid h-11 w-11 shrink-0 place-items-center rounded-xl border border-[#c8c9cf] bg-white">
             <Filter className="h-5 w-5 text-[#6c7078]" />
           </button>
         </div>

--- a/components/mobile/alphabet-rail.tsx
+++ b/components/mobile/alphabet-rail.tsx
@@ -8,9 +8,9 @@ interface AlphabetRailProps {
 
 export function AlphabetRail({ onSelect }: AlphabetRailProps) {
   return (
-    <div className="absolute right-1 top-[260px] z-[1200] flex w-6 flex-col items-center gap-0.5 text-[14px] font-semibold text-[#1e88e5]">
+    <div className="absolute right-1 top-[260px] z-[1200] flex w-7 flex-col items-center gap-0.5 text-[13px] font-semibold text-[#1e88e5]">
       {LETTERS.map((letter) => (
-        <button key={letter} type="button" onClick={() => onSelect(letter)} className="h-5 leading-5">
+        <button key={letter} type="button" onClick={() => onSelect(letter)} className="h-6 w-6 leading-6">
           {letter}
         </button>
       ))}

--- a/components/mobile/route-mobile.tsx
+++ b/components/mobile/route-mobile.tsx
@@ -263,7 +263,7 @@ export function RouteMobile() {
                   </option>
                 ))}
               </select>
-              <button type="button" onClick={requestCurrentLocation} disabled={locating} className="inline-flex items-center gap-1 rounded-lg border border-[#c9cad0] bg-white px-3 py-2 text-[13px]">
+              <button type="button" onClick={requestCurrentLocation} disabled={locating} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-[#c9cad0] bg-white px-3 py-2 text-[13px]">
                 {locating ? <Loader2 className="h-4 w-4 animate-spin" /> : <LocateFixed className="h-4 w-4" />}
                 Use Current
               </button>
@@ -290,14 +290,14 @@ export function RouteMobile() {
               <p className="mt-3 text-[15px] leading-6 text-[#606066]">
                 Add accounts to build a route, then optimize for car, bike, or transit handoff.
               </p>
-              <button onClick={() => setShowAddModal(true)} className="mt-6 w-full rounded-2xl bg-[#4f8edf] px-6 py-3 text-[16px] font-semibold text-white">
+              <button type="button" onClick={() => setShowAddModal(true)} className="mt-6 w-full rounded-2xl bg-[#4f8edf] px-6 py-3 text-[16px] font-semibold text-white">
                 + Add Location
               </button>
             </div>
           ) : (
             <>
               <div className="border-b border-[#c9cad0] px-4 py-3">
-                <button onClick={() => setShowAddModal(true)} className="w-full rounded-2xl bg-[#4f8edf] px-6 py-3 text-[16px] font-semibold text-white">
+                <button type="button" onClick={() => setShowAddModal(true)} className="w-full rounded-2xl bg-[#4f8edf] px-6 py-3 text-[16px] font-semibold text-white">
                   + Add Location
                 </button>
                 <p className="mt-2 text-center text-[13px] font-semibold text-[#595c62]">
@@ -324,7 +324,7 @@ export function RouteMobile() {
                 return (
                   <div key={stop.id}>
                     {index > 0 ? <p className="bg-[#d9d9dd] px-4 py-1 text-[12px] text-[#7a7d83]">Travel Time {travelMinutes} minutes</p> : null}
-                    <div className="grid grid-cols-[22px_28px_64px_56px_1fr_20px] items-center gap-2 border-b border-[#cbccd2] px-3 py-2.5">
+                    <div className="grid grid-cols-[18px_26px_54px_48px_minmax(0,1fr)_18px] items-center gap-2 border-b border-[#cbccd2] px-3 py-2.5">
                       <GripHorizontal className="h-4 w-4 text-[#b8b9be]" />
                       <span className="grid h-7 w-7 place-items-center rounded-full border-2 border-[#41b64b] text-[12px] font-semibold text-[#2c7f31]">{index + 1}</span>
                       <div>
@@ -335,7 +335,7 @@ export function RouteMobile() {
                         <p className="text-[12px] font-semibold text-[#4d4f55]">00:30</p>
                         <p className="text-[11px] text-[#979aa2]">Length</p>
                       </div>
-                      <button type="button" onClick={() => routePlan.removeStop(stop.id)} className="truncate text-left text-[15px] font-semibold text-[#3c3e44]">
+                      <button type="button" onClick={() => routePlan.removeStop(stop.id)} className="min-w-0 truncate text-left text-[15px] font-semibold text-[#3c3e44]">
                         {stop.name}
                       </button>
                       <ChevronRight className="h-4 w-4 text-[#c1c2c8]" />
@@ -347,13 +347,13 @@ export function RouteMobile() {
           )}
         </div>
       ) : (
-        <SavedRoutesList />
+        <SavedRoutesList onRouteLoaded={() => setTab('current')} />
       )}
 
       {tab === 'current' ? (
-        <div className="fixed bottom-[84px] left-0 right-0 z-[2600]">
+        <div className="fixed bottom-[calc(84px+env(safe-area-inset-bottom))] left-0 right-0 z-[2600]">
           <div className="mx-auto grid max-w-[480px] grid-cols-5 border-t border-[#c4c5cc] bg-[#f3f3f6] py-2 text-[#5a95e7]">
-            <button onClick={launchGo} className="mx-2 rounded-2xl bg-[#3ac128] px-2 py-2 text-[15px] font-bold text-white">
+            <button type="button" onClick={launchGo} className="mx-2 rounded-2xl bg-[#3ac128] px-2 py-2 text-[15px] font-bold text-white">
               GO
             </button>
             <ActionIconButton label="optimize" onClick={optimizeRoute} icon={optimizing ? <Loader2 className="h-5 w-5 animate-spin" /> : <RotateCcw className="h-5 w-5" />} disabled={optimizing} />
@@ -394,7 +394,7 @@ export function RouteMobile() {
   );
 }
 
-function SavedRoutesList() {
+function SavedRoutesList({ onRouteLoaded }: { onRouteLoaded: () => void }) {
   const routePlan = useRoutePlan();
 
   if (routePlan.savedRoutes.length === 0) {
@@ -408,7 +408,15 @@ function SavedRoutesList() {
       </div>
       <div className="mt-2 border-t border-[#c9cad0]">
         {routePlan.savedRoutes.map((route) => (
-          <button key={route.id} onClick={() => routePlan.loadSavedRoute(route.id)} className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-4 py-3 text-left">
+          <button
+            key={route.id}
+            type="button"
+            onClick={() => {
+              routePlan.loadSavedRoute(route.id);
+              onRouteLoaded();
+            }}
+            className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-4 py-3 text-left"
+          >
             <div>
               <p className="text-[15px] text-[#3b3d44]">{route.name}</p>
               <p className="text-[13px] text-[#8f9299]">{new Date(route.createdAt).toLocaleDateString()}</p>
@@ -461,7 +469,7 @@ function AddLocationModal({
       <div className="mx-auto h-full max-w-[480px] bg-[#e6e6e9]">
         <div className="bg-[#c93412] px-4 py-3 text-white">
           <div className="relative flex items-center justify-between">
-            <button onClick={onClose} className="min-w-14 text-left" aria-label="Close">
+            <button type="button" onClick={onClose} className="min-w-14 text-left" aria-label="Close">
               <X className="h-6 w-6" />
             </button>
             <h1 className="absolute left-1/2 -translate-x-1/2 text-[18px] font-semibold">Add Locations</h1>
@@ -485,7 +493,7 @@ function AddLocationModal({
               {list.map((store) => {
                 const selected = selectedStopIds.includes(store.id);
                 return (
-                  <button key={store.id} onClick={() => onToggleStop(store.id)} className="flex w-full items-center gap-3 border-b border-[#d0d1d4] px-4 py-2.5 text-left">
+                  <button type="button" key={store.id} onClick={() => onToggleStop(store.id)} className="flex w-full items-center gap-3 border-b border-[#d0d1d4] px-4 py-2.5 text-left">
                     <span className={cn('grid h-6 w-6 shrink-0 place-items-center rounded-full border-2 text-xs', selected ? 'border-[#49b84c] text-[#49b84c]' : 'border-[#b7b9bf] text-transparent')}>
                       ✓
                     </span>
@@ -505,7 +513,7 @@ function AddLocationModal({
 
 function ActionIconButton({ label, icon, onClick, disabled = false }: { label: string; icon: ReactNode; onClick: () => void; disabled?: boolean }) {
   return (
-    <button onClick={onClick} className="flex min-h-[52px] flex-col items-center justify-center gap-1 text-[11px]" disabled={disabled}>
+    <button type="button" onClick={onClick} className="flex min-h-[52px] flex-col items-center justify-center gap-1 text-[11px]" disabled={disabled}>
       {icon}
       <span>{label}</span>
     </button>

--- a/components/mobile/settings-mobile.tsx
+++ b/components/mobile/settings-mobile.tsx
@@ -1,17 +1,18 @@
 'use client';
 
+import Link from 'next/link';
 import { ChevronRight } from 'lucide-react';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 
 const items = [
-  'Profile',
-  'Notion Connection',
-  'Map Preferences',
-  'Route Defaults',
-  'Team Access',
-  'Notifications',
-  'Support',
-  'Sign Out',
+  { label: 'Profile', href: '/accounts' },
+  { label: 'Notion Connection', href: '/conversations' },
+  { label: 'Map Preferences', href: '/territory' },
+  { label: 'Route Defaults', href: '/route' },
+  { label: 'Team Access', href: '/accounts' },
+  { label: 'Notifications', href: '/calendar' },
+  { label: 'Support', href: '/conversations' },
+  { label: 'Sign Out', href: '/territory' },
 ];
 
 export function SettingsMobile() {
@@ -20,10 +21,10 @@ export function SettingsMobile() {
       <MobileHeader title="Settings" />
       <div className="border-t border-[#c7c8ce]">
         {items.map((item) => (
-          <button key={item} className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-5 py-4 text-left">
-            <span className="text-[23px] text-[#2a2c31]">{item}</span>
-            <ChevronRight className="h-7 w-7 text-[#bcc0c7]" />
-          </button>
+          <Link key={item.label} href={item.href} className="grid min-h-12 w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-5 py-3 text-left">
+            <span className="truncate text-[18px] text-[#2a2c31]">{item.label}</span>
+            <ChevronRight className="h-6 w-6 text-[#bcc0c7]" />
+          </Link>
         ))}
       </div>
     </div>

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -137,7 +137,7 @@ export function TerritoryMobile() {
           <div className="absolute left-3 top-4 z-[1500] flex flex-col gap-2">
             <button
               type="button"
-              className="grid h-10 w-10 place-items-center rounded-xl bg-white/95 shadow"
+              className="grid h-11 w-11 place-items-center rounded-xl bg-white/95 shadow"
               onClick={() => setFocusedId(null)}
               title="Recenter"
             >
@@ -145,7 +145,7 @@ export function TerritoryMobile() {
             </button>
             <button
               type="button"
-              className="grid h-10 w-10 place-items-center rounded-xl bg-white/95 shadow"
+              className="grid h-11 w-11 place-items-center rounded-xl bg-white/95 shadow"
               onClick={() => setRefreshNonce((v) => v + 1)}
               title="Refresh"
             >
@@ -154,10 +154,10 @@ export function TerritoryMobile() {
           </div>
 
           <div className="absolute right-3 top-4 z-[1500] flex flex-col gap-2">
-            <button type="button" className="grid h-10 w-10 place-items-center rounded-xl bg-white/95 shadow" onClick={() => setView('list')} title="List">
+            <button type="button" className="grid h-11 w-11 place-items-center rounded-xl bg-white/95 shadow" onClick={() => setView('list')} title="List">
               <Search className="h-5 w-5 text-[#7f828a]" />
             </button>
-            <button type="button" className="grid h-10 w-10 place-items-center rounded-xl bg-white/95 shadow" onClick={() => setShowFilters(true)} title="Filters">
+            <button type="button" className="grid h-11 w-11 place-items-center rounded-xl bg-white/95 shadow" onClick={() => setShowFilters(true)} title="Filters">
               <Filter className="h-5 w-5 text-[#7f828a]" />
             </button>
           </div>
@@ -166,7 +166,7 @@ export function TerritoryMobile() {
         <div className="px-4 pb-28 pt-3">
           <div className="flex items-center gap-2">
             <MobileSearch value={search} onChange={setSearch} placeholder="Search Locations" className="flex-1" />
-            <button type="button" onClick={() => setShowFilters(true)} className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-[#c8c9cf] bg-white">
+            <button type="button" onClick={() => setShowFilters(true)} className="grid h-11 w-11 shrink-0 place-items-center rounded-xl border border-[#c8c9cf] bg-white">
               <Filter className="h-5 w-5 text-[#6c7078]" />
             </button>
           </div>
@@ -197,13 +197,13 @@ export function TerritoryMobile() {
       )}
 
       {view === 'map' && focusedStore ? (
-        <div className="fixed bottom-[84px] left-0 right-0 z-[2500]">
+        <div className="fixed bottom-[calc(84px+env(safe-area-inset-bottom))] left-0 right-0 z-[2500]">
           <div className="mx-auto max-w-[480px] bg-[#1d1f24] text-white shadow-[0_-2px_8px_rgba(0,0,0,0.35)]">
             <button type="button" onClick={() => setDetailStoreId(focusedStore.id)} className="w-full border-b border-[#30333b] px-4 py-2.5 text-left">
               <p className="truncate text-[16px] font-semibold">{focusedStore.name}</p>
               <p className="truncate text-[13px] text-[#b6bac3]">{focusedStore.locationAddress ?? focusedStore.locationLabel ?? 'No address'}</p>
             </button>
-            <div className="grid grid-cols-[1fr_56px_56px] border-b border-[#30333b]">
+            <div className="grid grid-cols-[1fr_64px_64px] border-b border-[#30333b]">
               <button type="button" className="flex items-center gap-2 px-4 py-2 text-[13px] text-[#d5d9e1]">
                 <span className="inline-block h-3.5 w-3.5 rounded-full" style={{ backgroundColor: focusedStore.statusColor }} />
                 {focusedStore.repNames[0] ?? 'Unassigned'}


### PR DESCRIPTION
## Summary\n- increase small mobile tap targets in territory/accounts/conversations controls\n- increase alphabet rail hit area for faster index jumping\n- move territory focused-card sticky bar above bottom safe-area inset to avoid blocking controls\n- widen territory card action columns to reduce icon clipping on narrow viewports\n\n## Validation\n- npm run lint *(fails in this environment with Node fs read error: Unknown system error -11)*\n