### PR TITLE
UI polish: add feedback states for send + territory filters

### DIFF
--- a/app/(main)/conversations/page.tsx
+++ b/app/(main)/conversations/page.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 import { requireWorkspaceContext } from '@/lib/auth/workspace';
 import { Channel } from '@prisma/client';
-import { Card, CardContent, CardHeader, CardTitle, Input, Textarea, Button, Badge } from '@/components/ui';
+import { Card, CardContent, CardHeader, CardTitle, Badge } from '@/components/ui';
+import { MockComposer } from '@/components/conversations/mock-composer';
 import { getConversationOverview } from '@/lib/data/queries';
 
 export default async function ConversationsPage({
@@ -89,13 +90,7 @@ export default async function ConversationsPage({
                 </div>
               ))}
 
-              <div className="space-y-2 rounded-xl border bg-white p-3 dark:bg-slate-950">
-                <Input placeholder="Subject (optional)" />
-                <Textarea placeholder="Compose message... (mock mode)" />
-                <div className="flex justify-end">
-                  <Button className="min-h-11">Send (mock)</Button>
-                </div>
-              </div>
+              <MockComposer />
             </CardContent>
           </Card>
         ) : (
@@ -155,12 +150,8 @@ export default async function ConversationsPage({
               </div>
             ))}
 
-            <div className="sticky bottom-0 space-y-2 rounded-xl border bg-white p-3 dark:bg-slate-950">
-              <Input placeholder="Subject (optional)" />
-              <Textarea placeholder="Compose message... (mock mode)" />
-              <div className="flex justify-end">
-                <Button>Send (mock)</Button>
-              </div>
+            <div className="sticky bottom-0">
+              <MockComposer />
             </div>
           </CardContent>
         </Card>

--- a/components/conversations/mock-composer.tsx
+++ b/components/conversations/mock-composer.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button, Input, Textarea } from '@/components/ui';
+
+export function MockComposer() {
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleSend() {
+    setError(null);
+    setStatus(null);
+
+    if (!body.trim()) {
+      setError('Add a message before sending.');
+      return;
+    }
+
+    setSending(true);
+    try {
+      await new Promise((resolve) => window.setTimeout(resolve, 700));
+      setBody('');
+      setSubject('');
+      setStatus('Message queued (mock mode).');
+    } catch {
+      setError('Unable to send right now. Try again.');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2 rounded-xl border bg-white p-3 dark:bg-slate-950">
+      <Input value={subject} onChange={(event) => setSubject(event.target.value)} placeholder="Subject (optional)" disabled={sending} />
+      <Textarea value={body} onChange={(event) => setBody(event.target.value)} placeholder="Compose message... (mock mode)" disabled={sending} />
+      {error ? <p className="text-xs text-red-600">{error}</p> : null}
+      {status ? <p className="text-xs text-emerald-600">{status}</p> : null}
+      <div className="flex justify-end">
+        <Button className="min-h-11" onClick={handleSend} disabled={sending || !body.trim()}>
+          {sending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Sending...
+            </>
+          ) : (
+            'Send (mock)'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/territory/filter-bar.tsx
+++ b/components/territory/filter-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Search, X } from 'lucide-react';
+import { Loader2, Search, X } from 'lucide-react';
 import { Button, Input } from '@/components/ui';
 import type { TerritoryFilterCount } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
@@ -15,6 +15,7 @@ interface TerritoryFilterBarProps {
   onToggleStatus: (value: string) => void;
   onToggleRep: (value: string) => void;
   onClearFilters: () => void;
+  isFiltering?: boolean;
 }
 
 export function TerritoryFilterBar({
@@ -27,29 +28,39 @@ export function TerritoryFilterBar({
   onToggleStatus,
   onToggleRep,
   onClearFilters,
+  isFiltering = false,
 }: TerritoryFilterBarProps) {
   return (
     <div className="space-y-2 rounded-xl border border-slate-200 bg-white/95 p-3 shadow-lg backdrop-blur dark:border-slate-700 dark:bg-slate-950/95">
       <div className="relative">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-        <Input value={search} onChange={(event) => onSearchChange(event.target.value)} className="h-10 pl-9 pr-9" placeholder="Search store name" />
+        <Input value={search} onChange={(event) => onSearchChange(event.target.value)} className="h-10 pl-9 pr-9" placeholder="Search store name" disabled={isFiltering} />
         {search ? (
           <button
             type="button"
             aria-label="Clear search"
             className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400"
             onClick={() => onSearchChange('')}
+            disabled={isFiltering}
           >
             <X className="h-4 w-4" />
           </button>
         ) : null}
       </div>
 
-      <FilterRow label="Status" items={statuses} selected={selectedStatuses} onToggle={onToggleStatus} />
-      <FilterRow label="Rep" items={reps} selected={selectedReps} onToggle={onToggleRep} />
+      <FilterRow label="Status" items={statuses} selected={selectedStatuses} onToggle={onToggleStatus} disabled={isFiltering} />
+      <FilterRow label="Rep" items={reps} selected={selectedReps} onToggle={onToggleRep} disabled={isFiltering} />
 
-      <div className="flex justify-end">
-        <Button variant="ghost" size="sm" onClick={onClearFilters}>
+      <div className="flex items-center justify-between">
+        {isFiltering ? (
+          <p className="inline-flex items-center gap-1 text-xs text-slate-500">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Updating results...
+          </p>
+        ) : (
+          <span />
+        )}
+        <Button variant="ghost" size="sm" onClick={onClearFilters} disabled={isFiltering}>
           Clear Filters
         </Button>
       </div>
@@ -62,11 +73,13 @@ function FilterRow({
   items,
   selected,
   onToggle,
+  disabled = false,
 }: {
   label: string;
   items: TerritoryFilterCount[];
   selected: string[];
   onToggle: (value: string) => void;
+  disabled?: boolean;
 }) {
   return (
     <div className="space-y-1">
@@ -81,11 +94,12 @@ function FilterRow({
               type="button"
               onClick={() => onToggle(item.value)}
               className={cn(
-                'whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+                'whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60',
                 active
                   ? 'border-blue-500 bg-blue-600 text-white'
                   : 'border-slate-300 bg-slate-100 text-slate-700 hover:bg-slate-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200',
               )}
+              disabled={disabled}
             >
               {item.value} ({item.count})
             </button>

--- a/components/territory/territory-client.tsx
+++ b/components/territory/territory-client.tsx
@@ -230,13 +230,14 @@ export function TerritoryClient() {
               setSelectedReps([]);
               setOptimizedRoute(null);
             }}
+            isFiltering={storesQuery.isFetching}
           />
         </div>
 
         <div className="absolute right-3 top-[12.6rem] z-[1000]">
-          <Button variant="secondary" size="sm" onClick={() => setRefreshNonce((value) => value + 1)}>
-            <RefreshCw className="mr-1 h-4 w-4" />
-            Refresh
+          <Button variant="secondary" size="sm" onClick={() => setRefreshNonce((value) => value + 1)} disabled={storesQuery.isFetching}>
+            {storesQuery.isFetching ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-1 h-4 w-4" />}
+            {storesQuery.isFetching ? 'Refreshing...' : 'Refresh'}
           </Button>
         </div>
 
@@ -251,7 +252,9 @@ export function TerritoryClient() {
 
         {stores.length === 0 ? (
           <div className="absolute left-2 right-2 top-1/2 z-[1000] -translate-y-1/2 rounded-xl border border-amber-300 bg-amber-50 p-3 text-center text-sm text-amber-900 md:left-1/2 md:right-auto md:w-[520px] md:-translate-x-1/2">
-            No mapped stores available yet. Tap Refresh to force a live Notion sync and geocode missing addresses.
+            {search || selectedStatuses.length > 0 || selectedReps.length > 0
+              ? 'No stores match your current search/filters. Clear filters to see all locations.'
+              : 'No mapped stores available yet. Tap Refresh to force a live Notion sync and geocode missing addresses.'}
           </div>
         ) : null}
 


### PR DESCRIPTION
## Summary\n- add a reusable mock conversation composer with disabled, loading, and inline success/error feedback for Send\n- disable territory search/filter controls while results refresh and show an "Updating results..." indicator\n- disable Refresh while fetching with spinner + "Refreshing..." label\n- improve empty-state copy when active search/filters produce no territory results\n\n## QA\n- \n- verified send button stays disabled until message body exists, shows spinner while sending, and reports success/error text\n- verified territory filter/search buttons disable during fetch and no-result messaging is clear when filters narrow to zero\n