### PR TITLE
feat: fix non-functional mobile UI actions and sync account detail flows

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -23,7 +23,7 @@ export default async function SettingsPage() {
           <p className="text-sm text-slate-500">Role sync, integration health, custom fields, and account-wide controls.</p>
         </header>
 
-        <Card>
+        <Card id="team-roles">
           <CardHeader>
             <CardTitle>Team Roles (Synced from Notion Team Directory)</CardTitle>
           </CardHeader>
@@ -40,7 +40,7 @@ export default async function SettingsPage() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card id="integrations">
           <CardHeader>
             <CardTitle>Integrations</CardTitle>
           </CardHeader>

--- a/app/api/territory/check-in/route.ts
+++ b/app/api/territory/check-in/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireTerritoryApiAccess } from '@/lib/auth/territory-access';
+import { recordTerritoryStoreCheckIn } from '@/lib/server/notion-territory';
+
+const requestSchema = z.object({
+  storeId: z.string().min(1),
+});
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  try {
+    const payload = requestSchema.parse(await request.json());
+    const result = await recordTerritoryStoreCheckIn(payload.storeId);
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: 'Invalid check-in payload',
+          details: error.issues,
+        },
+        { status: 400 },
+      );
+    }
+
+    const message = error instanceof Error ? error.message : 'Check-in failed';
+    const status = message === 'Store not found' ? 404 : message.includes('No check-in date property') ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/api/territory/stores/[storeId]/route.ts
+++ b/app/api/territory/stores/[storeId]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireTerritoryApiAccess } from '@/lib/auth/territory-access';
+import { loadTerritoryStoreDetail, updateTerritoryStoreNotes } from '@/lib/server/notion-territory';
+
+const patchSchema = z.object({
+  notes: z.string().max(4000),
+});
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: Request, context: { params: Promise<{ storeId: string }> }) {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  const { storeId } = await context.params;
+
+  try {
+    const detail = await loadTerritoryStoreDetail(storeId);
+    return NextResponse.json(detail);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load store detail';
+    return NextResponse.json({ error: message }, { status: message === 'Store not found' ? 404 : 500 });
+  }
+}
+
+export async function PATCH(request: Request, context: { params: Promise<{ storeId: string }> }) {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  const { storeId } = await context.params;
+
+  try {
+    const payload = patchSchema.parse(await request.json());
+    const result = await updateTerritoryStoreNotes(storeId, payload.notes);
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: 'Invalid notes payload',
+          details: error.issues,
+        },
+        { status: 400 },
+      );
+    }
+    const message = error instanceof Error ? error.message : 'Failed to update notes';
+    const status = message === 'Store not found' ? 404 : message.includes('No writable Notes property') ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -1,24 +1,182 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { MapPinned, Navigation, PencilLine, X } from 'lucide-react';
-import type { TerritoryStorePin } from '@/lib/territory/types';
+import { toast } from 'sonner';
+import type { TerritoryStoreDetailResponse, TerritoryStorePin } from '@/lib/territory/types';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
+import { Button, Textarea } from '@/components/ui';
 import { cn } from '@/lib/utils';
+
+type DetailTab = 'detail' | 'location' | 'notes' | 'history';
+
+function formatCheckInLabel(value: string | null | undefined) {
+  if (!value) return 'No check-ins';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'No check-ins';
+  return date.toLocaleString();
+}
+
+function formatDateLabel(value: string | null | undefined, fallback: string) {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return date.toLocaleDateString();
+}
 
 interface AccountDetailSheetProps {
   store: TerritoryStorePin | null;
   onClose: () => void;
   onAddToRoute: (storeId: string) => void;
   routeSelected: boolean;
+  onCenterStore?: (store: TerritoryStorePin) => void;
 }
 
-export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected }: AccountDetailSheetProps) {
+export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected, onCenterStore }: AccountDetailSheetProps) {
+  const [tab, setTab] = useState<DetailTab>('detail');
+  const [detail, setDetail] = useState<TerritoryStoreDetailResponse | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [notesDraft, setNotesDraft] = useState('');
+  const [savingNotes, setSavingNotes] = useState(false);
+  const [checkingIn, setCheckingIn] = useState(false);
+
+  useEffect(() => {
+    if (!store) {
+      setDetail(null);
+      setNotesDraft('');
+      return;
+    }
+
+    setTab('detail');
+
+    const controller = new AbortController();
+
+    const loadDetail = async () => {
+      setLoadingDetail(true);
+      try {
+        const response = await fetch(`/api/territory/stores/${store.id}`, {
+          signal: controller.signal,
+          cache: 'no-store',
+        });
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload?.error ?? 'Failed to load account detail');
+        }
+
+        const payload = (await response.json()) as TerritoryStoreDetailResponse;
+        setDetail(payload);
+        setNotesDraft(payload.store.notes ?? '');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setDetail(null);
+        setNotesDraft(store.notes ?? '');
+        toast.error(error instanceof Error ? error.message : 'Failed to load account detail');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoadingDetail(false);
+        }
+      }
+    };
+
+    void loadDetail();
+
+    return () => controller.abort();
+  }, [store]);
+
   if (!store) {
     return null;
   }
 
-  const navigateUrl = `https://www.google.com/maps/dir/?api=1&destination=${store.lat},${store.lng}`;
+  const activeStore = detail?.store ?? store;
+  const contacts = detail?.contacts ?? [];
+  const navigateUrl = `https://www.google.com/maps/dir/?api=1&destination=${activeStore.lat},${activeStore.lng}`;
+  const notionUrl = `https://www.notion.so/${activeStore.notionPageId.replace(/-/g, '')}`;
+  const persistedNotes = (detail?.store.notes ?? store.notes ?? '').trim();
+  const canSaveNotes = notesDraft.trim() !== persistedNotes;
+
+  async function handleCheckIn() {
+    setCheckingIn(true);
+    try {
+      const response = await fetch('/api/territory/check-in', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ storeId: activeStore.id }),
+      });
+
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error ?? 'Failed to record check-in');
+      }
+
+      const checkedInAt = typeof payload?.checkedInAt === 'string' ? payload.checkedInAt : new Date().toISOString();
+
+      setDetail((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          store: {
+            ...prev.store,
+            lastCheckIn: checkedInAt,
+            lastEditedTime: checkedInAt,
+          },
+        };
+      });
+
+      toast.success(`Check-in recorded for ${activeStore.name}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to record check-in');
+    } finally {
+      setCheckingIn(false);
+    }
+  }
+
+  async function handleSaveNotes() {
+    if (!canSaveNotes) return;
+
+    setSavingNotes(true);
+    try {
+      const response = await fetch(`/api/territory/stores/${activeStore.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes: notesDraft }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error ?? 'Failed to save notes');
+      }
+
+      const updatedAt = typeof payload?.updatedAt === 'string' ? payload.updatedAt : new Date().toISOString();
+      const nextNotes = typeof payload?.notes === 'string' ? payload.notes : notesDraft.trim();
+
+      setDetail((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          store: {
+            ...prev.store,
+            notes: nextNotes,
+            lastEditedTime: updatedAt,
+          },
+        };
+      });
+
+      setNotesDraft(nextNotes);
+      toast.success('Notes synced to Notion');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save notes');
+    } finally {
+      setSavingNotes(false);
+    }
+  }
+
+  function handleCenter() {
+    if (onCenterStore) {
+      onCenterStore(activeStore);
+      onClose();
+      return;
+    }
+    window.open(`https://www.google.com/maps/search/?api=1&query=${activeStore.lat},${activeStore.lng}`, '_blank', 'noopener,noreferrer');
+  }
 
   return (
     <div className="fixed inset-0 z-[5000] bg-black/35">
@@ -33,11 +191,13 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
               <X className="h-8 w-8" />
             </button>
             <h1 className="absolute left-1/2 -translate-x-1/2 text-[28px] font-semibold">Account Details</h1>
-            <button className="min-w-14 text-right text-[24px]">Edit</button>
+            <button type="button" onClick={() => window.open(notionUrl, '_blank', 'noopener,noreferrer')} className="min-w-14 text-right text-[24px]" aria-label="Open account in Notion">
+              Edit
+            </button>
           </div>
           <SegmentedControl
-            value="detail"
-            onChange={() => {}}
+            value={tab}
+            onChange={(value) => setTab(value as DetailTab)}
             options={[
               { value: 'detail', label: 'Detail' },
               { value: 'location', label: 'Location' },
@@ -50,25 +210,76 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
 
         <div className="pb-[170px]">
           <div className="border-y border-[#c6c7cb] bg-[#e6e6e9] px-5 py-6">
-            <h2 className="text-[50px] font-medium text-[#111217]">{store.name}</h2>
-            <p className="text-[34px] text-[#8e9096]">{store.locationAddress ?? store.locationLabel ?? 'No address'}</p>
+            <h2 className="text-[50px] font-medium text-[#111217]">{activeStore.name}</h2>
+            <p className="text-[34px] text-[#8e9096]">{activeStore.locationAddress ?? activeStore.locationLabel ?? 'No address'}</p>
+            {loadingDetail ? <p className="mt-2 text-[15px] text-[#6e7078]">Syncing account details...</p> : null}
           </div>
 
-          <DetailRow label="Phone" value="" />
-          <DetailRow label="Email" value="" />
-          <DetailRow label="Last check-in" value="No check-ins" strong />
-          <DetailRow label="Follow-up Date" value="" />
-          <DetailRow label="Account Owner" value={store.repNames[0] ?? 'Unassigned'} strong />
-          <DetailRow label="Account Status" value={store.status} strong />
-          <DetailRow label="PICC Rep" value={store.repNames.join(', ') || '—'} />
-          <DetailRow label="License" value={store.licenseNumber ?? '—'} />
+          {tab === 'detail' ? (
+            <>
+              <DetailRow label="Phone" value={activeStore.phoneNumber || 'No phone on file'} />
+              <DetailRow label="Email" value={activeStore.email || activeStore.repEmails[0] || 'No email on file'} />
+              <DetailRow label="Last check-in" value={formatCheckInLabel(activeStore.lastCheckIn)} strong />
+              <DetailRow label="Follow-up Date" value={formatDateLabel(activeStore.followUpDate, 'No follow-up set')} />
+              <DetailRow label="Account Owner" value={activeStore.repNames[0] ?? 'Unassigned'} strong />
+              <DetailRow label="Account Status" value={activeStore.status} strong />
+              <DetailRow label="PICC Rep" value={activeStore.repNames.join(', ') || '—'} />
+              <DetailRow label="License" value={activeStore.licenseNumber ?? '—'} />
+
+              <div className="border-b border-[#c6c7cb] px-5 py-4">
+                <p className="text-[20px] text-[#a2a3a8]">Associated Contacts</p>
+                {contacts.length === 0 ? <p className="mt-1 text-[21px] text-[#1d1f23]">No contacts linked.</p> : null}
+                {contacts.map((contact) => (
+                  <div key={contact.id} className="mt-2 rounded-lg border border-[#c7c8cd] bg-[#f3f3f6] px-3 py-2">
+                    <p className="text-[19px] font-medium text-[#202229]">{contact.name}</p>
+                    <p className="text-[16px] text-[#5e6169]">{contact.roleTitle || '—'}</p>
+                    <p className="text-[16px] text-[#5e6169]">{contact.email || '—'} · {contact.phone || '—'}</p>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : null}
+
+          {tab === 'location' ? (
+            <>
+              <DetailRow label="Address" value={activeStore.locationAddress ?? activeStore.locationLabel ?? 'No address'} strong />
+              <DetailRow label="Coordinates" value={`${activeStore.lat.toFixed(5)}, ${activeStore.lng.toFixed(5)}`} />
+              <DetailRow label="City / State" value={activeStore.city && activeStore.state ? `${activeStore.city}, ${activeStore.state}` : 'Not available'} />
+              <DetailRow label="Location Source" value={activeStore.locationSource} />
+            </>
+          ) : null}
+
+          {tab === 'notes' ? (
+            <div className="border-b border-[#c6c7cb] px-5 py-5 text-[#5f6269]">
+              <p className="text-[22px] font-medium text-[#1d1f23]">Account Notes</p>
+              <p className="mt-1 text-[17px]">Notes save directly to Notion.</p>
+              <Textarea
+                value={notesDraft}
+                onChange={(event) => setNotesDraft(event.target.value)}
+                className="mt-3 min-h-[160px] bg-white text-[18px]"
+                placeholder="Add visit notes, next steps, or key blockers..."
+              />
+              <Button type="button" className="mt-3 h-11 px-5" onClick={handleSaveNotes} disabled={!canSaveNotes || savingNotes}>
+                {savingNotes ? 'Saving...' : 'Save Notes'}
+              </Button>
+            </div>
+          ) : null}
+
+          {tab === 'history' ? (
+            <>
+              <DetailRow label="Last edited" value={new Date(activeStore.lastEditedTime).toLocaleString()} />
+              <DetailRow label="Last check-in" value={formatCheckInLabel(activeStore.lastCheckIn)} strong />
+              <DetailRow label="Route status" value={routeSelected ? 'In current route' : 'Not in current route'} />
+              <DetailRow label="Sync source" value="Notion live cache" />
+            </>
+          ) : null}
         </div>
 
         <div className="fixed bottom-[92px] left-0 right-0 z-[5100]">
           <div className="mx-auto grid max-w-[480px] grid-cols-4 border-t border-[#c6c7cb] bg-[#f2f2f5] py-3 text-[#5a96e8]">
-            <ActionButton label={routeSelected ? 'remove' : 'add to...'} onClick={() => onAddToRoute(store.id)} icon={<MapPinned className="h-6 w-6" />} />
-            <ActionButton label="check-in" onClick={() => {}} icon={<PencilLine className="h-6 w-6" />} />
-            <ActionButton label="center" onClick={() => {}} icon={<MapPinned className="h-6 w-6" />} />
+            <ActionButton label={routeSelected ? 'remove' : 'add to...'} onClick={() => onAddToRoute(activeStore.id)} icon={<MapPinned className="h-6 w-6" />} />
+            <ActionButton label={checkingIn ? 'saving...' : 'check-in'} onClick={handleCheckIn} icon={<PencilLine className="h-6 w-6" />} disabled={checkingIn} />
+            <ActionButton label="center" onClick={handleCenter} icon={<MapPinned className="h-6 w-6" />} />
             <a href={navigateUrl} target="_blank" rel="noreferrer" className={cn(actionBaseClass, 'text-center')}>
               <Navigation className="h-6 w-6" />
               <span>navigate</span>
@@ -91,9 +302,9 @@ function DetailRow({ label, value, strong = false }: { label: string; value: str
 
 const actionBaseClass = 'flex flex-col items-center justify-center gap-1 text-[14px] font-medium';
 
-function ActionButton({ label, icon, onClick }: { label: string; icon: ReactNode; onClick: () => void }) {
+function ActionButton({ label, icon, onClick, disabled = false }: { label: string; icon: ReactNode; onClick: () => void; disabled?: boolean }) {
   return (
-    <button type="button" onClick={onClick} className={actionBaseClass}>
+    <button type="button" onClick={onClick} className={cn(actionBaseClass, disabled ? 'opacity-60' : '')} disabled={disabled}>
       {icon}
       <span>{label}</span>
     </button>

--- a/components/mobile/accounts-mobile.tsx
+++ b/components/mobile/accounts-mobile.tsx
@@ -3,6 +3,7 @@
 import { Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { AccountDetailSheet } from '@/components/mobile/account-detail-sheet';
 import { AlphabetRail } from '@/components/mobile/alphabet-rail';
 import { MobileHeader } from '@/components/mobile/mobile-header';
@@ -76,7 +77,19 @@ export function AccountsMobile() {
 
   return (
     <div className="min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
-      <MobileHeader title="Accounts" right={<button className="text-[42px] leading-none"><Plus className="ml-auto h-9 w-9" /></button>}>
+      <MobileHeader
+        title="Accounts"
+        right={(
+          <button
+            type="button"
+            className="text-[42px] leading-none"
+            onClick={() => toast.message('Create account is available in desktop mode.')}
+            aria-label="Create account"
+          >
+            <Plus className="ml-auto h-9 w-9" />
+          </button>
+        )}
+      >
         <SegmentedControl
           value={scope}
           onChange={(value) => setScope(value as 'all' | 'recent' | 'follow-ups')}

--- a/components/mobile/calendar-mobile.tsx
+++ b/components/mobile/calendar-mobile.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ChevronLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 
 const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
@@ -20,12 +21,14 @@ const aprilRows = [
 ];
 
 export function CalendarMobile() {
+  const router = useRouter();
+
   return (
     <div className="min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
       <MobileHeader
         title="March - 2026"
         left={
-          <button className="flex items-center gap-1 text-[22px]">
+          <button type="button" onClick={() => router.push('/dashboard')} className="flex items-center gap-1 text-[22px]" aria-label="Back to dashboard">
             <ChevronLeft className="h-8 w-8" />
             <span>Calendar</span>
           </button>

--- a/components/mobile/route-mobile.tsx
+++ b/components/mobile/route-mobile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { CalendarDays, Check, ChevronRight, GripHorizontal, Plus, RotateCcw, Save, X } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { CalendarDays, Check, ChevronRight, GripHorizontal, Plus, RotateCcw, Save, Trash2, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -23,10 +23,17 @@ export function RouteMobile() {
   const routePlan = useRoutePlan();
   const [tab, setTab] = useState<'current' | 'saved'>('current');
   const [showAddModal, setShowAddModal] = useState(false);
+  const [savedEditing, setSavedEditing] = useState(false);
   const [search, setSearch] = useState('');
   const [optMode] = useState<RouteMode>('car');
   const [optimizing, setOptimizing] = useState(false);
   const [optimized, setOptimized] = useState<TerritoryOptimizedRouteResponse | null>(null);
+
+  useEffect(() => {
+    if (tab === 'current') {
+      setSavedEditing(false);
+    }
+  }, [tab]);
 
   const storesQuery = useQuery({
     queryKey: ['route-mobile-stores'],
@@ -104,12 +111,39 @@ export function RouteMobile() {
     window.open(`https://www.google.com/maps/dir/?${params.toString()}`, '_blank', 'noopener,noreferrer');
   }
 
+  function launchCalendarDraft() {
+    if (orderedStops.length === 0) {
+      toast.error('Add at least 1 location to draft a calendar event.');
+      return;
+    }
+
+    const details = orderedStops
+      .map((stop, index) => `${index + 1}. ${stop.name}${stop.locationAddress ? ` - ${stop.locationAddress}` : ''}`)
+      .join('\n');
+
+    const params = new URLSearchParams({
+      action: 'TEMPLATE',
+      text: `PICC Route - ${new Date().toLocaleDateString()}`,
+      details,
+    });
+
+    window.open(`https://calendar.google.com/calendar/render?${params.toString()}`, '_blank', 'noopener,noreferrer');
+  }
+
   return (
     <div className="min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
       <MobileHeader
         title="Route"
         right={
-          tab === 'saved' ? <button className="text-[24px]">Edit</button> : <Plus className="ml-auto h-10 w-10" />
+          tab === 'saved' ? (
+            <button type="button" className="text-[24px]" onClick={() => setSavedEditing((value) => !value)}>
+              {savedEditing ? 'Done' : 'Edit'}
+            </button>
+          ) : (
+            <button type="button" className="grid h-10 w-10 place-items-center" onClick={() => setShowAddModal(true)} aria-label="Add location">
+              <Plus className="h-10 w-10" />
+            </button>
+          )
         }
       >
         <SegmentedControl
@@ -187,7 +221,13 @@ export function RouteMobile() {
           )}
         </div>
       ) : (
-        <SavedRoutesList />
+        <SavedRoutesList
+          editing={savedEditing}
+          onLoadRoute={() => {
+            setTab('current');
+            setSavedEditing(false);
+          }}
+        />
       )}
 
       {tab === 'current' ? (
@@ -200,6 +240,10 @@ export function RouteMobile() {
             <ActionIconButton
               label="save"
               onClick={() => {
+                if (selectedStops.length === 0) {
+                  toast.error('Add at least 1 location before saving.');
+                  return;
+                }
                 const name = `Route ${new Date().toLocaleDateString()}`;
                 routePlan.saveCurrentRoute(name);
                 toast.success('Route saved');
@@ -215,7 +259,7 @@ export function RouteMobile() {
               }}
               icon={<X className="h-7 w-7" />}
             />
-            <ActionIconButton label="+ calendar" onClick={() => toast.message('Calendar sync is next')} icon={<CalendarDays className="h-7 w-7" />} />
+            <ActionIconButton label="+ calendar" onClick={launchCalendarDraft} icon={<CalendarDays className="h-7 w-7" />} />
           </div>
         </div>
       ) : null}
@@ -234,8 +278,15 @@ export function RouteMobile() {
   );
 }
 
-function SavedRoutesList() {
+function SavedRoutesList({ editing, onLoadRoute }: { editing: boolean; onLoadRoute: () => void }) {
   const routePlan = useRoutePlan();
+  const [search, setSearch] = useState('');
+
+  const routes = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return routePlan.savedRoutes;
+    return routePlan.savedRoutes.filter((route) => route.name.toLowerCase().includes(q));
+  }, [routePlan.savedRoutes, search]);
 
   if (routePlan.savedRoutes.length === 0) {
     return <p className="px-6 py-8 text-[22px] text-[#6f7178]">No saved routes yet.</p>;
@@ -244,19 +295,38 @@ function SavedRoutesList() {
   return (
     <div className="pb-28 pt-3">
       <div className="px-4">
-        <MobileSearch value="" onChange={() => {}} placeholder="Search Routes" />
+        <MobileSearch value={search} onChange={setSearch} placeholder="Search Routes" />
       </div>
       <div className="mt-2 border-t border-[#c9cad0]">
-        {routePlan.savedRoutes.map((route) => (
-          <button key={route.id} onClick={() => routePlan.loadSavedRoute(route.id)} className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-6 py-4 text-left">
-            <div>
+        {routes.map((route) => (
+          <div key={route.id} className="grid grid-cols-[1fr_40px] items-center border-b border-[#c9cad0] px-2">
+            <button
+              type="button"
+              onClick={() => {
+                routePlan.loadSavedRoute(route.id);
+                onLoadRoute();
+              }}
+              className="px-4 py-4 text-left"
+            >
               <p className="text-[23px] text-[#3b3d44]">{route.name}</p>
               <p className="text-[20px] text-[#8f9299]">{new Date(route.createdAt).toLocaleDateString()}</p>
               <p className="text-[20px] text-[#6f7278]">Bryce Johnson</p>
-            </div>
-            <ChevronRight className="h-8 w-8 text-[#c3c5cc]" />
-          </button>
+            </button>
+            {editing ? (
+              <button
+                type="button"
+                aria-label={`Delete ${route.name}`}
+                className="grid h-10 w-10 place-items-center rounded-xl text-[#c14a4a]"
+                onClick={() => routePlan.deleteSavedRoute(route.id)}
+              >
+                <Trash2 className="h-6 w-6" />
+              </button>
+            ) : (
+              <ChevronRight className="h-8 w-8 justify-self-center text-[#c3c5cc]" />
+            )}
+          </div>
         ))}
+        {routes.length === 0 ? <p className="px-6 py-6 text-[19px] text-[#7e8189]">No routes match your search.</p> : null}
       </div>
     </div>
   );

--- a/components/mobile/settings-mobile.tsx
+++ b/components/mobile/settings-mobile.tsx
@@ -1,27 +1,64 @@
 'use client';
 
 import { ChevronRight } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useClerk } from '@clerk/nextjs';
+import { toast } from 'sonner';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 
-const items = [
-  'Profile',
-  'Notion Connection',
-  'Map Preferences',
-  'Route Defaults',
-  'Team Access',
-  'Notifications',
-  'Support',
-  'Sign Out',
+type SettingsItem = {
+  label: string;
+  action: 'route' | 'mailto' | 'signout';
+  value: string;
+};
+
+const items: SettingsItem[] = [
+  { label: 'Profile', action: 'route', value: '/settings' },
+  { label: 'Notion Connection', action: 'route', value: '/settings#integrations' },
+  { label: 'Map Preferences', action: 'route', value: '/territory' },
+  { label: 'Route Defaults', action: 'route', value: '/route' },
+  { label: 'Team Access', action: 'route', value: '/settings#team-roles' },
+  { label: 'Notifications', action: 'route', value: '/conversations' },
+  { label: 'Support', action: 'mailto', value: 'support@picc.co' },
+  { label: 'Sign Out', action: 'signout', value: '' },
 ];
 
 export function SettingsMobile() {
+  const router = useRouter();
+  const { signOut } = useClerk();
+
+  async function handleItemClick(item: SettingsItem) {
+    if (item.action === 'route') {
+      router.push(item.value);
+      return;
+    }
+
+    if (item.action === 'mailto') {
+      window.open(`mailto:${item.value}?subject=PICC%20Support`, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    try {
+      await signOut({ redirectUrl: '/sign-in' });
+    } catch {
+      toast.error('Sign out failed. Please try again.');
+    }
+  }
+
   return (
     <div className="min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
       <MobileHeader title="Settings" />
       <div className="border-t border-[#c7c8ce]">
         {items.map((item) => (
-          <button key={item} className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-5 py-4 text-left">
-            <span className="text-[23px] text-[#2a2c31]">{item}</span>
+          <button
+            key={item.label}
+            type="button"
+            onClick={() => {
+              void handleItemClick(item);
+            }}
+            className="grid w-full grid-cols-[1fr_24px] items-center border-b border-[#c9cad0] px-5 py-4 text-left"
+          >
+            <span className="text-[23px] text-[#2a2c31]">{item.label}</span>
             <ChevronRight className="h-7 w-7 text-[#bcc0c7]" />
           </button>
         ))}

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 import { ListFilter, MapPinned, MessageCircleMore, Navigation, Plus, Search, SlidersHorizontal } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
@@ -35,6 +36,7 @@ export function TerritoryMobile() {
   const [focusedId, setFocusedId] = useState<string | null>(null);
   const [detailStoreId, setDetailStoreId] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [showRouteOnly, setShowRouteOnly] = useState(false);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
 
   useEffect(() => {
@@ -64,15 +66,25 @@ export function TerritoryMobile() {
 
   const stores = useMemo(() => storesQuery.data?.stores ?? [], [storesQuery.data?.stores]);
   const storeById = useMemo(() => new Map(stores.map((store) => [store.id, store])), [stores]);
+  const displayedStores = useMemo(() => {
+    if (!showRouteOnly) return stores;
+    return stores.filter((store) => routePlan.selectedStopIds.includes(store.id));
+  }, [showRouteOnly, stores, routePlan.selectedStopIds]);
+
+  useEffect(() => {
+    if (showRouteOnly && routePlan.selectedStopIds.length === 0) {
+      setShowRouteOnly(false);
+    }
+  }, [showRouteOnly, routePlan.selectedStopIds.length]);
 
   const focusedStore = useMemo(() => {
-    if (!stores.length) return null;
+    if (!displayedStores.length) return null;
     if (focusedId) {
       const focused = storeById.get(focusedId);
-      if (focused) return focused;
+      if (focused && (!showRouteOnly || routePlan.selectedStopIds.includes(focused.id))) return focused;
     }
-    return stores[0];
-  }, [stores, focusedId, storeById]);
+    return displayedStores[0];
+  }, [displayedStores, focusedId, routePlan.selectedStopIds, showRouteOnly, storeById]);
 
   const orderedStops = useMemo(() => {
     const ids = routePlan.orderedStopIds.length > 0 ? routePlan.orderedStopIds : routePlan.selectedStopIds;
@@ -83,16 +95,38 @@ export function TerritoryMobile() {
 
   const grouped = useMemo(() => {
     const groups = new Map<string, TerritoryStorePin[]>();
-    for (const store of stores) {
+    for (const store of displayedStores) {
       const letter = firstLetter(store.name);
       const list = groups.get(letter) ?? [];
       list.push(store);
       groups.set(letter, list);
     }
     return [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-  }, [stores]);
+  }, [displayedStores]);
 
   const selectedOnCard = focusedStore ? routePlan.selectedStopIds.includes(focusedStore.id) : false;
+
+  function toggleRouteOnly() {
+    if (!showRouteOnly && routePlan.selectedStopIds.length === 0) {
+      toast.message('Add locations to your route first.');
+      return;
+    }
+    setShowRouteOnly((value) => !value);
+  }
+
+  function messageRep(store: TerritoryStorePin | null) {
+    if (!store) {
+      toast.error('Select a location first.');
+      return;
+    }
+    const email = store.repEmails[0];
+    if (!email) {
+      toast.message('No rep email is available for this account.');
+      return;
+    }
+    const subject = encodeURIComponent(`PICC follow-up: ${store.name}`);
+    window.open(`mailto:${email}?subject=${subject}`, '_blank', 'noopener,noreferrer');
+  }
 
   return (
     <div className="relative min-h-[calc(100vh-92px)] bg-[#e6e6e9]">
@@ -115,7 +149,7 @@ export function TerritoryMobile() {
       {view === 'map' ? (
         <div className="relative h-[calc(100vh-260px)] min-h-[520px]">
           <TerritoryMapMobile
-            stores={stores}
+            stores={displayedStores}
             selectedStopIds={routePlan.selectedStopIds}
             orderedStopIds={routePlan.orderedStopIds}
             focusedStoreId={focusedStore?.id ?? null}
@@ -124,22 +158,33 @@ export function TerritoryMobile() {
           />
 
           <div className="absolute left-3 top-6 z-[1500] flex flex-col gap-3">
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow">
+            <button
+              type="button"
+              aria-label="Open focused account details"
+              className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow"
+              onClick={() => {
+                if (!focusedStore) {
+                  toast.message('Select a location first.');
+                  return;
+                }
+                setDetailStoreId(focusedStore.id);
+              }}
+            >
               <MapPinned className="h-6 w-6 text-[#7f828a]" />
             </button>
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setRefreshNonce((v) => v + 1)}>
+            <button type="button" aria-label="Refresh territory data" className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setRefreshNonce((v) => v + 1)}>
               <SlidersHorizontal className="h-6 w-6 text-[#7f828a]" />
             </button>
           </div>
 
           <div className="absolute right-3 top-6 z-[1500] flex flex-col gap-3">
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setView('list')}>
+            <button type="button" aria-label="Switch to list view" className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setView('list')}>
               <Search className="h-6 w-6 text-[#7f828a]" />
             </button>
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow">
-              <ListFilter className="h-6 w-6 text-[#7f828a]" />
+            <button type="button" aria-label="Toggle route filter" className={cn('grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow', showRouteOnly ? 'ring-2 ring-[#4f8edf]' : '')} onClick={toggleRouteOnly}>
+              <ListFilter className={cn('h-6 w-6', showRouteOnly ? 'text-[#4f8edf]' : 'text-[#7f828a]')} />
             </button>
-            <button className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow">
+            <button type="button" aria-label="Message account rep" className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => messageRep(focusedStore)}>
               <MessageCircleMore className="h-6 w-6 text-[#d25a3f]" />
             </button>
           </div>
@@ -191,7 +236,7 @@ export function TerritoryMobile() {
               <p className="truncate text-[17px] text-[#b6bac3]">{focusedStore.locationAddress ?? focusedStore.locationLabel ?? 'No address'}</p>
             </button>
             <div className="grid grid-cols-[1fr_72px_72px] border-b border-[#30333b]">
-              <button type="button" className="flex items-center gap-2 px-4 py-2 text-[17px] text-[#d5d9e1]">
+              <button type="button" className="flex items-center gap-2 px-4 py-2 text-[17px] text-[#d5d9e1]" onClick={() => messageRep(focusedStore)}>
                 <span className="inline-block h-4 w-4 rounded-full bg-[#f45a34]" />
                 {focusedStore.repNames[0] ?? 'Unassigned'}
               </button>
@@ -216,6 +261,10 @@ export function TerritoryMobile() {
         onClose={() => setDetailStoreId(null)}
         onAddToRoute={(id) => routePlan.toggleStop(id)}
         routeSelected={detailStoreId ? routePlan.selectedStopIds.includes(detailStoreId) : false}
+        onCenterStore={(store) => {
+          setFocusedId(store.id);
+          setView('map');
+        }}
       />
     </div>
   );

--- a/lib/server/notion-territory.ts
+++ b/lib/server/notion-territory.ts
@@ -8,7 +8,7 @@ import {
   type NotionCacheSnapshot,
   writeNotionCacheSnapshot,
 } from '@/lib/server/notion-cache-store';
-import { colorForStatus, normalizeStatus, type TerritoryStoresResponse, type TerritoryStorePin } from '@/lib/territory/types';
+import { colorForStatus, normalizeStatus, type TerritoryStoreContact, type TerritoryStoresResponse, type TerritoryStorePin } from '@/lib/territory/types';
 
 const NOTION_API_BASE = 'https://api.notion.com/v1';
 const NOTION_VERSION = '2022-06-28';
@@ -67,8 +67,13 @@ type NotionPlace = {
 type NotionPropertyValue = {
   title?: NotionTextSegment[];
   rich_text?: NotionTextSegment[];
+  phone_number?: string | null;
+  email?: string | null;
   status?: {
     name?: string;
+  } | null;
+  date?: {
+    start?: string | null;
   } | null;
   people?: NotionPerson[];
   place?: NotionPlace | null;
@@ -96,10 +101,16 @@ interface TerritorySnapshotResult {
   meta: TerritorySnapshotMeta;
 }
 
+interface CachedContactRow extends TerritoryStoreContact {
+  accountPageIds: string[];
+  lastEditedTime: string;
+}
+
 let lastGeocodeLookupAt = 0;
 const memoryGeocodeCache = new Map<string, { lat: number; lng: number; formattedAddress: string }>();
 let territorySyncInFlight: Promise<void> | null = null;
 let territoryLastSyncError: string | null = null;
+const CONTACTS_SNAPSHOT_KEY = 'crm-contacts-v1';
 
 function requiredEnv(name: 'NOTION_API_KEY' | 'NOTION_MASTER_LIST_DATABASE_ID') {
   const value = process.env[name]?.trim();
@@ -177,12 +188,45 @@ function textFromRichTextProperty(property: NotionPropertyValue | undefined) {
   return textArray.map((item) => item?.plain_text ?? '').join('').trim();
 }
 
+function readPhoneNumberProperty(property: NotionPropertyValue | undefined) {
+  return typeof property?.phone_number === 'string' ? property.phone_number.trim() : '';
+}
+
+function readEmailProperty(property: NotionPropertyValue | undefined) {
+  return typeof property?.email === 'string' ? property.email.trim() : '';
+}
+
+function readDateStartProperty(property: NotionPropertyValue | undefined) {
+  return typeof property?.date?.start === 'string' ? property.date.start : '';
+}
+
 function readFormulaNumber(property: NotionPropertyValue | undefined) {
   const formula = (property as { formula?: { number?: number } } | undefined)?.formula;
   if (typeof formula?.number === 'number') {
     return formula.number;
   }
   return 0;
+}
+
+function normalizePropertyName(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function pickPropertyNameByType(
+  properties: Record<string, NotionPropertySchema>,
+  candidates: string[],
+  expectedType: string,
+) {
+  const candidateSet = new Set(candidates.map(normalizePropertyName));
+  for (const [name, schema] of Object.entries(properties)) {
+    if (schema.type !== expectedType) {
+      continue;
+    }
+    if (candidateSet.has(normalizePropertyName(name))) {
+      return name;
+    }
+  }
+  return null;
 }
 
 function parseStateFromAddress(address: string | null | undefined) {
@@ -414,6 +458,15 @@ async function syncTerritorySnapshotFromNotion(input?: { maxLiveGeocodeLookups?:
 
   for (const row of rows) {
     const properties = row.properties ?? {};
+    const propertyByCandidates = (...candidates: string[]) => {
+      const normalizedCandidates = new Set(candidates.map(normalizePropertyName));
+      for (const [name, value] of Object.entries(properties)) {
+        if (normalizedCandidates.has(normalizePropertyName(name))) {
+          return value;
+        }
+      }
+      return undefined;
+    };
 
     const name = textFromTitleProperty(properties['Dispensary Name']) || 'Untitled Store';
     const statusName = properties['Account Status']?.status?.name ?? 'Unspecified';
@@ -433,12 +486,17 @@ async function syncTerritorySnapshotFromNotion(input?: { maxLiveGeocodeLookups?:
     const placeName = typeof place?.name === 'string' ? place.name.trim() : '';
     const placeAddress = typeof place?.address === 'string' ? place.address.trim() : '';
 
-    const fullAddress = textFromRichTextProperty(properties['Full Address']);
-    const address1 = textFromRichTextProperty(properties['Address 1']);
-    const city = textFromRichTextProperty(properties['City']);
-    const zipcode = textFromRichTextProperty(properties['Zipcode']);
-    const licenseNumber = textFromRichTextProperty(properties['License Number']);
-    const daysOverdue = readFormulaNumber(properties['Days Overdue']);
+    const fullAddress = textFromRichTextProperty((propertyByCandidates('full address', 'address') as NotionPropertyValue | undefined) ?? properties['Full Address']);
+    const address1 = textFromRichTextProperty((propertyByCandidates('address 1', 'street address') as NotionPropertyValue | undefined) ?? properties['Address 1']);
+    const city = textFromRichTextProperty((propertyByCandidates('city') as NotionPropertyValue | undefined) ?? properties['City']);
+    const zipcode = textFromRichTextProperty((propertyByCandidates('zipcode', 'zip code') as NotionPropertyValue | undefined) ?? properties['Zipcode']);
+    const licenseNumber = textFromRichTextProperty((propertyByCandidates('license number', 'license') as NotionPropertyValue | undefined) ?? properties['License Number']);
+    const daysOverdue = readFormulaNumber((propertyByCandidates('days overdue') as NotionPropertyValue | undefined) ?? properties['Days Overdue']);
+    const phoneNumber = readPhoneNumberProperty((propertyByCandidates('phone number', 'phone') as NotionPropertyValue | undefined) ?? properties['Phone Number']) || null;
+    const email = readEmailProperty((propertyByCandidates('email', 'email address') as NotionPropertyValue | undefined) ?? properties.Email) || null;
+    const followUpDate = readDateStartProperty((propertyByCandidates('follow-up date', 'follow up date') as NotionPropertyValue | undefined) ?? properties['Follow-up Date']) || null;
+    const notes = textFromRichTextProperty((propertyByCandidates('notes', 'account notes', 'store notes') as NotionPropertyValue | undefined) ?? properties.Notes) || null;
+    const lastCheckIn = readDateStartProperty((propertyByCandidates('last check-in', 'last check in', 'last visit') as NotionPropertyValue | undefined) ?? properties['Last Check-in']) || null;
 
     const fallbackAddress = firstNonEmpty([placeAddress, placeName, fullAddress, [address1, city, zipcode].filter(Boolean).join(', ')]);
 
@@ -487,6 +545,11 @@ async function syncTerritorySnapshotFromNotion(input?: { maxLiveGeocodeLookups?:
       city: city || null,
       state: parseStateFromAddress(firstNonEmpty([resolvedAddress, fullAddress, fallbackAddress])),
       daysOverdue,
+      phoneNumber,
+      email,
+      followUpDate,
+      notes,
+      lastCheckIn,
     };
 
     if (!lastEditedMax || row.last_edited_time > lastEditedMax) {
@@ -613,6 +676,191 @@ async function getTerritorySnapshot(input?: {
   };
 }
 
+function normalizePageId(value: string) {
+  return value.replace(/-/g, '').toLowerCase();
+}
+
+function normalizeCachedContacts(payload: unknown): CachedContactRow[] {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload.filter((row): row is CachedContactRow => {
+    if (typeof row !== 'object' || row === null) {
+      return false;
+    }
+
+    const candidate = row as CachedContactRow;
+    return Boolean(candidate.id && candidate.name && Array.isArray(candidate.accountPageIds));
+  });
+}
+
+function findStoreById(stores: TerritoryStorePin[], storeId: string) {
+  const normalizedStoreId = normalizePageId(storeId);
+  return (
+    stores.find((store) => normalizePageId(store.id) === normalizedStoreId || normalizePageId(store.notionPageId) === normalizedStoreId) ??
+    null
+  );
+}
+
+async function patchStoreInSnapshot(storeId: string, updater: (store: TerritoryStorePin) => TerritoryStorePin) {
+  const snapshot = await readNotionCacheSnapshot<TerritoryStorePin[]>(TERRITORY_SNAPSHOT_KEY);
+  if (!snapshot) {
+    return;
+  }
+
+  const normalizedPayload = normalizeSnapshotPayload(snapshot.payload);
+  const normalizedStoreId = normalizePageId(storeId);
+  let changed = false;
+
+  const payload = normalizedPayload.map((store) => {
+    const matches = normalizePageId(store.id) === normalizedStoreId || normalizePageId(store.notionPageId) === normalizedStoreId;
+    if (!matches) {
+      return store;
+    }
+    changed = true;
+    return updater(store);
+  });
+
+  if (!changed) {
+    return;
+  }
+
+  await writeNotionCacheSnapshot({
+    key: TERRITORY_SNAPSHOT_KEY,
+    payload,
+    recordsRead: snapshot.recordsRead,
+    unresolvedLocationCount: snapshot.unresolvedLocationCount,
+    lastEditedMax: snapshot.lastEditedMax,
+  });
+}
+
+export async function loadTerritoryStoreDetail(storeId: string) {
+  const snapshot = await getTerritorySnapshot();
+  const store = findStoreById(snapshot.stores, storeId);
+  if (!store) {
+    throw new Error('Store not found');
+  }
+
+  const contactsSnapshot = await readNotionCacheSnapshot<CachedContactRow[]>(CONTACTS_SNAPSHOT_KEY);
+  const contacts = normalizeCachedContacts(contactsSnapshot?.payload).filter((contact) =>
+    contact.accountPageIds.some((pageId) => normalizePageId(pageId) === normalizePageId(store.notionPageId)),
+  );
+
+  contacts.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    store,
+    contacts: contacts.map((contact) => ({
+      id: contact.id,
+      name: contact.name,
+      roleTitle: contact.roleTitle,
+      email: contact.email,
+      phone: contact.phone,
+      status: contact.status,
+      linkedWork: contact.linkedWork,
+    })),
+  };
+}
+
+export async function updateTerritoryStoreNotes(storeId: string, notes: string) {
+  const snapshot = await getTerritorySnapshot();
+  const store = findStoreById(snapshot.stores, storeId);
+  if (!store) {
+    throw new Error('Store not found');
+  }
+
+  const schema = await fetchAndValidateDatabaseSchema();
+  const notesProperty = pickPropertyNameByType(
+    schema.database.properties ?? {},
+    ['Notes', 'Account Notes', 'Store Notes', 'Visit Notes'],
+    'rich_text',
+  );
+
+  if (!notesProperty) {
+    throw new Error('No writable Notes property found in Notion database');
+  }
+
+  const trimmed = notes.trim().slice(0, 2000);
+
+  await notionRequest<unknown>(`/pages/${store.notionPageId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      properties: {
+        [notesProperty]: {
+          rich_text: trimmed
+            ? [
+                {
+                  type: 'text',
+                  text: { content: trimmed },
+                },
+              ]
+            : [],
+        },
+      },
+    }),
+  });
+
+  const now = new Date().toISOString();
+  await patchStoreInSnapshot(store.id, (entry) => ({
+    ...entry,
+    notes: trimmed || null,
+    lastEditedTime: now,
+  }));
+
+  return {
+    storeId: store.id,
+    notes: trimmed || null,
+    updatedAt: now,
+  };
+}
+
+export async function recordTerritoryStoreCheckIn(storeId: string) {
+  const snapshot = await getTerritorySnapshot();
+  const store = findStoreById(snapshot.stores, storeId);
+  if (!store) {
+    throw new Error('Store not found');
+  }
+
+  const schema = await fetchAndValidateDatabaseSchema();
+  const properties = schema.database.properties ?? {};
+  const checkInProperty = pickPropertyNameByType(
+    properties,
+    ['Last Check-in', 'Last Check In', 'Last Visit', 'Recent Check-in'],
+    'date',
+  );
+
+  if (!checkInProperty) {
+    throw new Error('No check-in date property found in Notion database');
+  }
+
+  const checkedInAt = new Date().toISOString();
+
+  await notionRequest<unknown>(`/pages/${store.notionPageId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      properties: {
+        [checkInProperty]: {
+          date: {
+            start: checkedInAt,
+          },
+        },
+      },
+    }),
+  });
+
+  await patchStoreInSnapshot(store.id, (entry) => ({
+    ...entry,
+    lastCheckIn: checkedInAt,
+    lastEditedTime: checkedInAt,
+  }));
+
+  return {
+    storeId: store.id,
+    checkedInAt,
+  };
+}
+
 export async function territoryConnectionCheck() {
   const schema = await fetchAndValidateDatabaseSchema();
 
@@ -677,8 +925,21 @@ export async function loadTerritoryStores(input?: {
       }
     }
 
-    if (filters.q && !pin.name.toLowerCase().includes(filters.q)) {
-      return false;
+    if (filters.q) {
+      const searchable = [
+        pin.name,
+        pin.locationAddress ?? '',
+        pin.city ?? '',
+        pin.state ?? '',
+        pin.status,
+        pin.repNames.join(' '),
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      if (!searchable.includes(filters.q)) {
+        return false;
+      }
     }
 
     return true;

--- a/lib/territory/types.ts
+++ b/lib/territory/types.ts
@@ -19,6 +19,26 @@ export interface TerritoryStorePin {
   city?: string | null;
   state?: string | null;
   daysOverdue?: number | null;
+  phoneNumber?: string | null;
+  email?: string | null;
+  followUpDate?: string | null;
+  notes?: string | null;
+  lastCheckIn?: string | null;
+}
+
+export interface TerritoryStoreContact {
+  id: string;
+  name: string;
+  roleTitle: string;
+  email: string;
+  phone: string;
+  status: 'ACTIVE' | 'INACTIVE';
+  linkedWork: string;
+}
+
+export interface TerritoryStoreDetailResponse {
+  store: TerritoryStorePin;
+  contacts: TerritoryStoreContact[];
 }
 
 export interface TerritoryFilterCount {


### PR DESCRIPTION
## Summary
- replace dead/no-op mobile controls with real behavior in route, territory, accounts, calendar, and settings views
- add backend-backed store detail API (`/api/territory/stores/[storeId]`) returning richer account fields and associated contacts
- add backend-backed check-in API (`/api/territory/check-in`) and wire account detail check-in action to sync state
- add Notion notes update flow from mobile account detail (notes tab now saves to Notion-backed data)
- improve territory query filtering (search now matches name, address, city/state, status, and rep)

## Functional fixes included
- `RouteMobile`: saved-route search works, edit mode works, route deletion works, add button works, calendar draft action now opens Google Calendar with route stop details
- `TerritoryMobile`: map/list filter toggle works, details/map pin button works, rep/message actions work, focused account center flow works
- `AccountDetailSheet`: segmented tabs are functional, notes are editable + synced, check-in is persisted through API, associated contacts now render
- `SettingsMobile` + `CalendarMobile`: previously inert buttons now navigate or perform sign-out/support actions

## Validation
- Node: `v22.22.0`
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run build` passed

## Notes
- Existing warnings under `src/` remain unchanged from base branch; no new lint/type errors introduced.
