### PR TITLE
UI pass 3: improve list row interactions

### DIFF
--- a/app/(main)/conversations/page.tsx
+++ b/app/(main)/conversations/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
 import { requireWorkspaceContext } from '@/lib/auth/workspace';
 import { Channel } from '@prisma/client';
 import { Card, CardContent, CardHeader, CardTitle, Badge } from '@/components/ui';
@@ -99,16 +100,27 @@ export default async function ConversationsPage({
               <CardTitle>Inbox</CardTitle>
             </CardHeader>
             <CardContent className="space-y-2">
-              {conversations.map((conversation) => (
-                <Link key={conversation.id} href={`/conversations?channel=${activeChannel}&selected=${conversation.id}`} className="block rounded-lg border p-3 hover:bg-slate-50 dark:hover:bg-slate-900">
-                  <div className="flex items-center justify-between">
-                    <p className="font-semibold">{conversation.account.name}</p>
-                    {conversation.unreadCount > 0 && <Badge>{conversation.unreadCount}</Badge>}
-                  </div>
-                  <p className="text-xs text-slate-500">{conversation.channel} · {conversation.contact ? `${conversation.contact.firstName} ${conversation.contact.lastName}` : 'No contact'}</p>
-                  <p className="truncate text-sm text-slate-600 dark:text-slate-300">{conversation.messages[0]?.body ?? 'No messages yet.'}</p>
-                </Link>
-              ))}
+              {conversations.map((conversation) => {
+                const isSelected = selected?.id === conversation.id;
+                return (
+                  <Link
+                    key={conversation.id}
+                    href={`/conversations?channel=${activeChannel}&selected=${conversation.id}`}
+                    className={`block rounded-lg border p-3 transition hover:bg-slate-50 dark:hover:bg-slate-900 ${isSelected ? 'border-primary/40 bg-primary/5' : ''}`}
+                    aria-current={isSelected ? 'page' : undefined}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-semibold">{conversation.account.name}</p>
+                      <div className="flex items-center gap-2">
+                        {conversation.unreadCount > 0 && <Badge>{conversation.unreadCount}</Badge>}
+                        <ChevronRight className="h-4 w-4 text-slate-400" />
+                      </div>
+                    </div>
+                    <p className="text-xs text-slate-500">{conversation.channel} · {conversation.contact ? `${conversation.contact.firstName} ${conversation.contact.lastName}` : 'No contact'}</p>
+                    <p className="truncate text-sm text-slate-600 dark:text-slate-300">{conversation.messages[0]?.body ?? 'No messages yet.'}</p>
+                  </Link>
+                );
+              })}
             </CardContent>
           </Card>
         )}
@@ -120,16 +132,27 @@ export default async function ConversationsPage({
             <CardTitle>Inbox</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            {conversations.map((conversation) => (
-              <Link key={conversation.id} href={`/conversations?channel=${activeChannel}&selected=${conversation.id}`} className="block rounded-lg border p-3 hover:bg-slate-50 dark:hover:bg-slate-900">
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold">{conversation.account.name}</p>
-                  {conversation.unreadCount > 0 && <Badge>{conversation.unreadCount}</Badge>}
-                </div>
-                <p className="text-xs text-slate-500">{conversation.channel} · {conversation.contact ? `${conversation.contact.firstName} ${conversation.contact.lastName}` : 'No contact'}</p>
-                <p className="truncate text-sm text-slate-600 dark:text-slate-300">{conversation.messages[0]?.body ?? 'No messages yet.'}</p>
-              </Link>
-            ))}
+            {conversations.map((conversation) => {
+              const isSelected = selected?.id === conversation.id;
+              return (
+                <Link
+                  key={conversation.id}
+                  href={`/conversations?channel=${activeChannel}&selected=${conversation.id}`}
+                  className={`block rounded-lg border p-3 transition hover:bg-slate-50 dark:hover:bg-slate-900 ${isSelected ? 'border-primary/40 bg-primary/5' : ''}`}
+                  aria-current={isSelected ? 'page' : undefined}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-semibold">{conversation.account.name}</p>
+                    <div className="flex items-center gap-2">
+                      {conversation.unreadCount > 0 && <Badge>{conversation.unreadCount}</Badge>}
+                      <ChevronRight className="h-4 w-4 text-slate-400" />
+                    </div>
+                  </div>
+                  <p className="text-xs text-slate-500">{conversation.channel} · {conversation.contact ? `${conversation.contact.firstName} ${conversation.contact.lastName}` : 'No contact'}</p>
+                  <p className="truncate text-sm text-slate-600 dark:text-slate-300">{conversation.messages[0]?.body ?? 'No messages yet.'}</p>
+                </Link>
+              );
+            })}
           </CardContent>
         </Card>
 

--- a/components/crm/accounts-table.tsx
+++ b/components/crm/accounts-table.tsx
@@ -66,6 +66,8 @@ export function AccountsTable({ rows }: { rows: AccountTableRow[] }) {
       columns={columns}
       data={rows}
       searchPlaceholder="Search dispensary or license..."
+      getRowHref={(row) => `/accounts/${row.id}`}
+      rowAriaLabel={(row) => `Open account ${row.name}`}
       mobileCardRenderer={(row) => (
         <>
           <div className="flex items-start justify-between gap-3">

--- a/components/crm/advanced-data-table.tsx
+++ b/components/crm/advanced-data-table.tsx
@@ -13,6 +13,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { Download, Filter, Settings2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { Button, Input } from '@/components/ui';
@@ -24,6 +25,8 @@ interface Props<TData, TValue> {
   searchPlaceholder?: string;
   onExportCsv?: () => void;
   mobileCardRenderer?: (row: TData) => ReactNode;
+  getRowHref?: (row: TData) => string | null;
+  rowAriaLabel?: (row: TData) => string;
 }
 
 export function AdvancedDataTable<TData, TValue>({
@@ -33,7 +36,10 @@ export function AdvancedDataTable<TData, TValue>({
   searchPlaceholder = 'Search...',
   onExportCsv,
   mobileCardRenderer,
+  getRowHref,
+  rowAriaLabel,
 }: Props<TData, TValue>) {
+  const router = useRouter();
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
@@ -96,22 +102,42 @@ export function AdvancedDataTable<TData, TValue>({
 
       <div className="space-y-2 md:hidden">
         {table.getRowModel().rows?.length ? (
-          table.getRowModel().rows.map((row) => (
-            <article key={row.id} className="space-y-2 rounded-xl border bg-white p-3 dark:bg-slate-950">
-              {mobileCardRenderer ? (
-                mobileCardRenderer(row.original)
-              ) : (
-                row.getVisibleCells().map((cell) => (
-                  <div key={cell.id} className="flex items-center justify-between gap-3 text-sm">
-                    <span className="text-slate-500">
-                      {typeof cell.column.columnDef.header === 'string' ? cell.column.columnDef.header : String(cell.column.id)}
-                    </span>
-                    <span className="text-right">{flexRender(cell.column.columnDef.cell, cell.getContext())}</span>
-                  </div>
-                ))
-              )}
-            </article>
-          ))
+          table.getRowModel().rows.map((row) => {
+            const rowHref = getRowHref?.(row.original);
+            return (
+              <article
+                key={row.id}
+                className={`space-y-2 rounded-xl border bg-white p-3 dark:bg-slate-950 ${rowHref ? 'cursor-pointer active:bg-slate-50 dark:active:bg-slate-900' : ''}`}
+                role={rowHref ? 'link' : undefined}
+                tabIndex={rowHref ? 0 : undefined}
+                aria-label={rowHref ? rowAriaLabel?.(row.original) : undefined}
+                onClick={rowHref ? () => router.push(rowHref) : undefined}
+                onKeyDown={
+                  rowHref
+                    ? (event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          router.push(rowHref);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                {mobileCardRenderer ? (
+                  mobileCardRenderer(row.original)
+                ) : (
+                  row.getVisibleCells().map((cell) => (
+                    <div key={cell.id} className="flex items-center justify-between gap-3 text-sm">
+                      <span className="text-slate-500">
+                        {typeof cell.column.columnDef.header === 'string' ? cell.column.columnDef.header : String(cell.column.id)}
+                      </span>
+                      <span className="text-right">{flexRender(cell.column.columnDef.cell, cell.getContext())}</span>
+                    </div>
+                  ))
+                )}
+              </article>
+            );
+          })
         ) : (
           <div className="rounded-xl border p-6 text-center text-slate-500">No results.</div>
         )}
@@ -135,19 +161,39 @@ export function AdvancedDataTable<TData, TValue>({
             </thead>
             <tbody>
               {table.getRowModel().rows?.length ? (
-                table.getRowModel().rows.map((row, idx) => (
-                  <tr
-                    key={row.id}
-                    data-state={row.getIsSelected() && 'selected'}
-                    className={idx % 2 === 0 ? 'bg-white dark:bg-slate-950' : 'bg-slate-50/50 dark:bg-slate-900/30'}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className="border-b px-3 py-2 align-top">
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    ))}
-                  </tr>
-                ))
+                table.getRowModel().rows.map((row, idx) => {
+                  const rowHref = getRowHref?.(row.original);
+                  return (
+                    <tr
+                      key={row.id}
+                      data-state={row.getIsSelected() && 'selected'}
+                      className={[
+                        idx % 2 === 0 ? 'bg-white dark:bg-slate-950' : 'bg-slate-50/50 dark:bg-slate-900/30',
+                        rowHref ? 'cursor-pointer hover:bg-slate-100/80 dark:hover:bg-slate-800/70' : '',
+                      ].join(' ')}
+                      role={rowHref ? 'link' : undefined}
+                      tabIndex={rowHref ? 0 : undefined}
+                      aria-label={rowHref ? rowAriaLabel?.(row.original) : undefined}
+                      onClick={rowHref ? () => router.push(rowHref) : undefined}
+                      onKeyDown={
+                        rowHref
+                          ? (event) => {
+                              if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                router.push(rowHref);
+                              }
+                            }
+                          : undefined
+                      }
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <td key={cell.id} className="border-b px-3 py-2 align-top">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })
               ) : (
                 <tr>
                   <td colSpan={columns.length} className="h-28 text-center text-slate-500">

--- a/components/mobile/accounts-mobile.tsx
+++ b/components/mobile/accounts-mobile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Filter } from 'lucide-react';
+import { ChevronRight, Filter } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
@@ -114,9 +114,18 @@ export function AccountsMobile() {
           >
             <div className="border-b border-[#c6c7cb] px-1 py-1.5 text-[14px] font-semibold text-[#8a8d95]">{letter}</div>
             {list.map((store) => (
-              <button key={store.id} type="button" onClick={() => setDetailStoreId(store.id)} className="w-full border-b border-[#d0d1d4] px-1 py-2.5 text-left">
-                <p className="truncate text-[15px] text-[#15171c]">{store.name}</p>
-                <p className="truncate text-[12px] text-[#8c8f97]">{store.status} · {store.repNames[0] ?? 'Unassigned'}</p>
+              <button
+                key={store.id}
+                type="button"
+                onClick={() => setDetailStoreId(store.id)}
+                className="flex w-full items-center justify-between gap-3 border-b border-[#d0d1d4] px-2 py-3 text-left active:bg-black/5"
+                aria-label={`Open ${store.name}`}
+              >
+                <span className="min-w-0">
+                  <p className="truncate text-[15px] text-[#15171c]">{store.name}</p>
+                  <p className="truncate text-[12px] text-[#8c8f97]">{store.status} · {store.repNames[0] ?? 'Unassigned'}</p>
+                </span>
+                <ChevronRight className="h-4 w-4 shrink-0 text-[#9b9ea6]" />
               </button>
             ))}
           </section>

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
-import { Filter, LocateFixed, Navigation, Plus, Search } from 'lucide-react';
+import { ChevronRight, Filter, LocateFixed, Navigation, Plus, Search } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { MobileHeader } from '@/components/mobile/mobile-header';
@@ -178,11 +178,18 @@ export function TerritoryMobile() {
               {list.map((store) => {
                 const selected = routePlan.selectedStopIds.includes(store.id);
                 return (
-                  <button key={store.id} type="button" onClick={() => setDetailStoreId(store.id)} className="flex w-full items-center gap-3 border-b border-[#d0d1d4] px-1 py-2.5 text-left">
+                  <button
+                    key={store.id}
+                    type="button"
+                    onClick={() => setDetailStoreId(store.id)}
+                    className="flex w-full items-center gap-3 border-b border-[#d0d1d4] px-2 py-3 text-left active:bg-black/5"
+                    aria-label={`Open ${store.name}`}
+                  >
                     <span className={cn('grid h-6 w-6 shrink-0 place-items-center rounded-full border-2 text-xs', selected ? 'border-[#4fb649] text-[#4fb649]' : 'border-[#b8bac0] text-transparent')}>
                       ✓
                     </span>
-                    <span className="truncate text-[15px] text-[#15171c]">{store.name}</span>
+                    <span className="min-w-0 flex-1 truncate text-[15px] text-[#15171c]">{store.name}</span>
+                    <ChevronRight className="h-4 w-4 shrink-0 text-[#9b9ea6]" />
                   </button>
                 );
               })}


### PR DESCRIPTION
## Summary
- make account table rows tappable/clickable on desktop + mobile cards with keyboard support
- add stronger row-level affordances (chevrons, active states, aria labels) in Accounts and Territory mobile lists
- improve conversation inbox row affordance with selected-state highlighting and trailing chevrons

## Validation
- npx eslint app/'(main)'/conversations/page.tsx components/crm/advanced-data-table.tsx components/crm/accounts-table.tsx components/mobile/accounts-mobile.tsx components/mobile/territory-mobile.tsx