### PR TITLE
feat: add associated-contact navigation + quick contact check-ins

### DIFF
--- a/app/(main)/contacts/[contactId]/page.tsx
+++ b/app/(main)/contacts/[contactId]/page.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
+import { loadLiveNotionContacts } from '@/lib/server/notion-live-crm';
+
+function normalizeId(value: string) {
+  return value.replace(/-/g, '').trim().toLowerCase();
+}
+
+export default async function ContactDetailPage({ params }: { params: Promise<{ contactId: string }> }) {
+  const { contactId } = await params;
+  const rows = await loadLiveNotionContacts();
+  const normalizedTargetId = normalizeId(contactId);
+  const contact = rows.find((row) => normalizeId(row.id) === normalizedTargetId);
+
+  if (!contact) {
+    notFound();
+  }
+
+  const notionUrl = `https://www.notion.so/${contact.id.replace(/-/g, '')}`;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <Link href="/contacts" className="text-sm text-slate-500 hover:text-slate-700">
+          ← Back to Contacts
+        </Link>
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold">{contact.name}</h1>
+          <Badge variant={contact.status === 'ACTIVE' ? 'success' : 'secondary'}>{contact.status}</Badge>
+        </div>
+        <p className="text-sm text-slate-500">{contact.roleTitle || 'No role title'}</p>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Contact Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>
+              <span className="font-semibold text-slate-700">Dispensary:</span> {contact.accountName}
+            </p>
+            <p>
+              <span className="font-semibold text-slate-700">Email:</span> {contact.email}
+            </p>
+            <p>
+              <span className="font-semibold text-slate-700">Phone:</span> {contact.phone}
+            </p>
+            <p>
+              <span className="font-semibold text-slate-700">Linked Work:</span> {contact.linkedWork}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Actions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Button asChild>
+              <a href={notionUrl} target="_blank" rel="noreferrer">
+                Open In Notion
+              </a>
+            </Button>
+            {contact.email !== '—' ? (
+              <Button asChild variant="secondary">
+                <a href={`mailto:${contact.email}`}>Email Contact</a>
+              </Button>
+            ) : null}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/app/api/territory/check-in/route.ts
+++ b/app/api/territory/check-in/route.ts
@@ -1,10 +1,34 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireTerritoryApiAccess } from '@/lib/auth/territory-access';
+import { createMeetingCheckIn } from '@/lib/server/notion-meeting-notes';
 import { recordTerritoryStoreCheckIn } from '@/lib/server/notion-territory';
 
-const requestSchema = z.object({
+const legacyRequestSchema = z.object({
   storeId: z.string().min(1),
+});
+
+const meetingNoteRequestSchema = z.object({
+  store: z.object({
+    id: z.string().min(1).optional(),
+    name: z.string().min(1),
+    notionPageId: z.string().min(1),
+    lat: z.number().finite().optional(),
+    lng: z.number().finite().optional(),
+    address: z.string().optional(),
+    repName: z.string().nullable().optional(),
+  }),
+  mode: z.enum(['written', 'voice']).default('written'),
+  noteText: z.string().max(5000).optional(),
+  associatedContact: z
+    .object({
+      id: z.string().min(1).optional(),
+      name: z.string().min(1),
+      roleTitle: z.string().optional(),
+      email: z.string().optional(),
+      phone: z.string().optional(),
+    })
+    .optional(),
 });
 
 export const dynamic = 'force-dynamic';
@@ -16,22 +40,74 @@ export async function POST(request: Request) {
   }
 
   try {
-    const payload = requestSchema.parse(await request.json());
-    const result = await recordTerritoryStoreCheckIn(payload.storeId);
-    return NextResponse.json(result);
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        {
-          error: 'Invalid check-in payload',
-          details: error.issues,
-        },
-        { status: 400 },
-      );
+    const body = await request.json();
+
+    const meetingPayload = meetingNoteRequestSchema.safeParse(body);
+    if (meetingPayload.success) {
+      const payload = meetingPayload.data;
+      const storeId = payload.store.id?.trim() || payload.store.notionPageId;
+
+      const note = await createMeetingCheckIn({
+        store: payload.store,
+        mode: payload.mode,
+        noteText: payload.noteText,
+        actorEmail: access.email,
+        associatedContact: payload.associatedContact,
+      });
+
+      let checkedInAt = new Date().toISOString();
+      let syncWarning: string | null = null;
+
+      try {
+        const checkIn = await recordTerritoryStoreCheckIn(storeId);
+        checkedInAt = checkIn.checkedInAt;
+      } catch (syncError) {
+        const message = syncError instanceof Error ? syncError.message : 'Failed to update store check-in timestamp';
+        if (message.includes('No check-in date property') || message === 'Store not found') {
+          syncWarning = message;
+        } else {
+          throw syncError;
+        }
+      }
+
+      return NextResponse.json({
+        ok: true,
+        id: note.id,
+        url: note.url,
+        storeId,
+        checkedInAt,
+        mode: payload.mode,
+        syncWarning,
+        associatedContact: payload.associatedContact
+          ? {
+              id: payload.associatedContact.id ?? null,
+              name: payload.associatedContact.name,
+            }
+          : null,
+      });
     }
 
+    const legacyPayload = legacyRequestSchema.safeParse(body);
+    if (legacyPayload.success) {
+      const result = await recordTerritoryStoreCheckIn(legacyPayload.data.storeId);
+      return NextResponse.json(result);
+    }
+
+    return NextResponse.json(
+      {
+        error: 'Invalid check-in payload',
+        details: [...meetingPayload.error.issues, ...legacyPayload.error.issues],
+      },
+      { status: 400 },
+    );
+  } catch (error) {
     const message = error instanceof Error ? error.message : 'Check-in failed';
-    const status = message === 'Store not found' ? 404 : message.includes('No check-in date property') ? 400 : 500;
+    const status =
+      message === 'Store not found'
+        ? 404
+        : message.includes('No check-in date property')
+          ? 400
+          : 500;
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/components/crm/contacts-table.tsx
+++ b/components/crm/contacts-table.tsx
@@ -56,6 +56,8 @@ export function ContactsTable({ rows }: { rows: ContactTableRow[] }) {
       data={rows}
       columns={columns}
       searchPlaceholder="Search contact, role, or dispensary..."
+      getRowHref={(row) => `/contacts/${encodeURIComponent(row.id)}`}
+      rowAriaLabel={(row) => `Open contact ${row.name}`}
       mobileCardRenderer={(row) => (
         <>
           <div className="flex items-start justify-between gap-3">

--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import Link from 'next/link';
 import { type ReactNode, useEffect, useState } from 'react';
 import { MapPinned, Navigation, PencilLine, X } from 'lucide-react';
 import { toast } from 'sonner';
-import type { TerritoryStoreDetailResponse, TerritoryStorePin } from '@/lib/territory/types';
+import type { TerritoryStoreContact, TerritoryStoreDetailResponse, TerritoryStorePin } from '@/lib/territory/types';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
 import { Button, Textarea } from '@/components/ui';
 import { cn } from '@/lib/utils';
 
 type DetailTab = 'detail' | 'location' | 'notes' | 'history';
+type CheckInMode = 'written' | 'voice';
 
 function formatCheckInLabel(value: string | null | undefined) {
   if (!value) return 'No check-ins';
@@ -22,6 +24,13 @@ function formatDateLabel(value: string | null | undefined, fallback: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return fallback;
   return date.toLocaleDateString();
+}
+
+function cleanContactField(value: string | null | undefined) {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '—') return undefined;
+  return trimmed;
 }
 
 interface AccountDetailSheetProps {
@@ -39,15 +48,27 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
   const [notesDraft, setNotesDraft] = useState('');
   const [savingNotes, setSavingNotes] = useState(false);
   const [checkingIn, setCheckingIn] = useState(false);
+  const [checkInModalOpen, setCheckInModalOpen] = useState(false);
+  const [checkInMode, setCheckInMode] = useState<CheckInMode>('written');
+  const [checkInDraft, setCheckInDraft] = useState('');
+  const [checkInContact, setCheckInContact] = useState<TerritoryStoreContact | null>(null);
 
   useEffect(() => {
     if (!store) {
       setDetail(null);
       setNotesDraft('');
+      setCheckInModalOpen(false);
+      setCheckInMode('written');
+      setCheckInDraft('');
+      setCheckInContact(null);
       return;
     }
 
     setTab('detail');
+    setCheckInModalOpen(false);
+    setCheckInMode('written');
+    setCheckInDraft('');
+    setCheckInContact(null);
 
     const controller = new AbortController();
 
@@ -94,18 +115,46 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
   const persistedNotes = (detail?.store.notes ?? store.notes ?? '').trim();
   const canSaveNotes = notesDraft.trim() !== persistedNotes;
 
-  async function handleCheckIn() {
+  function openCheckInModal(contact: TerritoryStoreContact | null = null) {
+    setCheckInContact(contact);
+    setCheckInMode('written');
+    setCheckInDraft('');
+    setCheckInModalOpen(true);
+  }
+
+  async function handleCheckInSubmit() {
     setCheckingIn(true);
     try {
       const response = await fetch('/api/territory/check-in', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ storeId: activeStore.id }),
+        body: JSON.stringify({
+          store: {
+            id: activeStore.id,
+            name: activeStore.name,
+            notionPageId: activeStore.notionPageId,
+            lat: activeStore.lat,
+            lng: activeStore.lng,
+            address: activeStore.locationAddress ?? activeStore.locationLabel ?? undefined,
+            repName: activeStore.repNames[0] ?? null,
+          },
+          mode: checkInMode,
+          noteText: cleanContactField(checkInDraft),
+          associatedContact: checkInContact
+            ? {
+                id: checkInContact.id,
+                name: checkInContact.name,
+                roleTitle: cleanContactField(checkInContact.roleTitle),
+                email: cleanContactField(checkInContact.email),
+                phone: cleanContactField(checkInContact.phone),
+              }
+            : undefined,
+        }),
       });
 
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
-        throw new Error(payload?.error ?? 'Failed to record check-in');
+        throw new Error(payload?.error ?? 'Failed to create check-in');
       }
 
       const checkedInAt = typeof payload?.checkedInAt === 'string' ? payload.checkedInAt : new Date().toISOString();
@@ -122,9 +171,18 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
         };
       });
 
-      toast.success(`Check-in recorded for ${activeStore.name}`);
+      if (checkInMode === 'voice' && typeof payload?.url === 'string') {
+        window.open(payload.url, '_blank', 'noopener,noreferrer');
+      }
+
+      const contactLabel = checkInContact ? ` with ${checkInContact.name}` : '';
+      toast.success(`${checkInMode === 'voice' ? 'Voice' : 'Written'} check-in saved${contactLabel}`);
+      setCheckInModalOpen(false);
+      setCheckInContact(null);
+      setCheckInDraft('');
+      setCheckInMode('written');
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to record check-in');
+      toast.error(error instanceof Error ? error.message : 'Failed to create check-in');
     } finally {
       setCheckingIn(false);
     }
@@ -231,7 +289,19 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
                 {contacts.length === 0 ? <p className="mt-1 text-[21px] text-[#1d1f23]">No contacts linked.</p> : null}
                 {contacts.map((contact) => (
                   <div key={contact.id} className="mt-2 rounded-lg border border-[#c7c8cd] bg-[#f3f3f6] px-3 py-2">
-                    <p className="text-[19px] font-medium text-[#202229]">{contact.name}</p>
+                    <div className="flex items-start justify-between gap-3">
+                      <Link href={`/contacts/${encodeURIComponent(contact.id)}`} className="text-[19px] font-medium text-[#1f4e9f] underline-offset-2 hover:underline">
+                        {contact.name}
+                      </Link>
+                      <button
+                        type="button"
+                        className="rounded-md border border-[#b4b7bf] px-2.5 py-1 text-[13px] font-medium text-[#27303f] hover:bg-[#e8eaf0]"
+                        onClick={() => openCheckInModal(contact)}
+                        disabled={checkingIn}
+                      >
+                        Check-in
+                      </button>
+                    </div>
                     <p className="text-[16px] text-[#5e6169]">{contact.roleTitle || '—'}</p>
                     <p className="text-[16px] text-[#5e6169]">{contact.email || '—'} · {contact.phone || '—'}</p>
                   </div>
@@ -275,10 +345,87 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
           ) : null}
         </div>
 
+        {checkInModalOpen ? (
+          <div className="fixed inset-0 z-[5200] bg-black/40" onClick={() => !checkingIn && setCheckInModalOpen(false)}>
+            <div className="absolute inset-x-0 bottom-0 mx-auto max-w-[480px] rounded-t-2xl bg-[#f8f8fb] px-4 pb-[max(16px,env(safe-area-inset-bottom))] pt-4" onClick={(event) => event.stopPropagation()}>
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-[20px] font-semibold text-[#1d1f23]">Create Check-in</h3>
+                  <p className="text-[14px] text-[#5f6269]">
+                    {checkInContact ? `${checkInContact.name} · ${activeStore.name}` : activeStore.name}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-md p-1 text-[#5f6269] hover:bg-[#ececf1]"
+                  onClick={() => setCheckInModalOpen(false)}
+                  disabled={checkingIn}
+                  aria-label="Close check-in modal"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  className={cn(
+                    'rounded-lg border px-3 py-2 text-sm font-medium',
+                    checkInMode === 'written' ? 'border-[#1f4e9f] bg-[#dce8ff] text-[#123a7c]' : 'border-[#c3c5cc] bg-white text-[#3f4249]',
+                  )}
+                  onClick={() => setCheckInMode('written')}
+                  disabled={checkingIn}
+                >
+                  Written
+                </button>
+                <button
+                  type="button"
+                  className={cn(
+                    'rounded-lg border px-3 py-2 text-sm font-medium',
+                    checkInMode === 'voice' ? 'border-[#1f4e9f] bg-[#dce8ff] text-[#123a7c]' : 'border-[#c3c5cc] bg-white text-[#3f4249]',
+                  )}
+                  onClick={() => setCheckInMode('voice')}
+                  disabled={checkingIn}
+                >
+                  Voice
+                </button>
+              </div>
+
+              {checkInMode === 'written' ? (
+                <div className="mt-3">
+                  <Textarea
+                    value={checkInDraft}
+                    onChange={(event) => setCheckInDraft(event.target.value)}
+                    className="min-h-[130px] bg-white text-[16px]"
+                    placeholder={
+                      checkInContact
+                        ? `Capture notes from your check-in with ${checkInContact.name}...`
+                        : 'Capture notes from this check-in...'
+                    }
+                  />
+                </div>
+              ) : (
+                <p className="mt-3 rounded-lg border border-[#cfd2d9] bg-white px-3 py-2 text-[14px] text-[#5f6269]">
+                  A voice check-in note will open in Notion so you can capture details quickly.
+                </p>
+              )}
+
+              <div className="mt-4 grid grid-cols-2 gap-2">
+                <Button type="button" variant="secondary" className="h-11" onClick={() => setCheckInModalOpen(false)} disabled={checkingIn}>
+                  Cancel
+                </Button>
+                <Button type="button" className="h-11" onClick={handleCheckInSubmit} disabled={checkingIn}>
+                  {checkingIn ? 'Saving...' : checkInMode === 'voice' ? 'Start Voice' : 'Save Check-in'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
         <div className="fixed bottom-[92px] left-0 right-0 z-[5100]">
           <div className="mx-auto grid max-w-[480px] grid-cols-4 border-t border-[#c6c7cb] bg-[#f2f2f5] py-3 text-[#5a96e8]">
             <ActionButton label={routeSelected ? 'remove' : 'add to...'} onClick={() => onAddToRoute(activeStore.id)} icon={<MapPinned className="h-6 w-6" />} />
-            <ActionButton label={checkingIn ? 'saving...' : 'check-in'} onClick={handleCheckIn} icon={<PencilLine className="h-6 w-6" />} disabled={checkingIn} />
+            <ActionButton label={checkingIn ? 'saving...' : 'check-in'} onClick={() => openCheckInModal()} icon={<PencilLine className="h-6 w-6" />} disabled={checkingIn} />
             <ActionButton label="center" onClick={handleCenter} icon={<MapPinned className="h-6 w-6" />} />
             <a href={navigateUrl} target="_blank" rel="noreferrer" className={cn(actionBaseClass, 'text-center')}>
               <Navigation className="h-6 w-6" />

--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { type ReactNode, useEffect, useState } from 'react';
-import { MapPinned, Navigation, PencilLine, X } from 'lucide-react';
+import { Copy, MapPinned, Navigation, PencilLine, PhoneCall, X } from 'lucide-react';
 import { toast } from 'sonner';
 import type { TerritoryStoreContact, TerritoryStoreDetailResponse, TerritoryStorePin } from '@/lib/territory/types';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
@@ -33,6 +33,13 @@ function cleanContactField(value: string | null | undefined) {
   return trimmed;
 }
 
+function toDialablePhone(value: string | null | undefined) {
+  const trimmed = cleanContactField(value);
+  if (!trimmed) return null;
+  const normalized = trimmed.replace(/[^+\d]/g, '');
+  return normalized.length > 0 ? normalized : null;
+}
+
 interface AccountDetailSheetProps {
   store: TerritoryStorePin | null;
   onClose: () => void;
@@ -52,6 +59,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
   const [checkInMode, setCheckInMode] = useState<CheckInMode>('written');
   const [checkInDraft, setCheckInDraft] = useState('');
   const [checkInContact, setCheckInContact] = useState<TerritoryStoreContact | null>(null);
+  const [streetViewLoadError, setStreetViewLoadError] = useState(false);
 
   useEffect(() => {
     if (!store) {
@@ -61,6 +69,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
       setCheckInMode('written');
       setCheckInDraft('');
       setCheckInContact(null);
+      setStreetViewLoadError(false);
       return;
     }
 
@@ -69,6 +78,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
     setCheckInMode('written');
     setCheckInDraft('');
     setCheckInContact(null);
+    setStreetViewLoadError(false);
 
     const controller = new AbortController();
 
@@ -114,6 +124,40 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
   const notionUrl = `https://www.notion.so/${activeStore.notionPageId.replace(/-/g, '')}`;
   const persistedNotes = (detail?.store.notes ?? store.notes ?? '').trim();
   const canSaveNotes = notesDraft.trim() !== persistedNotes;
+  const addressValue = activeStore.locationAddress ?? activeStore.locationLabel ?? 'No address';
+  const streetViewUrl = `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${activeStore.lat},${activeStore.lng}`;
+  const streetViewPreviewUrl = `https://maps.googleapis.com/maps/api/streetview?size=900x420&location=${activeStore.lat},${activeStore.lng}&fov=85&pitch=0`;
+
+  async function copyAddress() {
+    if (!addressValue || addressValue === 'No address') {
+      toast.message('No address available to copy');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(addressValue);
+      toast.success('Address copied');
+    } catch {
+      toast.error('Unable to copy address');
+    }
+  }
+
+  function launchDial(value: string | null | undefined, fallbackLabel: string) {
+    const dialable = toDialablePhone(value);
+    if (!dialable) {
+      toast.error(`No phone available for ${fallbackLabel}.`);
+      return;
+    }
+    window.location.href = `tel:${dialable}`;
+  }
+
+  function callStore() {
+    launchDial(activeStore.phoneNumber, activeStore.name);
+  }
+
+  function callFromContactCard(contact: TerritoryStoreContact) {
+    const number = cleanContactField(activeStore.phoneNumber) ?? cleanContactField(contact.phone);
+    launchDial(number, activeStore.name);
+  }
 
   function openCheckInModal(contact: TerritoryStoreContact | null = null) {
     setCheckInContact(contact);
@@ -293,14 +337,23 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
                       <Link href={`/contacts/${encodeURIComponent(contact.id)}`} className="text-[19px] font-medium text-[#1f4e9f] underline-offset-2 hover:underline">
                         {contact.name}
                       </Link>
-                      <button
-                        type="button"
-                        className="rounded-md border border-[#b4b7bf] px-2.5 py-1 text-[13px] font-medium text-[#27303f] hover:bg-[#e8eaf0]"
-                        onClick={() => openCheckInModal(contact)}
-                        disabled={checkingIn}
-                      >
-                        Check-in
-                      </button>
+                      <div className="flex items-center gap-1.5">
+                        <button
+                          type="button"
+                          className="rounded-md border border-[#b4b7bf] px-2.5 py-1 text-[13px] font-medium text-[#27303f] hover:bg-[#e8eaf0]"
+                          onClick={() => callFromContactCard(contact)}
+                        >
+                          Call Store
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded-md border border-[#b4b7bf] px-2.5 py-1 text-[13px] font-medium text-[#27303f] hover:bg-[#e8eaf0]"
+                          onClick={() => openCheckInModal(contact)}
+                          disabled={checkingIn}
+                        >
+                          Check-in
+                        </button>
+                      </div>
                     </div>
                     <p className="text-[16px] text-[#5e6169]">{contact.roleTitle || '—'}</p>
                     <p className="text-[16px] text-[#5e6169]">{contact.email || '—'} · {contact.phone || '—'}</p>
@@ -312,7 +365,57 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
 
           {tab === 'location' ? (
             <>
-              <DetailRow label="Address" value={activeStore.locationAddress ?? activeStore.locationLabel ?? 'No address'} strong />
+              <div className="border-b border-[#c6c7cb] px-5 py-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-[20px] text-[#a2a3a8]">Address</p>
+                    <p className="mt-1 text-[21px] font-medium text-[#1d1f23]">{addressValue}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={copyAddress}
+                    className="inline-flex h-10 shrink-0 items-center gap-1 rounded-lg border border-[#9ab9ea] px-3 text-[15px] font-medium text-[#2872d1]"
+                  >
+                    <Copy className="h-4 w-4" />
+                    Copy
+                  </button>
+                </div>
+              </div>
+
+              <div className="border-b border-[#c6c7cb] px-5 py-4">
+                <p className="text-[20px] text-[#a2a3a8]">Street View</p>
+                <div className="mt-2 overflow-hidden rounded-xl border border-[#c4c6cc] bg-[#dfe2e8]">
+                  {streetViewLoadError ? (
+                    <button
+                      type="button"
+                      className="grid h-[210px] w-full place-items-center bg-[#eef0f5] px-5 text-center text-[15px] text-[#4d515b]"
+                      onClick={() => window.open(streetViewUrl, '_blank', 'noopener,noreferrer')}
+                    >
+                      Street View preview unavailable. Tap to open Street View.
+                    </button>
+                  ) : (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={streetViewPreviewUrl}
+                      alt={`Street view near ${activeStore.name}`}
+                      className="h-[210px] w-full object-cover"
+                      loading="lazy"
+                      onError={() => setStreetViewLoadError(true)}
+                    />
+                  )}
+                </div>
+
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  <Button type="button" className="h-11" onClick={() => window.open(streetViewUrl, '_blank', 'noopener,noreferrer')}>
+                    Open Street View
+                  </Button>
+                  <Button type="button" variant="secondary" className="h-11" onClick={callStore}>
+                    <PhoneCall className="mr-1 h-4 w-4" />
+                    Call Store
+                  </Button>
+                </div>
+              </div>
+
               <DetailRow label="Coordinates" value={`${activeStore.lat.toFixed(5)}, ${activeStore.lng.toFixed(5)}`} />
               <DetailRow label="City / State" value={activeStore.city && activeStore.state ? `${activeStore.city}, ${activeStore.state}` : 'Not available'} />
               <DetailRow label="Location Source" value={activeStore.locationSource} />

--- a/components/mobile/store-filter-sheet.tsx
+++ b/components/mobile/store-filter-sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { X } from 'lucide-react';
+import type { PinColorMode } from '@/lib/territory/pin-colors';
 import type { TerritoryFilterCount } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
 
@@ -13,7 +14,11 @@ interface StoreFilterSheetProps {
   selectedReps: string[];
   onToggleStatus: (value: string) => void;
   onToggleRep: (value: string) => void;
-  onReset: () => void;
+  pinColorMode: PinColorMode;
+  onSetPinColorMode: (mode: PinColorMode) => void;
+  onSaveSelection: () => void;
+  onClearAll: () => void;
+  savedFiltersLabel?: string | null;
 }
 
 export function StoreFilterSheet({
@@ -25,7 +30,11 @@ export function StoreFilterSheet({
   selectedReps,
   onToggleStatus,
   onToggleRep,
-  onReset,
+  pinColorMode,
+  onSetPinColorMode,
+  onSaveSelection,
+  onClearAll,
+  savedFiltersLabel = null,
 }: StoreFilterSheetProps) {
   if (!open) {
     return null;
@@ -38,13 +47,40 @@ export function StoreFilterSheet({
     <div className="fixed inset-0 z-[5400] bg-black/35">
       <div className="mx-auto flex h-full max-w-[480px] flex-col bg-[#e6e6e9]">
         <div className="flex items-center justify-between border-b border-[#c8c9cf] bg-[#c93412] px-4 py-3 text-white">
-          <h2 className="text-[17px] font-semibold">Filters</h2>
+          <h2 className="text-[17px] font-semibold">Filters & Visualization</h2>
           <button type="button" onClick={onClose} className="grid h-9 w-9 place-items-center rounded-lg hover:bg-black/10" aria-label="Close filters">
             <X className="h-5 w-5" />
           </button>
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 py-4">
+          <section className="mb-4 rounded-xl border border-[#c7c9cf] bg-white p-3">
+            <h3 className="mb-2 text-[12px] font-semibold uppercase tracking-wide text-[#7b7e87]">Pin Colors</h3>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                className={cn(
+                  'rounded-lg border px-3 py-2 text-[13px] font-medium',
+                  pinColorMode === 'status' ? 'border-[#cd3814] bg-[#cd3814] text-white' : 'border-[#c3c5cb] bg-white text-[#4a4c52]',
+                )}
+                onClick={() => onSetPinColorMode('status')}
+              >
+                By Status
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  'rounded-lg border px-3 py-2 text-[13px] font-medium',
+                  pinColorMode === 'rep' ? 'border-[#cd3814] bg-[#cd3814] text-white' : 'border-[#c3c5cb] bg-white text-[#4a4c52]',
+                )}
+                onClick={() => onSetPinColorMode('rep')}
+              >
+                By Rep
+              </button>
+            </div>
+            <p className="mt-2 text-[12px] text-[#72757d]">Filter results are still applied. This only changes pin coloring.</p>
+          </section>
+
           <FilterSection
             title="Account Status"
             options={statuses.map((entry) => ({ label: entry.value, value: entry.value, count: entry.count }))}
@@ -59,18 +95,27 @@ export function StoreFilterSheet({
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-2 border-t border-[#c8c9cf] bg-[#f2f2f5] px-4 py-3">
-          <button
-            type="button"
-            onClick={onReset}
-            disabled={!hasActiveFilters}
-            className="rounded-lg border border-[#c6c7cc] bg-white px-3 py-2 text-[14px] font-medium text-[#3e4046] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            Reset
-          </button>
-          <button type="button" onClick={onClose} className="rounded-lg bg-[#cd3814] px-3 py-2 text-[14px] font-semibold text-white">
-            {hasActiveFilters ? `Apply (${activeFilters})` : 'Apply'}
-          </button>
+        <div className="border-t border-[#c8c9cf] bg-[#f2f2f5] px-4 py-3">
+          <div className="grid grid-cols-3 gap-2">
+            <button
+              type="button"
+              onClick={onClearAll}
+              className="rounded-lg border border-[#c6c7cc] bg-white px-2 py-2 text-[13px] font-medium text-[#3e4046]"
+            >
+              Clear All
+            </button>
+            <button
+              type="button"
+              onClick={onSaveSelection}
+              className="rounded-lg border border-[#b95b45] bg-[#f8ede9] px-2 py-2 text-[13px] font-semibold text-[#9d2f12]"
+            >
+              Save Filters
+            </button>
+            <button type="button" onClick={onClose} className="rounded-lg bg-[#cd3814] px-2 py-2 text-[13px] font-semibold text-white">
+              {hasActiveFilters ? `Apply (${activeFilters})` : 'Apply'}
+            </button>
+          </div>
+          {savedFiltersLabel ? <p className="mt-2 text-center text-[12px] text-[#6d7078]">Saved filters: {savedFiltersLabel}</p> : null}
         </div>
       </div>
     </div>

--- a/components/mobile/territory-map-mobile.tsx
+++ b/components/mobile/territory-map-mobile.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react';
 import { MapContainer, Marker, Polyline, TileLayer, useMap, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import type { LatLngExpression } from 'leaflet';
+import { pinColorForStore, type PinColorMode } from '@/lib/territory/pin-colors';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 
 interface TerritoryMapMobileProps {
@@ -12,12 +13,21 @@ interface TerritoryMapMobileProps {
   orderedStopIds: string[];
   focusedStoreId: string | null;
   routeCoordinates: [number, number][];
+  pinColorMode: PinColorMode;
   onSelectStore: (id: string | null) => void;
 }
 
 const FALLBACK_CENTER: LatLngExpression = [39.8283, -98.5795];
 
-export function TerritoryMapMobile({ stores, selectedStopIds, orderedStopIds, focusedStoreId, routeCoordinates, onSelectStore }: TerritoryMapMobileProps) {
+export function TerritoryMapMobile({
+  stores,
+  selectedStopIds,
+  orderedStopIds,
+  focusedStoreId,
+  routeCoordinates,
+  pinColorMode,
+  onSelectStore,
+}: TerritoryMapMobileProps) {
   const selectedSet = useMemo(() => new Set(selectedStopIds), [selectedStopIds]);
   const orderMap = useMemo(() => {
     const map = new Map<string, number>();
@@ -52,7 +62,7 @@ export function TerritoryMapMobile({ stores, selectedStopIds, orderedStopIds, fo
       <MapContainer
         center={center}
         zoom={11}
-        className="h-full w-full"
+        className="h-full w-full [filter:saturate(1.08)_contrast(1.03)]"
         zoomControl={false}
         preferCanvas
         zoomAnimation
@@ -63,25 +73,33 @@ export function TerritoryMapMobile({ stores, selectedStopIds, orderedStopIds, fo
         zoomSnap={0.25}
         zoomDelta={0.5}
       >
-      <TileLayer attribution='&copy; OpenStreetMap contributors &copy; CARTO' url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png" />
-      <FitMapBounds stores={stores} focusedStoreId={focusedStoreId} />
-      <MapClickClear onClear={() => onSelectStore(null)} />
-      {routeLine.length > 1 ? <Polyline positions={routeLine} color="#3ea5ff" weight={6} opacity={0.9} /> : null}
+        <TileLayer attribution='&copy; OpenStreetMap contributors &copy; CARTO' url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png" />
+        <FitMapBounds stores={stores} focusedStoreId={focusedStoreId} />
+        <MapClickClear onClear={() => onSelectStore(null)} />
 
-      {stores.map((store) => {
-        const selected = selectedSet.has(store.id);
-        const order = orderMap.get(store.id);
-        const focused = focusedStoreId === store.id;
-        return (
-          <Marker
-            key={store.id}
-            position={[store.lat, store.lng]}
-            icon={selected ? buildSelectedPin(order ?? 1, focused) : buildDefaultPin(focused)}
-            bubblingMouseEvents={false}
-            eventHandlers={{ click: () => onSelectStore(store.id) }}
-          />
-        );
-      })}
+        {routeLine.length > 1 ? (
+          <>
+            <Polyline positions={routeLine} color="#0f5f9e" weight={9} opacity={0.28} />
+            <Polyline positions={routeLine} color="#20a8ff" weight={5} opacity={0.95} />
+          </>
+        ) : null}
+
+        {stores.map((store) => {
+          const selected = selectedSet.has(store.id);
+          const order = orderMap.get(store.id);
+          const focused = focusedStoreId === store.id;
+          const pinColor = pinColorForStore(store, pinColorMode);
+
+          return (
+            <Marker
+              key={store.id}
+              position={[store.lat, store.lng]}
+              icon={selected ? buildSelectedPin(order ?? 1, focused) : buildDefaultPin(pinColor, focused)}
+              bubblingMouseEvents={false}
+              eventHandlers={{ click: () => onSelectStore(store.id) }}
+            />
+          );
+        })}
       </MapContainer>
     </>
   );
@@ -118,19 +136,21 @@ function MapClickClear({ onClear }: { onClear: () => void }) {
   return null;
 }
 
-function buildDefaultPin(focused: boolean) {
-  const size = focused ? 24 : 18;
+function buildDefaultPin(color: string, focused: boolean) {
+  const size = focused ? 26 : 20;
   const focusedClass = focused ? 'picc-mobile-focused-pin' : '';
+  const border = focused ? '#4f8edf' : '#ffffff';
+
   return L.divIcon({
     className: '',
-    html: `<div class="${focusedClass}" style="width:${size}px;height:${size}px;border-radius:50%;background:#f45a34;border:3px solid ${focused ? '#4f8edf' : '#f9b09a'};box-shadow:0 3px 7px rgba(0,0,0,0.25);"></div>`,
+    html: `<div class="${focusedClass}" style="width:${size}px;height:${size}px;background:${color};border:2px solid ${border};border-radius:50% 50% 50% 0;transform:rotate(-45deg);box-shadow:0 4px 9px rgba(0,0,0,0.26);"></div>`,
     iconSize: [size, size],
-    iconAnchor: [Math.round(size / 2), Math.round(size / 2)],
+    iconAnchor: [Math.round(size / 2) - 1, size],
   });
 }
 
 function buildSelectedPin(order: number, focused: boolean) {
-  const size = focused ? 30 : 24;
+  const size = focused ? 32 : 26;
   const focusedClass = focused ? 'picc-mobile-focused-pin' : '';
   return L.divIcon({
     className: '',

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { ListFilter, MapPinned, MessageCircleMore, Navigation, Plus, Search, SlidersHorizontal } from 'lucide-react';
+import { Filter, ListFilter, MapPinned, MessageCircleMore, Navigation, Plus, RefreshCw, Search } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -10,6 +10,8 @@ import { MobileSearch } from '@/components/mobile/mobile-search';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
 import { AlphabetRail } from '@/components/mobile/alphabet-rail';
 import { AccountDetailSheet } from '@/components/mobile/account-detail-sheet';
+import { StoreFilterSheet } from '@/components/mobile/store-filter-sheet';
+import { pinColorForStore, repColorForLabel, type PinColorMode } from '@/lib/territory/pin-colors';
 import type { TerritoryStorePin, TerritoryStoresResponse } from '@/lib/territory/types';
 import { useRoutePlan } from '@/lib/territory/route-plan-client';
 import { cn } from '@/lib/utils';
@@ -22,10 +24,32 @@ const TerritoryMapMobile = dynamic(
   },
 );
 
+const FILTER_STORAGE_KEY = 'territory-mobile-filters-v1';
+
+type SavedFiltersPayload = {
+  search: string;
+  selectedStatuses: string[];
+  selectedReps: string[];
+  showRouteOnly: boolean;
+  pinColorMode: PinColorMode;
+  savedAt: string;
+};
+
 function firstLetter(name: string) {
   const normalized = name.trim().toUpperCase();
   const char = normalized[0] ?? '#';
   return /[A-Z]/.test(char) ? char : '#';
+}
+
+function toggleListValue(current: string[], value: string) {
+  return current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
+}
+
+function formatSavedTimestamp(value: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
 }
 
 export function TerritoryMobile() {
@@ -37,6 +61,11 @@ export function TerritoryMobile() {
   const [detailStoreId, setDetailStoreId] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [showRouteOnly, setShowRouteOnly] = useState(false);
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
+  const [selectedReps, setSelectedReps] = useState<string[]>([]);
+  const [showFilters, setShowFilters] = useState(false);
+  const [pinColorMode, setPinColorMode] = useState<PinColorMode>('status');
+  const [savedFiltersAt, setSavedFiltersAt] = useState<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
 
   useEffect(() => {
@@ -47,11 +76,32 @@ export function TerritoryMobile() {
     return () => window.clearTimeout(timeoutId);
   }, [search]);
 
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(FILTER_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Partial<SavedFiltersPayload>;
+
+      setSearch(typeof parsed.search === 'string' ? parsed.search : '');
+      setDebouncedSearch(typeof parsed.search === 'string' ? parsed.search.trim() : '');
+      setSelectedStatuses(Array.isArray(parsed.selectedStatuses) ? parsed.selectedStatuses.filter((value): value is string => typeof value === 'string') : []);
+      setSelectedReps(Array.isArray(parsed.selectedReps) ? parsed.selectedReps.filter((value): value is string => typeof value === 'string') : []);
+      setShowRouteOnly(Boolean(parsed.showRouteOnly));
+      setPinColorMode(parsed.pinColorMode === 'rep' ? 'rep' : 'status');
+      setSavedFiltersAt(typeof parsed.savedAt === 'string' ? parsed.savedAt : null);
+      toast.success('Loaded saved territory filters');
+    } catch {
+      // Ignore malformed local storage.
+    }
+  }, []);
+
   const storesQuery = useQuery({
-    queryKey: ['territory-mobile', debouncedSearch, refreshNonce],
+    queryKey: ['territory-mobile', debouncedSearch, selectedStatuses.join('|'), selectedReps.join('|'), refreshNonce],
     queryFn: async () => {
       const params = new URLSearchParams();
       if (debouncedSearch) params.set('q', debouncedSearch);
+      for (const status of selectedStatuses) params.append('status', status);
+      for (const rep of selectedReps) params.append('rep', rep);
       if (refreshNonce > 0) params.set('refresh', '1');
       const response = await fetch(`/api/territory/stores?${params.toString()}`);
       if (!response.ok) {
@@ -76,6 +126,15 @@ export function TerritoryMobile() {
       setShowRouteOnly(false);
     }
   }, [showRouteOnly, routePlan.selectedStopIds.length]);
+
+  useEffect(() => {
+    if (selectedReps.length > 0 && pinColorMode !== 'rep') {
+      setPinColorMode('rep');
+    }
+    if (selectedReps.length === 0 && selectedStatuses.length > 0 && pinColorMode !== 'status') {
+      setPinColorMode('status');
+    }
+  }, [selectedReps.length, selectedStatuses.length, pinColorMode]);
 
   useEffect(() => {
     if (!focusedId) return;
@@ -110,7 +169,49 @@ export function TerritoryMobile() {
     return [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   }, [displayedStores]);
 
+  const repLegend = useMemo(() => {
+    if (pinColorMode !== 'rep') {
+      return [] as Array<{ label: string; color: string; count: number }>;
+    }
+    const counts = new Map<string, number>();
+    for (const store of displayedStores) {
+      const label = store.repNames.find((name) => name.trim().length > 0) ?? 'Unassigned';
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([label, count]) => ({ label, count, color: repColorForLabel(label) }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 4);
+  }, [displayedStores, pinColorMode]);
+
   const selectedOnCard = focusedStore ? routePlan.selectedStopIds.includes(focusedStore.id) : false;
+  const activeFiltersCount = selectedStatuses.length + selectedReps.length;
+
+  function persistCurrentFilters() {
+    const payload: SavedFiltersPayload = {
+      search: search.trim(),
+      selectedStatuses,
+      selectedReps,
+      showRouteOnly,
+      pinColorMode,
+      savedAt: new Date().toISOString(),
+    };
+    window.localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(payload));
+    setSavedFiltersAt(payload.savedAt);
+    toast.success('Filters saved');
+  }
+
+  function clearAllFilters() {
+    setSearch('');
+    setDebouncedSearch('');
+    setSelectedStatuses([]);
+    setSelectedReps([]);
+    setShowRouteOnly(false);
+    setPinColorMode('status');
+    setSavedFiltersAt(null);
+    window.localStorage.removeItem(FILTER_STORAGE_KEY);
+    toast.success('Filters cleared');
+  }
 
   function toggleRouteOnly() {
     if (!showRouteOnly && routePlan.selectedStopIds.length === 0) {
@@ -160,6 +261,7 @@ export function TerritoryMobile() {
             orderedStopIds={routePlan.orderedStopIds}
             focusedStoreId={focusedStore?.id ?? null}
             routeCoordinates={routeCoordinates}
+            pinColorMode={pinColorMode}
             onSelectStore={setFocusedId}
           />
 
@@ -168,6 +270,23 @@ export function TerritoryMobile() {
               {hasRoadRouteGeometry
                 ? `${routePlan.optimizedRoute?.mode === 'transit' ? 'Transit' : routePlan.optimizedRoute?.mode === 'bike' ? 'Bike' : 'Driving'} route on roads`
                 : 'Add 2+ stops and tap Optimize in Route view'}
+            </div>
+          ) : null}
+
+          {pinColorMode === 'rep' && repLegend.length > 0 ? (
+            <div className="absolute bottom-20 left-3 z-[1500] max-w-[240px] rounded-xl bg-black/70 px-3 py-2 text-white">
+              <p className="mb-1 text-[11px] uppercase tracking-wide text-white/70">Rep Colors</p>
+              <div className="space-y-1">
+                {repLegend.map((entry) => (
+                  <div key={entry.label} className="flex items-center justify-between gap-3 text-[12px]">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: entry.color }} />
+                      <span className="truncate">{entry.label}</span>
+                    </span>
+                    <span className="text-white/70">{entry.count}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           ) : null}
 
@@ -186,14 +305,28 @@ export function TerritoryMobile() {
             >
               <MapPinned className="h-6 w-6 text-[#7f828a]" />
             </button>
-            <button type="button" aria-label="Refresh territory data" className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setRefreshNonce((v) => v + 1)}>
-              <SlidersHorizontal className="h-6 w-6 text-[#7f828a]" />
+            <button
+              type="button"
+              aria-label="Refresh territory data"
+              className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow"
+              onClick={() => setRefreshNonce((value) => value + 1)}
+            >
+              <RefreshCw className="h-6 w-6 text-[#7f828a]" />
             </button>
           </div>
 
           <div className="absolute right-3 top-6 z-[1500] flex flex-col gap-3">
             <button type="button" aria-label="Switch to list view" className="grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow" onClick={() => setView('list')}>
               <Search className="h-6 w-6 text-[#7f828a]" />
+            </button>
+            <button
+              type="button"
+              aria-label="Open filters"
+              className={cn('relative grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow', activeFiltersCount > 0 ? 'ring-2 ring-[#cd3814]' : '')}
+              onClick={() => setShowFilters(true)}
+            >
+              <Filter className={cn('h-6 w-6', activeFiltersCount > 0 ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
+              {activeFiltersCount > 0 ? <span className="absolute -right-1 -top-1 grid h-5 min-w-5 place-items-center rounded-full bg-[#cd3814] px-1 text-[11px] font-semibold text-white">{activeFiltersCount}</span> : null}
             </button>
             <button type="button" aria-label="Toggle route filter" className={cn('grid h-12 w-12 place-items-center rounded-xl bg-white/90 shadow', showRouteOnly ? 'ring-2 ring-[#4f8edf]' : '')} onClick={toggleRouteOnly}>
               <ListFilter className={cn('h-6 w-6', showRouteOnly ? 'text-[#4f8edf]' : 'text-[#7f828a]')} />
@@ -205,7 +338,17 @@ export function TerritoryMobile() {
         </div>
       ) : (
         <div className="px-4 pb-28 pt-3">
-          <MobileSearch value={search} onChange={setSearch} placeholder="Search Locations" />
+          <div className="flex items-center gap-2">
+            <MobileSearch value={search} onChange={setSearch} placeholder="Search Locations" className="flex-1" />
+            <button
+              type="button"
+              onClick={() => setShowFilters(true)}
+              className={cn('relative grid h-11 w-11 shrink-0 place-items-center rounded-xl border bg-white', activeFiltersCount > 0 ? 'border-[#cd3814]' : 'border-[#c8c9cf]')}
+            >
+              <Filter className={cn('h-5 w-5', activeFiltersCount > 0 ? 'text-[#cd3814]' : 'text-[#6c7078]')} />
+              {activeFiltersCount > 0 ? <span className="absolute -right-1 -top-1 grid h-5 min-w-5 place-items-center rounded-full bg-[#cd3814] px-1 text-[11px] font-semibold text-white">{activeFiltersCount}</span> : null}
+            </button>
+          </div>
           <div className="mt-3 border-t border-[#c6c7cb]" />
           {grouped.map(([letter, list]) => (
             <section
@@ -217,6 +360,7 @@ export function TerritoryMobile() {
               <div className="border-b border-[#c6c7cb] px-1 py-2 text-[38px] text-[#8a8d95]">{letter}</div>
               {list.map((store) => {
                 const selected = routePlan.selectedStopIds.includes(store.id);
+                const pinColor = pinColorForStore(store, pinColorMode);
                 return (
                   <button
                     key={store.id}
@@ -224,6 +368,7 @@ export function TerritoryMobile() {
                     onClick={() => setDetailStoreId(store.id)}
                     className="flex w-full items-center gap-3 border-b border-[#d0d1d4] px-1 py-3 text-left"
                   >
+                    <span className="inline-block h-3.5 w-3.5 shrink-0 rounded-full" style={{ backgroundColor: pinColor }} />
                     <span
                       className={cn(
                         'grid h-8 w-8 shrink-0 place-items-center rounded-full border-2 text-lg',
@@ -251,7 +396,7 @@ export function TerritoryMobile() {
             </button>
             <div className="grid grid-cols-[1fr_72px_72px] border-b border-[#30333b]">
               <button type="button" className="flex items-center gap-2 px-4 py-2 text-[17px] text-[#d5d9e1]" onClick={() => messageRep(focusedStore)}>
-                <span className="inline-block h-4 w-4 rounded-full bg-[#f45a34]" />
+                <span className="inline-block h-4 w-4 rounded-full" style={{ backgroundColor: pinColorForStore(focusedStore, pinColorMode) }} />
                 {focusedStore.repNames[0] ?? 'Unassigned'}
               </button>
               <button type="button" onClick={() => routePlan.toggleStop(focusedStore.id)} className="grid place-items-center border-l border-[#30333b]">
@@ -269,6 +414,22 @@ export function TerritoryMobile() {
           </div>
         </div>
       ) : null}
+
+      <StoreFilterSheet
+        open={showFilters}
+        onClose={() => setShowFilters(false)}
+        statuses={storesQuery.data?.filters.statuses ?? []}
+        reps={storesQuery.data?.filters.reps ?? []}
+        selectedStatuses={selectedStatuses}
+        selectedReps={selectedReps}
+        onToggleStatus={(value) => setSelectedStatuses((current) => toggleListValue(current, value))}
+        onToggleRep={(value) => setSelectedReps((current) => toggleListValue(current, value))}
+        pinColorMode={pinColorMode}
+        onSetPinColorMode={setPinColorMode}
+        onSaveSelection={persistCurrentFilters}
+        onClearAll={clearAllFilters}
+        savedFiltersLabel={formatSavedTimestamp(savedFiltersAt)}
+      />
 
       <AccountDetailSheet
         store={detailStoreId ? storeById.get(detailStoreId) ?? null : null}

--- a/components/territory/map-canvas-inner.tsx
+++ b/components/territory/map-canvas-inner.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react';
 import { MapContainer, Marker, Polyline, Popup, TileLayer, useMap, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import type { LatLngExpression } from 'leaflet';
+import { pinColorForStore } from '@/lib/territory/pin-colors';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 
 interface MapCanvasInnerProps {
@@ -61,7 +62,7 @@ export function TerritoryMapCanvasInner({ stores, selectedStopIds, orderedStopId
       <MapContainer
         center={mapCenter}
         zoom={6}
-        className="h-full w-full"
+        className="h-full w-full [filter:saturate(1.08)_contrast(1.03)]"
         zoomControl={false}
         preferCanvas
         zoomAnimation
@@ -73,14 +74,19 @@ export function TerritoryMapCanvasInner({ stores, selectedStopIds, orderedStopId
         zoomDelta={0.5}
       >
       <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+        attribution='&copy; OpenStreetMap contributors &copy; CARTO'
+        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
       />
 
       <FitBounds stores={stores} focusedStoreId={focusedStoreId} />
       <MapClickClear onClear={() => onSelectStore(null)} />
 
-      {routeLatLngs.length > 1 ? <Polyline positions={routeLatLngs} color="#0f172a" weight={4} opacity={0.85} /> : null}
+      {routeLatLngs.length > 1 ? (
+        <>
+          <Polyline positions={routeLatLngs} color="#0f5f9e" weight={8} opacity={0.28} />
+          <Polyline positions={routeLatLngs} color="#20a8ff" weight={5} opacity={0.95} />
+        </>
+      ) : null}
 
       {stores.map((store) => {
         const selected = selectedSet.has(store.id);
@@ -91,7 +97,7 @@ export function TerritoryMapCanvasInner({ stores, selectedStopIds, orderedStopId
           <Marker
             key={store.id}
             position={[store.lat, store.lng]}
-            icon={buildMarkerIcon(store.statusColor, selected, order, focused)}
+            icon={buildMarkerIcon(pinColorForStore(store, 'status'), selected, order, focused)}
             bubblingMouseEvents={false}
             eventHandlers={{
               click: () => onSelectStore(store.id),
@@ -152,14 +158,20 @@ function buildMarkerIcon(color: string, selected: boolean, order: number | undef
 
   const size = focused ? 30 : selected ? 24 : 22;
   const borderColor = focused ? '#3b82f6' : selected ? '#0f172a' : '#ffffff';
-  const shadow = focused ? '0 0 0 3px rgba(59,130,246,0.25)' : selected ? '0 0 0 2px rgba(15,23,42,0.25)' : '0 1px 3px rgba(15,23,42,0.25)';
+  const shadow = focused ? '0 0 0 3px rgba(59,130,246,0.25)' : selected ? '0 0 0 2px rgba(15,23,42,0.25)' : '0 3px 8px rgba(15,23,42,0.28)';
   const focusedClass = focused ? ' picc-focused-pin' : '';
+  const pinShape = selected
+    ? `position:relative;width:${size}px;height:${size}px;border-radius:50%;background:${color};border:3px solid ${borderColor};box-shadow:${shadow};transform:translateZ(0);`
+    : `position:relative;width:${size}px;height:${size}px;border-radius:50% 50% 50% 0;background:${color};border:3px solid ${borderColor};box-shadow:${shadow};transform:rotate(-45deg) translateZ(0);`;
+  const innerLabelStyle = selected
+    ? ''
+    : 'display:none;';
 
   return L.divIcon({
     className: '',
-    html: `<div class="${focusedClass.trim()}" style="position:relative;width:${size}px;height:${size}px;border-radius:50%;background:${color};border:3px solid ${borderColor};box-shadow:${shadow};transform:translateZ(0);">${badge}</div>`,
+    html: `<div class="${focusedClass.trim()}" style="${pinShape}"><span style="${innerLabelStyle}"></span>${badge}</div>`,
     iconSize: [size, size],
-    iconAnchor: [Math.round(size / 2), Math.round(size / 2)],
+    iconAnchor: selected ? [Math.round(size / 2), Math.round(size / 2)] : [Math.round(size / 2) - 1, size],
     popupAnchor: [0, -10],
   });
 }

--- a/lib/server/notion-meeting-notes.ts
+++ b/lib/server/notion-meeting-notes.ts
@@ -18,6 +18,13 @@ interface MeetingCheckInInput {
   mode: CheckInMode;
   noteText?: string;
   actorEmail?: string;
+  associatedContact?: {
+    id?: string;
+    name: string;
+    roleTitle?: string | null;
+    email?: string | null;
+    phone?: string | null;
+  };
 }
 
 interface MeetingCheckInHistoryInput {
@@ -395,6 +402,11 @@ export async function createMeetingCheckIn(input: MeetingCheckInInput) {
   const accountPropertyName = propertyByCandidates(properties, ['Account', 'Dispensary', 'Store', 'Store Name'], ['rich_text', 'title']);
   const addressPropertyName = propertyByCandidates(properties, ['Address', 'Location'], ['rich_text']);
   const repPropertyName = propertyByCandidates(properties, ['Rep', 'PICC Rep', 'Sales Rep', 'Owner'], ['rich_text']);
+  const associatedContactPropertyName = propertyByCandidates(
+    properties,
+    ['Associated Contact', 'Contact', 'Primary Contact', 'Contact Name'],
+    ['rich_text'],
+  );
   const statusPropertyName = propertyByCandidates(properties, ['Status', 'Type', 'Meeting Type'], ['status', 'select']);
   const notesPropertyName = propertyByCandidates(properties, ['Notes', 'Meeting Notes', 'Summary'], ['rich_text']);
 
@@ -435,6 +447,20 @@ export async function createMeetingCheckIn(input: MeetingCheckInInput) {
   if (repPropertyName && input.store.repName) {
     notionProperties[repPropertyName] = {
       rich_text: [{ text: { content: input.store.repName } }],
+    };
+  }
+
+  if (associatedContactPropertyName && input.associatedContact?.name) {
+    const contactLabel = [
+      input.associatedContact.name,
+      input.associatedContact.roleTitle?.trim() ? `(${input.associatedContact.roleTitle.trim()})` : '',
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+
+    notionProperties[associatedContactPropertyName] = {
+      rich_text: [{ text: { content: contactLabel } }],
     };
   }
 
@@ -483,6 +509,30 @@ export async function createMeetingCheckIn(input: MeetingCheckInInput) {
       },
     },
   ] as Array<Record<string, unknown>>;
+
+  if (input.associatedContact?.name) {
+    const contactParts = [
+      input.associatedContact.name.trim(),
+      input.associatedContact.roleTitle?.trim() || '',
+      input.associatedContact.email?.trim() || '',
+      input.associatedContact.phone?.trim() || '',
+    ].filter(Boolean);
+
+    children.push({
+      object: 'block',
+      type: 'paragraph',
+      paragraph: {
+        rich_text: [
+          {
+            type: 'text',
+            text: {
+              content: `Associated contact: ${contactParts.join(' · ')}`,
+            },
+          },
+        ],
+      },
+    });
+  }
 
   if (input.noteText?.trim()) {
     children.push({

--- a/lib/territory/pin-colors.ts
+++ b/lib/territory/pin-colors.ts
@@ -1,0 +1,39 @@
+import type { TerritoryStorePin } from '@/lib/territory/types';
+
+export type PinColorMode = 'status' | 'rep';
+
+const REP_PALETTE = [
+  '#0ea5e9',
+  '#6366f1',
+  '#14b8a6',
+  '#f97316',
+  '#e11d48',
+  '#8b5cf6',
+  '#10b981',
+  '#f59e0b',
+];
+
+function hashString(input: string) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function repColorForLabel(label: string) {
+  const normalized = label.trim().toLowerCase();
+  if (!normalized) {
+    return '#64748b';
+  }
+  return REP_PALETTE[hashString(normalized) % REP_PALETTE.length];
+}
+
+export function pinColorForStore(store: TerritoryStorePin, mode: PinColorMode) {
+  if (mode === 'rep') {
+    const rep = store.repNames.find((name) => name.trim().length > 0) ?? 'Unassigned';
+    return repColorForLabel(rep);
+  }
+  return store.statusColor;
+}


### PR DESCRIPTION
## Summary
- make associated contacts actionable from account details: each contact now links to an in-app contact detail page
- add a new `/contacts/[contactId]` page for direct contact navigation
- make contacts table rows navigate to their contact detail page
- extend check-in flow to support written/voice meeting-note check-ins with optional associated contact context
- keep backward compatibility for existing `POST /api/territory/check-in` payloads (`{ storeId }`)

## Behavior
- tapping **Check-in** from an associated contact opens a modal with **Written / Voice** mode
- created meeting notes include associated contact details when provided
- successful note check-ins still attempt to update territory last-check-in timestamp

## Validation
- npm run lint
- npm run typecheck
- npm run build