### PR TITLE
feat: postgis read-model cutover and territory layer APIs

### DIFF
--- a/app/api/territory/filter-presets/route.ts
+++ b/app/api/territory/filter-presets/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireTerritoryApiAccess } from '@/lib/auth/territory-access';
+import { listTerritoryFilterPresets, upsertTerritoryFilterPreset } from '@/lib/server/territory-read-model';
+
+const presetSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  search: z.string().max(256).default(''),
+  selectedStatuses: z.array(z.string().trim().min(1)).max(25).default([]),
+  selectedReps: z.array(z.string().trim().min(1)).max(25).default([]),
+  showRouteOnly: z.boolean().default(false),
+  pinColorMode: z.enum(['status', 'rep']).default('status'),
+});
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  try {
+    const presets = await listTerritoryFilterPresets(access.email);
+    return NextResponse.json({ presets });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load filter presets';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  try {
+    const parsed = presetSchema.parse(await request.json());
+    const preset = await upsertTerritoryFilterPreset(access.email, parsed);
+    return NextResponse.json({ preset });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid filter preset payload', details: error.issues }, { status: 400 });
+    }
+
+    const message = error instanceof Error ? error.message : 'Failed to save filter preset';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/territory/layers/route.ts
+++ b/app/api/territory/layers/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { requireTerritoryApiAccess } from '@/lib/auth/territory-access';
+import { loadTerritoryLayers, type TerritoryLayerMetric, type TerritoryLayerMode } from '@/lib/server/territory-read-model';
+
+const METRICS: TerritoryLayerMetric[] = ['interactions', 'purchases', 'follow_up'];
+const MODES: TerritoryLayerMode[] = ['pins', 'heatmap', 'hex'];
+
+function readMultiParam(searchParams: URLSearchParams, key: string) {
+  return searchParams
+    .getAll(key)
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const metric = (searchParams.get('metric') ?? 'interactions') as TerritoryLayerMetric;
+  const mode = (searchParams.get('mode') ?? 'pins') as TerritoryLayerMode;
+
+  if (!METRICS.includes(metric)) {
+    return NextResponse.json({ error: 'Invalid metric query parameter' }, { status: 400 });
+  }
+
+  if (!MODES.includes(mode)) {
+    return NextResponse.json({ error: 'Invalid mode query parameter' }, { status: 400 });
+  }
+
+  try {
+    const payload = await loadTerritoryLayers({
+      metric,
+      mode,
+      statuses: readMultiParam(searchParams, 'status'),
+      reps: readMultiParam(searchParams, 'rep'),
+      query: searchParams.get('q')?.trim() ?? '',
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        'X-Territory-Layer-Metric': metric,
+        'X-Territory-Layer-Mode': mode,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load territory layers';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/territory/prewarm/route.ts
+++ b/app/api/territory/prewarm/route.ts
@@ -14,7 +14,7 @@ export async function POST() {
     const payload = await prewarmTerritoryGeocodeCache();
     return NextResponse.json(payload, {
       headers: {
-        'X-Territory-Data-Source': 'notion-live-cache',
+        'X-Territory-Data-Source': 'postgis',
       },
     });
   } catch (error) {
@@ -26,7 +26,7 @@ export async function POST() {
       {
         status: 500,
         headers: {
-          'X-Territory-Data-Source': 'notion-live-cache',
+          'X-Territory-Data-Source': 'postgis',
         },
       },
     );

--- a/app/api/territory/stores/route.ts
+++ b/app/api/territory/stores/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json(payload, {
       headers: {
-        'X-Territory-Data-Source': payload.meta.dataSource,
+        'X-Territory-Data-Source': payload.meta.sourceEngine ?? payload.meta.dataSource,
       },
     });
   } catch (error) {
@@ -58,7 +58,7 @@ export async function GET(request: Request) {
       {
         status: 500,
         headers: {
-          'X-Territory-Data-Source': 'notion-live-cache',
+          'X-Territory-Data-Source': 'postgis',
         },
       },
     );

--- a/lib/server/notion-territory.ts
+++ b/lib/server/notion-territory.ts
@@ -8,6 +8,13 @@ import {
   type NotionCacheSnapshot,
   writeNotionCacheSnapshot,
 } from '@/lib/server/notion-cache-store';
+import {
+  loadTerritoryStoreFromReadModel,
+  loadTerritoryStoresFromReadModel,
+  patchTerritoryStoreReadModel,
+  recordTerritoryCheckInEvent,
+  syncTerritoryStoresReadModel,
+} from '@/lib/server/territory-read-model';
 import { colorForStatus, normalizeStatus, pinKindForStatus, type TerritoryStoreContact, type TerritoryStoresResponse, type TerritoryStorePin } from '@/lib/territory/types';
 
 const NOTION_API_BASE = 'https://api.notion.com/v1';
@@ -602,6 +609,7 @@ async function syncTerritorySnapshotFromNotion(input?: { maxLiveGeocodeLookups?:
     unresolvedLocationCount,
     lastEditedMax,
   });
+  await syncTerritoryStoresReadModel(stores);
 
   const snapshot: NotionCacheSnapshot<TerritoryStorePin[]> = {
     key: TERRITORY_SNAPSHOT_KEY,
@@ -771,7 +779,7 @@ async function patchStoreInSnapshot(storeId: string, updater: (store: TerritoryS
 
 export async function loadTerritoryStoreDetail(storeId: string) {
   const snapshot = await getTerritorySnapshot();
-  const store = findStoreById(snapshot.stores, storeId);
+  const store = (await loadTerritoryStoreFromReadModel(storeId)) ?? findStoreById(snapshot.stores, storeId);
   if (!store) {
     throw new Error('Store not found');
   }
@@ -841,6 +849,9 @@ export async function updateTerritoryStoreNotes(storeId: string, notes: string) 
     notes: trimmed || null,
     lastEditedTime: now,
   }));
+  await patchTerritoryStoreReadModel(store.id, {
+    notes: trimmed || null,
+  });
 
   return {
     storeId: store.id,
@@ -888,6 +899,16 @@ export async function recordTerritoryStoreCheckIn(storeId: string) {
     lastCheckIn: checkedInAt,
     lastEditedTime: checkedInAt,
   }));
+  await patchTerritoryStoreReadModel(store.id, {
+    lastCheckIn: checkedInAt,
+  });
+  await recordTerritoryCheckInEvent({
+    storeId: store.id,
+    lat: store.lat,
+    lng: store.lng,
+    noteText: `Check-in recorded at ${checkedInAt}`,
+    happenedAt: checkedInAt,
+  });
 
   return {
     storeId: store.id,
@@ -917,85 +938,24 @@ export async function loadTerritoryStores(input?: {
     refresh: input?.refresh,
     maxLiveGeocodeLookups: input?.maxLiveGeocodeLookups,
   });
-
-  const filters = {
-    status: new Set((input?.statuses ?? []).map((value) => normalizeStatus(value))),
-    rep: new Set((input?.reps ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean)),
-    q: input?.query?.trim().toLowerCase() ?? '',
-  };
-
-  const statusCounts = new Map<string, number>();
-  const repCounts = new Map<string, number>();
-
-  for (const pin of snapshot.stores) {
-    statusCounts.set(pin.status, (statusCounts.get(pin.status) ?? 0) + 1);
-
-    if (pin.repNames.length === 0 && pin.repEmails.length === 0) {
-      repCounts.set('Unassigned', (repCounts.get('Unassigned') ?? 0) + 1);
-      continue;
-    }
-
-    for (const repName of pin.repNames) {
-      repCounts.set(repName, (repCounts.get(repName) ?? 0) + 1);
-    }
-  }
-
-  const filteredStores = snapshot.stores.filter((pin) => {
-    if (filters.status.size > 0 && !filters.status.has(pin.statusKey)) {
-      return false;
-    }
-
-    if (filters.rep.size > 0) {
-      const repSet = buildRepLabelSet(pin);
-      let repMatch = false;
-      for (const filterValue of filters.rep) {
-        if (repSet.has(filterValue)) {
-          repMatch = true;
-          break;
-        }
-      }
-      if (!repMatch) {
-        return false;
-      }
-    }
-
-    if (filters.q) {
-      const searchable = [
-        pin.name,
-        pin.locationAddress ?? '',
-        pin.city ?? '',
-        pin.state ?? '',
-        pin.status,
-        pin.repNames.join(' '),
-      ]
-        .join(' ')
-        .toLowerCase();
-
-      if (!searchable.includes(filters.q)) {
-        return false;
-      }
-    }
-
-    return true;
+  await syncTerritoryStoresReadModel(snapshot.stores);
+  const readModel = await loadTerritoryStoresFromReadModel({
+    statuses: input?.statuses,
+    reps: input?.reps,
+    query: input?.query,
   });
 
-  filteredStores.sort((a, b) => a.name.localeCompare(b.name));
-
-  const statusFilterCounts = [...statusCounts.entries()]
-    .map(([value, count]) => ({ value, count }))
-    .sort((a, b) => a.value.localeCompare(b.value));
-
-  const repFilterCounts = [...repCounts.entries()]
-    .map(([value, count]) => ({ value, count }))
-    .sort((a, b) => a.value.localeCompare(b.value));
-
   return {
-    stores: filteredStores,
+    stores: readModel.stores,
     filters: {
-      statuses: statusFilterCounts,
-      reps: repFilterCounts,
+      statuses: readModel.filters.statuses,
+      reps: readModel.filters.reps,
     },
-    meta: snapshot.meta,
+    meta: {
+      ...snapshot.meta,
+      sourceEngine: 'postgis',
+      recordsRead: readModel.recordsRead,
+    },
   };
 }
 

--- a/lib/server/territory-read-model.ts
+++ b/lib/server/territory-read-model.ts
@@ -1,0 +1,588 @@
+import 'server-only';
+
+import { prisma } from '@/lib/db/prisma';
+import { normalizeStatus, type TerritoryFilterCount, type TerritoryStorePin } from '@/lib/territory/types';
+
+const DEFAULT_ORG_ID = process.env.TERRITORY_ORG_ID?.trim() || 'org_picc_demo';
+
+export type TerritoryLayerMetric = 'interactions' | 'purchases' | 'follow_up';
+export type TerritoryLayerMode = 'pins' | 'heatmap' | 'hex';
+
+export interface TerritoryFilterPresetInput {
+  name: string;
+  search: string;
+  selectedStatuses: string[];
+  selectedReps: string[];
+  showRouteOnly: boolean;
+  pinColorMode: 'status' | 'rep';
+}
+
+export interface TerritoryLayerFeature {
+  type: 'Feature';
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  properties: Record<string, unknown>;
+}
+
+function asDate(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function normalizeKey(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function metricForStore(store: TerritoryStorePin, checkInCount: number, purchaseScore: number) {
+  const interactionsScore = checkInCount > 0 ? checkInCount : store.lastCheckIn ? 1 : 0;
+
+  const followUpDate = asDate(store.followUpDate);
+  let followUpUrgencyScore = 0;
+  if (followUpDate) {
+    const daysUntil = Math.ceil((followUpDate.getTime() - Date.now()) / 86_400_000);
+    followUpUrgencyScore = Math.max(0, 14 - daysUntil);
+  }
+
+  return {
+    interactionsScore,
+    purchasesScore: Math.max(0, purchaseScore),
+    followUpUrgencyScore,
+  };
+}
+
+function metricValue(pin: TerritoryStorePin, metric: TerritoryLayerMetric) {
+  if (metric === 'interactions') return pin.metrics?.interactionsScore ?? 0;
+  if (metric === 'purchases') return pin.metrics?.purchasesScore ?? 0;
+  return pin.metrics?.followUpUrgencyScore ?? 0;
+}
+
+async function getPurchaseScoreByKey(orgId: string) {
+  const rows = await prisma.nabisOrder.findMany({
+    where: { orgId },
+    select: {
+      licensedLocationId: true,
+      licensedLocationName: true,
+      orderTotal: true,
+      deliveryDate: true,
+    },
+  });
+
+  const scores = new Map<string, number>();
+
+  for (const row of rows) {
+    const when = row.deliveryDate ?? null;
+    if (when) {
+      const ageDays = (Date.now() - when.getTime()) / 86_400_000;
+      if (ageDays > 120) {
+        continue;
+      }
+    }
+
+    const total = row.orderTotal ? Number(row.orderTotal) : 0;
+    const points = Math.max(1, Math.round(total / 1000));
+
+    const keys = [row.licensedLocationId, row.licensedLocationName]
+      .filter((value): value is string => Boolean(value && value.trim()))
+      .map((value) => normalizeKey(value));
+
+    for (const key of keys) {
+      scores.set(key, (scores.get(key) ?? 0) + points);
+    }
+  }
+
+  return scores;
+}
+
+function matchRepFilter(store: TerritoryStorePin, filterSet: Set<string>) {
+  if (filterSet.size === 0) return true;
+
+  const labels = new Set<string>();
+  for (const rep of store.repNames) labels.add(rep.toLowerCase());
+  for (const email of store.repEmails) labels.add(email.toLowerCase());
+  if (labels.size === 0) labels.add('unassigned');
+
+  for (const value of filterSet) {
+    if (labels.has(value)) return true;
+  }
+
+  return false;
+}
+
+function hydrateSearch(store: TerritoryStorePin) {
+  return [
+    store.name,
+    store.locationAddress ?? '',
+    store.city ?? '',
+    store.state ?? '',
+    store.status,
+    store.repNames.join(' '),
+    store.email ?? '',
+    store.phoneNumber ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+}
+
+function orgIdOrDefault(orgId?: string) {
+  const clean = orgId?.trim();
+  return clean || DEFAULT_ORG_ID;
+}
+
+function toPin(record: {
+  id: string;
+  notionPageId: string;
+  name: string;
+  status: string;
+  statusKey: string;
+  statusColor: string;
+  pinKind: string;
+  repNames: string[];
+  repEmails: string[];
+  lat: number;
+  lng: number;
+  locationLabel: string | null;
+  locationAddress: string | null;
+  locationSource: string;
+  lastEditedTime: Date;
+  licenseNumber: string | null;
+  city: string | null;
+  state: string | null;
+  daysOverdue: number | null;
+  phoneNumber: string | null;
+  email: string | null;
+  followUpDate: Date | null;
+  notes: string | null;
+  lastCheckIn: Date | null;
+  interactionsScore: number;
+  purchasesScore: number;
+  followUpUrgencyScore: number;
+}): TerritoryStorePin {
+  return {
+    id: record.id,
+    notionPageId: record.notionPageId,
+    name: record.name,
+    status: record.status,
+    statusKey: record.statusKey,
+    statusColor: record.statusColor,
+    pinKind: (record.pinKind as TerritoryStorePin['pinKind']) ?? 'other',
+    repNames: record.repNames,
+    repEmails: record.repEmails,
+    lat: record.lat,
+    lng: record.lng,
+    locationLabel: record.locationLabel,
+    locationAddress: record.locationAddress,
+    locationSource: (record.locationSource as TerritoryStorePin['locationSource']) ?? 'nominatim-cache',
+    lastEditedTime: record.lastEditedTime.toISOString(),
+    licenseNumber: record.licenseNumber,
+    city: record.city,
+    state: record.state,
+    daysOverdue: record.daysOverdue,
+    phoneNumber: record.phoneNumber,
+    email: record.email,
+    followUpDate: record.followUpDate ? record.followUpDate.toISOString() : null,
+    notes: record.notes,
+    lastCheckIn: record.lastCheckIn ? record.lastCheckIn.toISOString() : null,
+    geometry: {
+      type: 'Point',
+      coordinates: [record.lng, record.lat],
+    },
+    metrics: {
+      interactionsScore: Number(record.interactionsScore ?? 0),
+      purchasesScore: Number(record.purchasesScore ?? 0),
+      followUpUrgencyScore: Number(record.followUpUrgencyScore ?? 0),
+    },
+  };
+}
+
+export async function syncTerritoryStoresReadModel(stores: TerritoryStorePin[], input?: { orgId?: string }) {
+  const orgId = orgIdOrDefault(input?.orgId);
+  const purchaseScoreByKey = await getPurchaseScoreByKey(orgId);
+
+  const checkIns = await prisma.checkIn.groupBy({
+    by: ['storeId'],
+    where: {
+      orgId,
+      storeId: {
+        in: stores.map((store) => store.id),
+      },
+    },
+    _count: {
+      storeId: true,
+    },
+  });
+
+  const checkInCountByStore = new Map<string, number>();
+  for (const row of checkIns) {
+    if (!row.storeId) continue;
+    checkInCountByStore.set(row.storeId, row._count.storeId);
+  }
+
+  const rows = stores.map((store) => {
+    const checkInCount = checkInCountByStore.get(store.id) ?? 0;
+    const purchaseScore =
+      purchaseScoreByKey.get(normalizeKey(store.licenseNumber ?? '')) ??
+      purchaseScoreByKey.get(normalizeKey(store.name)) ??
+      0;
+
+    const metrics = metricForStore(store, checkInCount, purchaseScore);
+
+    return {
+      id: store.id,
+      orgId,
+      notionPageId: store.notionPageId,
+      name: store.name,
+      status: store.status,
+      statusKey: store.statusKey,
+      statusColor: store.statusColor,
+      pinKind: store.pinKind,
+      repNames: store.repNames,
+      repEmails: store.repEmails,
+      lat: store.lat,
+      lng: store.lng,
+      locationLabel: store.locationLabel,
+      locationAddress: store.locationAddress,
+      locationSource: store.locationSource,
+      lastEditedTime: new Date(store.lastEditedTime),
+      licenseNumber: store.licenseNumber ?? null,
+      city: store.city ?? null,
+      state: store.state ?? null,
+      daysOverdue: typeof store.daysOverdue === 'number' ? Math.trunc(store.daysOverdue) : null,
+      phoneNumber: store.phoneNumber ?? null,
+      email: store.email ?? null,
+      followUpDate: store.followUpDate ? new Date(store.followUpDate) : null,
+      notes: store.notes ?? null,
+      lastCheckIn: store.lastCheckIn ? new Date(store.lastCheckIn) : null,
+      interactionsScore: metrics.interactionsScore,
+      purchasesScore: metrics.purchasesScore,
+      followUpUrgencyScore: metrics.followUpUrgencyScore,
+    };
+  });
+
+  await prisma.$transaction([
+    prisma.territoryStoreReadModel.deleteMany({ where: { orgId } }),
+    prisma.territoryStoreReadModel.createMany({ data: rows }),
+  ]);
+
+  await prisma.$executeRawUnsafe(
+    `UPDATE "TerritoryStoreReadModel" SET "geoPoint" = ST_SetSRID(ST_MakePoint("lng", "lat"), 4326) WHERE "orgId" = $1`,
+    orgId,
+  );
+
+  for (const row of rows) {
+    const accountWhere = row.licenseNumber
+      ? {
+          orgId,
+          OR: [{ licenseNumber: row.licenseNumber }, { name: row.name }],
+        }
+      : {
+          orgId,
+          name: row.name,
+        };
+
+    await prisma.account.updateMany({
+      where: accountWhere,
+      data: {
+        geoLat: row.lat,
+        geoLng: row.lng,
+      },
+    });
+  }
+
+  await prisma.$executeRawUnsafe(
+    `UPDATE "Account" SET "geoPoint" = ST_SetSRID(ST_MakePoint("geoLng", "geoLat"), 4326) WHERE "orgId" = $1 AND "geoLat" IS NOT NULL AND "geoLng" IS NOT NULL`,
+    orgId,
+  );
+
+  return {
+    count: rows.length,
+    orgId,
+  };
+}
+
+export async function loadTerritoryStoresFromReadModel(input: {
+  statuses?: string[];
+  reps?: string[];
+  query?: string;
+  orgId?: string;
+}) {
+  const orgId = orgIdOrDefault(input.orgId);
+  const records = await prisma.territoryStoreReadModel.findMany({
+    where: { orgId },
+    orderBy: { name: 'asc' },
+  });
+
+  const pins = records.map((row) =>
+    toPin({
+      ...row,
+      locationLabel: row.locationLabel,
+      locationAddress: row.locationAddress,
+      licenseNumber: row.licenseNumber,
+      city: row.city,
+      state: row.state,
+      daysOverdue: row.daysOverdue,
+      phoneNumber: row.phoneNumber,
+      email: row.email,
+      followUpDate: row.followUpDate,
+      notes: row.notes,
+      lastCheckIn: row.lastCheckIn,
+    }),
+  );
+
+  const statusCounts = new Map<string, number>();
+  const repCounts = new Map<string, number>();
+
+  for (const pin of pins) {
+    statusCounts.set(pin.status, (statusCounts.get(pin.status) ?? 0) + 1);
+    if (pin.repNames.length === 0 && pin.repEmails.length === 0) {
+      repCounts.set('Unassigned', (repCounts.get('Unassigned') ?? 0) + 1);
+      continue;
+    }
+    for (const rep of pin.repNames) {
+      repCounts.set(rep, (repCounts.get(rep) ?? 0) + 1);
+    }
+  }
+
+  const statusFilter = new Set((input.statuses ?? []).map((value) => normalizeStatus(value)));
+  const repFilter = new Set((input.reps ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean));
+  const q = input.query?.trim().toLowerCase() ?? '';
+
+  const filteredStores = pins.filter((pin) => {
+    if (statusFilter.size > 0 && !statusFilter.has(pin.statusKey)) {
+      return false;
+    }
+
+    if (!matchRepFilter(pin, repFilter)) {
+      return false;
+    }
+
+    if (q && !hydrateSearch(pin).includes(q)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  const statuses: TerritoryFilterCount[] = [...statusCounts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => a.value.localeCompare(b.value));
+
+  const reps: TerritoryFilterCount[] = [...repCounts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => a.value.localeCompare(b.value));
+
+  return {
+    stores: filteredStores,
+    filters: {
+      statuses,
+      reps,
+    },
+    recordsRead: pins.length,
+  };
+}
+
+export async function loadTerritoryStoreFromReadModel(storeId: string, input?: { orgId?: string }) {
+  const orgId = orgIdOrDefault(input?.orgId);
+  const row = await prisma.territoryStoreReadModel.findFirst({
+    where: {
+      orgId,
+      OR: [{ id: storeId }, { notionPageId: storeId }],
+    },
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  return toPin({
+    ...row,
+    locationLabel: row.locationLabel,
+    locationAddress: row.locationAddress,
+    licenseNumber: row.licenseNumber,
+    city: row.city,
+    state: row.state,
+    daysOverdue: row.daysOverdue,
+    phoneNumber: row.phoneNumber,
+    email: row.email,
+    followUpDate: row.followUpDate,
+    notes: row.notes,
+    lastCheckIn: row.lastCheckIn,
+  });
+}
+
+export async function patchTerritoryStoreReadModel(storeId: string, input: { notes?: string | null; lastCheckIn?: string | null; orgId?: string }) {
+  const orgId = orgIdOrDefault(input.orgId);
+  const record = await prisma.territoryStoreReadModel.findFirst({
+    where: {
+      orgId,
+      OR: [{ id: storeId }, { notionPageId: storeId }],
+    },
+    select: { id: true },
+  });
+
+  if (!record) {
+    return;
+  }
+
+  await prisma.territoryStoreReadModel.update({
+    where: { id: record.id },
+    data: {
+      ...(Object.prototype.hasOwnProperty.call(input, 'notes') ? { notes: input.notes ?? null } : {}),
+      ...(Object.prototype.hasOwnProperty.call(input, 'lastCheckIn')
+        ? { lastCheckIn: input.lastCheckIn ? new Date(input.lastCheckIn) : null }
+        : {}),
+      ...(Object.prototype.hasOwnProperty.call(input, 'lastCheckIn') ? { interactionsScore: { increment: 1 } } : {}),
+    },
+  });
+}
+
+export async function recordTerritoryCheckInEvent(input: {
+  storeId: string;
+  contactId?: string | null;
+  noteText?: string | null;
+  lat?: number;
+  lng?: number;
+  mileageMiles?: number | null;
+  photoUrls?: string[];
+  createdByEmail?: string | null;
+  happenedAt: string;
+  orgId?: string;
+}) {
+  const orgId = orgIdOrDefault(input.orgId);
+  const checkIn = await prisma.checkIn.create({
+    data: {
+      orgId,
+      storeId: input.storeId,
+      contactId: input.contactId ?? null,
+      noteText: input.noteText ?? null,
+      geoLat: typeof input.lat === 'number' ? input.lat : null,
+      geoLng: typeof input.lng === 'number' ? input.lng : null,
+      mileageMiles: input.mileageMiles ?? null,
+      photoUrls: input.photoUrls ?? [],
+      createdByEmail: input.createdByEmail ?? null,
+      happenedAt: new Date(input.happenedAt),
+    },
+  });
+
+  if (typeof input.lat === 'number' && typeof input.lng === 'number') {
+    await prisma.$executeRawUnsafe(
+      `UPDATE "CheckIn" SET "geoPoint" = ST_SetSRID(ST_MakePoint("geoLng", "geoLat"), 4326) WHERE "id" = $1`,
+      checkIn.id,
+    );
+  }
+
+  return checkIn;
+}
+
+export async function loadTerritoryLayers(input: {
+  metric: TerritoryLayerMetric;
+  mode: TerritoryLayerMode;
+  statuses?: string[];
+  reps?: string[];
+  query?: string;
+  orgId?: string;
+}) {
+  const storesResult = await loadTerritoryStoresFromReadModel(input);
+  const pins = storesResult.stores;
+
+  if (input.mode === 'pins' || input.mode === 'heatmap') {
+    const features: TerritoryLayerFeature[] = pins.map((pin) => ({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [pin.lng, pin.lat],
+      },
+      properties: {
+        id: pin.id,
+        name: pin.name,
+        status: pin.status,
+        weight: metricValue(pin, input.metric),
+      },
+    }));
+
+    return {
+      type: 'FeatureCollection' as const,
+      mode: input.mode,
+      metric: input.metric,
+      features,
+      count: features.length,
+    };
+  }
+
+  const buckets = new Map<string, { lat: number; lng: number; weight: number; count: number }>();
+  for (const pin of pins) {
+    const latBucket = Math.round(pin.lat * 50) / 50;
+    const lngBucket = Math.round(pin.lng * 50) / 50;
+    const key = `${latBucket}:${lngBucket}`;
+    const current = buckets.get(key) ?? { lat: latBucket, lng: lngBucket, weight: 0, count: 0 };
+    current.weight += metricValue(pin, input.metric);
+    current.count += 1;
+    buckets.set(key, current);
+  }
+
+  const features: TerritoryLayerFeature[] = [...buckets.values()].map((bucket) => ({
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [bucket.lng, bucket.lat],
+    },
+    properties: {
+      count: bucket.count,
+      weight: bucket.weight,
+    },
+  }));
+
+  return {
+    type: 'FeatureCollection' as const,
+    mode: input.mode,
+    metric: input.metric,
+    features,
+    count: features.length,
+  };
+}
+
+export async function listTerritoryFilterPresets(ownerEmail: string, input?: { orgId?: string }) {
+  const orgId = orgIdOrDefault(input?.orgId);
+
+  return prisma.territoryFilterPreset.findMany({
+    where: {
+      orgId,
+      ownerEmail: ownerEmail.toLowerCase(),
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+}
+
+export async function upsertTerritoryFilterPreset(ownerEmail: string, payload: TerritoryFilterPresetInput, input?: { orgId?: string }) {
+  const orgId = orgIdOrDefault(input?.orgId);
+
+  const normalized = {
+    name: payload.name.trim(),
+    search: payload.search.trim(),
+    selectedStatuses: payload.selectedStatuses.map((value) => value.trim()).filter(Boolean),
+    selectedReps: payload.selectedReps.map((value) => value.trim()).filter(Boolean),
+    showRouteOnly: payload.showRouteOnly,
+    pinColorMode: payload.pinColorMode,
+  };
+
+  return prisma.territoryFilterPreset.upsert({
+    where: {
+      orgId_ownerEmail_name: {
+        orgId,
+        ownerEmail: ownerEmail.toLowerCase(),
+        name: normalized.name,
+      },
+    },
+    create: {
+      orgId,
+      ownerEmail: ownerEmail.toLowerCase(),
+      ...normalized,
+    },
+    update: {
+      ...normalized,
+    },
+  });
+}

--- a/lib/territory/types.ts
+++ b/lib/territory/types.ts
@@ -25,6 +25,15 @@ export interface TerritoryStorePin {
   followUpDate?: string | null;
   notes?: string | null;
   lastCheckIn?: string | null;
+  geometry?: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  metrics?: {
+    interactionsScore: number;
+    purchasesScore: number;
+    followUpUrgencyScore: number;
+  };
 }
 
 export interface TerritoryStoreContact {
@@ -55,6 +64,7 @@ export interface TerritoryStoresResponse {
   };
   meta: {
     dataSource: 'notion-live-cache' | 'notion-live-cache-stale';
+    sourceEngine?: 'postgis';
     lastEditedMax: string | null;
     recordsRead: number;
     unresolvedLocationCount: number;

--- a/prisma/migrations/202603030003_postgis_read_model_cutover/migration.sql
+++ b/prisma/migrations/202603030003_postgis_read_model_cutover/migration.sql
@@ -1,0 +1,132 @@
+-- PostGIS full-cutover foundation
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+ALTER TABLE "Account"
+  ADD COLUMN "geoLat" DOUBLE PRECISION,
+  ADD COLUMN "geoLng" DOUBLE PRECISION,
+  ADD COLUMN "geoPoint" geometry(Point,4326);
+
+ALTER TABLE "Contact"
+  ADD COLUMN "geoLat" DOUBLE PRECISION,
+  ADD COLUMN "geoLng" DOUBLE PRECISION,
+  ADD COLUMN "geoPoint" geometry(Point,4326);
+
+CREATE TABLE "Territory" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "geometry" geometry(MultiPolygon,4326) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Territory_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "Territory_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "OrganizationWorkspace"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "SalesRoute" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "mode" TEXT NOT NULL DEFAULT 'car',
+  "orderedStopIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "totalDistanceMeters" INTEGER NOT NULL DEFAULT 0,
+  "totalDurationSeconds" INTEGER NOT NULL DEFAULT 0,
+  "geometry" geometry(LineString,4326),
+  "createdBy" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SalesRoute_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "SalesRoute_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "OrganizationWorkspace"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "CheckIn" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "storeId" TEXT,
+  "contactId" TEXT,
+  "happenedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "noteText" TEXT,
+  "photoUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "mileageMiles" DOUBLE PRECISION,
+  "geoLat" DOUBLE PRECISION,
+  "geoLng" DOUBLE PRECISION,
+  "geoPoint" geometry(Point,4326),
+  "createdByEmail" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "CheckIn_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "CheckIn_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "OrganizationWorkspace"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "TerritoryStoreReadModel" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "notionPageId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "statusKey" TEXT NOT NULL,
+  "statusColor" TEXT NOT NULL,
+  "pinKind" TEXT NOT NULL,
+  "repNames" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "repEmails" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "lat" DOUBLE PRECISION NOT NULL,
+  "lng" DOUBLE PRECISION NOT NULL,
+  "locationLabel" TEXT,
+  "locationAddress" TEXT,
+  "locationSource" TEXT NOT NULL,
+  "lastEditedTime" TIMESTAMP(3) NOT NULL,
+  "licenseNumber" TEXT,
+  "city" TEXT,
+  "state" TEXT,
+  "daysOverdue" INTEGER,
+  "phoneNumber" TEXT,
+  "email" TEXT,
+  "followUpDate" TIMESTAMP(3),
+  "notes" TEXT,
+  "lastCheckIn" TIMESTAMP(3),
+  "interactionsScore" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "purchasesScore" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "followUpUrgencyScore" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "geoPoint" geometry(Point,4326),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "TerritoryStoreReadModel_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "TerritoryStoreReadModel_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "OrganizationWorkspace"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "TerritoryFilterPreset" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "ownerEmail" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "search" TEXT NOT NULL DEFAULT '',
+  "selectedStatuses" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "selectedReps" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "showRouteOnly" BOOLEAN NOT NULL DEFAULT false,
+  "pinColorMode" TEXT NOT NULL DEFAULT 'status',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "TerritoryFilterPreset_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "TerritoryFilterPreset_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "OrganizationWorkspace"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "TerritoryStoreReadModel_notionPageId_key" ON "TerritoryStoreReadModel"("notionPageId");
+CREATE UNIQUE INDEX "TerritoryFilterPreset_orgId_ownerEmail_name_key" ON "TerritoryFilterPreset"("orgId", "ownerEmail", "name");
+
+CREATE INDEX "Territory_orgId_name_idx" ON "Territory"("orgId", "name");
+CREATE INDEX "SalesRoute_orgId_createdAt_idx" ON "SalesRoute"("orgId", "createdAt");
+CREATE INDEX "CheckIn_orgId_storeId_happenedAt_idx" ON "CheckIn"("orgId", "storeId", "happenedAt");
+CREATE INDEX "TerritoryStoreReadModel_orgId_name_idx" ON "TerritoryStoreReadModel"("orgId", "name");
+CREATE INDEX "TerritoryStoreReadModel_orgId_statusKey_idx" ON "TerritoryStoreReadModel"("orgId", "statusKey");
+CREATE INDEX "TerritoryStoreReadModel_orgId_followUpDate_idx" ON "TerritoryStoreReadModel"("orgId", "followUpDate");
+CREATE INDEX "TerritoryFilterPreset_orgId_ownerEmail_updatedAt_idx" ON "TerritoryFilterPreset"("orgId", "ownerEmail", "updatedAt");
+
+CREATE INDEX "Account_geoLat_geoLng_idx" ON "Account"("geoLat", "geoLng");
+CREATE INDEX "Contact_geoLat_geoLng_idx" ON "Contact"("geoLat", "geoLng");
+
+CREATE INDEX "Territory_gix" ON "Territory" USING GIST ("geometry");
+CREATE INDEX "SalesRoute_gix" ON "SalesRoute" USING GIST ("geometry");
+CREATE INDEX "CheckIn_gix" ON "CheckIn" USING GIST ("geoPoint");
+CREATE INDEX "TerritoryStoreReadModel_gix" ON "TerritoryStoreReadModel" USING GIST ("geoPoint");
+CREATE INDEX "Account_gix" ON "Account" USING GIST ("geoPoint");
+CREATE INDEX "Contact_gix" ON "Contact" USING GIST ("geoPoint");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,11 @@ model OrganizationWorkspace {
   syncRuns        SyncRun[]
   importJobs      ImportJob[]
   exportJobs      ExportJob[]
+  territories     Territory[]
+  salesRoutes     SalesRoute[]
+  checkIns        CheckIn[]
+  territoryStores TerritoryStoreReadModel[]
+  territoryFilterPresets TerritoryFilterPreset[]
 }
 
 model Membership {
@@ -156,6 +161,9 @@ model Account {
   state                 String
   zipcode               String
   phone                 String?
+  geoLat                Float?
+  geoLng                Float?
+  geoPoint              Unsupported("geometry(Point,4326)")?
   status                RecordStatus                     @default(ACTIVE)
   lastContactedAt       DateTime?
   createdAt             DateTime                         @default(now())
@@ -193,6 +201,9 @@ model Contact {
   roleTitle           String
   email               String?
   phone               String?
+  geoLat              Float?
+  geoLng              Float?
+  geoPoint            Unsupported("geometry(Point,4326)")?
   status              RecordStatus              @default(ACTIVE)
   createdAt           DateTime                  @default(now())
   updatedAt           DateTime                  @updatedAt
@@ -803,4 +814,111 @@ model NotionCacheSnapshot {
   lastEditedMax           DateTime?
   syncedAt                DateTime @default(now())
   updatedAt               DateTime @updatedAt
+}
+
+model Territory {
+  id            String                @id @default(cuid())
+  orgId         String
+  org           OrganizationWorkspace @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  name          String
+  description   String?
+  geometry      Unsupported("geometry(MultiPolygon,4326)")
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+
+  @@index([orgId, name])
+}
+
+model SalesRoute {
+  id                  String                @id @default(cuid())
+  orgId               String
+  org                 OrganizationWorkspace @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  name                String
+  mode                String                @default("car")
+  orderedStopIds      String[]              @default([])
+  totalDistanceMeters Int                   @default(0)
+  totalDurationSeconds Int                  @default(0)
+  geometry            Unsupported("geometry(LineString,4326)")?
+  createdBy           String?
+  createdAt           DateTime              @default(now())
+  updatedAt           DateTime              @updatedAt
+
+  @@index([orgId, createdAt])
+}
+
+model CheckIn {
+  id            String                @id @default(cuid())
+  orgId         String
+  org           OrganizationWorkspace @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  storeId       String?
+  contactId     String?
+  happenedAt    DateTime              @default(now())
+  noteText      String?
+  photoUrls     String[]              @default([])
+  mileageMiles  Float?
+  geoLat        Float?
+  geoLng        Float?
+  geoPoint      Unsupported("geometry(Point,4326)")?
+  createdByEmail String?
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+
+  @@index([orgId, storeId, happenedAt])
+}
+
+model TerritoryStoreReadModel {
+  id                    String                @id
+  orgId                 String
+  org                   OrganizationWorkspace @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  notionPageId          String                @unique
+  name                  String
+  status                String
+  statusKey             String
+  statusColor           String
+  pinKind               String
+  repNames              String[]              @default([])
+  repEmails             String[]              @default([])
+  lat                   Float
+  lng                   Float
+  locationLabel         String?
+  locationAddress       String?
+  locationSource        String
+  lastEditedTime        DateTime
+  licenseNumber         String?
+  city                  String?
+  state                 String?
+  daysOverdue           Int?
+  phoneNumber           String?
+  email                 String?
+  followUpDate          DateTime?
+  notes                 String?
+  lastCheckIn           DateTime?
+  interactionsScore     Float                 @default(0)
+  purchasesScore        Float                 @default(0)
+  followUpUrgencyScore  Float                 @default(0)
+  geoPoint              Unsupported("geometry(Point,4326)")?
+  createdAt             DateTime              @default(now())
+  updatedAt             DateTime              @updatedAt
+
+  @@index([orgId, name])
+  @@index([orgId, statusKey])
+  @@index([orgId, followUpDate])
+}
+
+model TerritoryFilterPreset {
+  id               String                @id @default(cuid())
+  orgId            String
+  org              OrganizationWorkspace @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  ownerEmail       String
+  name             String
+  search           String                @default("")
+  selectedStatuses String[]              @default([])
+  selectedReps     String[]              @default([])
+  showRouteOnly    Boolean               @default(false)
+  pinColorMode     String                @default("status")
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
+
+  @@unique([orgId, ownerEmail, name])
+  @@index([orgId, ownerEmail, updatedAt])
 }


### PR DESCRIPTION
## Summary
- enable PostGIS extension and add geospatial schema for `Territory`, `SalesRoute`, `CheckIn`, and geo columns on account/contact records
- add GIST indexes and migration SQL for geometry-backed queries
- cut `/api/territory/stores` read path over to PostGIS read model while preserving backward-compatible shape
- add new layer/filter preset APIs:
  - `GET /api/territory/layers`
  - `GET /api/territory/filter-presets`
  - `POST /api/territory/filter-presets`
- add metric computation fields (interactions, purchases, follow-up urgency)

## Out of Scope
- routing optimization algorithms
- auth provider changes

## Validation
- npm run typecheck
- prisma generate
- territory endpoints verified in build
