### PR TITLE
feat: migrate territory web map to maplibre with enterprise UX polish

### DIFF
--- a/app/(main)/territory/layout.tsx
+++ b/app/(main)/territory/layout.tsx
@@ -1,4 +1,4 @@
-import 'leaflet/dist/leaflet.css';
+import 'maplibre-gl/dist/maplibre-gl.css';
 
 export default function TerritoryLayout({ children }: { children: React.ReactNode }) {
   return children;

--- a/components/mobile/territory-map-mobile.tsx
+++ b/components/mobile/territory-map-mobile.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
-import { MapContainer, Marker, Polyline, TileLayer, useMap, useMapEvents } from 'react-leaflet';
-import L from 'leaflet';
-import type { LatLngExpression } from 'leaflet';
-import { pinColorForStore, type PinColorMode } from '@/lib/territory/pin-colors';
+import type { PinColorMode } from '@/lib/territory/pin-colors';
 import type { TerritoryStorePin } from '@/lib/territory/types';
+import { MapLibreTerritoryMap, type TerritoryLayerMode } from '@/components/territory/maplibre-territory-map';
 
 interface TerritoryMapMobileProps {
   stores: TerritoryStorePin[];
@@ -14,22 +11,8 @@ interface TerritoryMapMobileProps {
   focusedStoreId: string | null;
   routeCoordinates: [number, number][];
   pinColorMode: PinColorMode;
+  layerMode: TerritoryLayerMode;
   onSelectStore: (id: string | null) => void;
-}
-
-const FALLBACK_CENTER: LatLngExpression = [39.8283, -98.5795];
-
-function isFiniteLatLng(lat: unknown, lng: unknown) {
-  return (
-    typeof lat === 'number' &&
-    Number.isFinite(lat) &&
-    lat >= -90 &&
-    lat <= 90 &&
-    typeof lng === 'number' &&
-    Number.isFinite(lng) &&
-    lng >= -180 &&
-    lng <= 180
-  );
 }
 
 export function TerritoryMapMobile({
@@ -39,161 +22,22 @@ export function TerritoryMapMobile({
   focusedStoreId,
   routeCoordinates,
   pinColorMode,
+  layerMode,
   onSelectStore,
 }: TerritoryMapMobileProps) {
-  const safeStores = useMemo(() => stores.filter((store) => isFiniteLatLng(store.lat, store.lng)), [stores]);
-  const selectedSet = useMemo(() => new Set(selectedStopIds), [selectedStopIds]);
-  const orderMap = useMemo(() => {
-    const map = new Map<string, number>();
-    orderedStopIds.forEach((id, index) => map.set(id, index + 1));
-    return map;
-  }, [orderedStopIds]);
-
-  const center = useMemo<LatLngExpression>(() => {
-    const focused = focusedStoreId ? safeStores.find((store) => store.id === focusedStoreId) : null;
-    if (focused && isFiniteLatLng(focused.lat, focused.lng)) return [focused.lat, focused.lng];
-    if (safeStores[0] && isFiniteLatLng(safeStores[0].lat, safeStores[0].lng)) return [safeStores[0].lat, safeStores[0].lng];
-    return FALLBACK_CENTER;
-  }, [safeStores, focusedStoreId]);
-
-  const routeLine = useMemo(
-    () =>
-      routeCoordinates
-        .filter((coord): coord is [number, number] => Array.isArray(coord) && coord.length === 2 && isFiniteLatLng(coord[1], coord[0]))
-        .map(([lng, lat]) => [lat, lng] as [number, number]),
-    [routeCoordinates],
-  );
-
   return (
-    <>
-      <style>
-        {`
-          @keyframes picc-mobile-focused-pin-pulse {
-            0% { box-shadow: 0 0 0 0 rgba(79, 142, 223, 0.5); }
-            70% { box-shadow: 0 0 0 11px rgba(79, 142, 223, 0); }
-            100% { box-shadow: 0 0 0 0 rgba(79, 142, 223, 0); }
-          }
-
-          .picc-mobile-focused-pin {
-            animation: picc-mobile-focused-pin-pulse 1.5s ease-in-out infinite;
-          }
-        `}
-      </style>
-      <MapContainer
-        center={center}
-        zoom={11}
-        className="h-full w-full [filter:saturate(1.08)_contrast(1.03)]"
-        zoomControl={false}
-        preferCanvas
-        zoomAnimation
-        fadeAnimation
-        markerZoomAnimation
-        inertia
-        inertiaDeceleration={2200}
-        zoomSnap={0.25}
-        zoomDelta={0.5}
-      >
-        <TileLayer attribution="&copy; OpenStreetMap contributors &copy; CARTO" url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png" />
-        <FitMapBounds stores={safeStores} focusedStoreId={focusedStoreId} />
-        <MapClickClear onClear={() => onSelectStore(null)} />
-
-        {routeLine.length > 1 ? (
-          <>
-            <Polyline positions={routeLine} color="#0f5f9e" weight={9} opacity={0.28} />
-            <Polyline positions={routeLine} color="#20a8ff" weight={5} opacity={0.95} />
-          </>
-        ) : null}
-
-        {safeStores.map((store) => {
-          const selected = selectedSet.has(store.id);
-          const order = orderMap.get(store.id);
-          const focused = focusedStoreId === store.id;
-          const pinColor = pinColorForStore(store, pinColorMode);
-
-          return (
-            <Marker
-              key={store.id}
-              position={[store.lat, store.lng]}
-              icon={selected ? buildSelectedPin(order ?? 1, focused) : buildDefaultPin(pinColor, focused)}
-              bubblingMouseEvents={false}
-              eventHandlers={{ click: () => onSelectStore(store.id) }}
-            />
-          );
-        })}
-      </MapContainer>
-    </>
+    <MapLibreTerritoryMap
+      stores={stores}
+      selectedStopIds={selectedStopIds}
+      orderedStopIds={orderedStopIds}
+      focusedStoreId={focusedStoreId}
+      routeCoordinates={routeCoordinates}
+      pinColorMode={pinColorMode}
+      layerMode={layerMode}
+      fitPadding={24}
+      maxFitZoom={11}
+      defaultZoom={10.2}
+      onSelectStore={onSelectStore}
+    />
   );
-}
-
-function FitMapBounds({ stores, focusedStoreId }: { stores: TerritoryStorePin[]; focusedStoreId: string | null }) {
-  const map = useMap();
-
-  useEffect(() => {
-    const size = map.getSize();
-    if (!size || size.x <= 0 || size.y <= 0) {
-      return;
-    }
-
-    if (stores.length === 0) {
-      map.setView(FALLBACK_CENTER, 4);
-      return;
-    }
-
-    const focused = focusedStoreId ? stores.find((store) => store.id === focusedStoreId) : null;
-    if (focused && isFiniteLatLng(focused.lat, focused.lng)) {
-      try {
-        map.flyTo([focused.lat, focused.lng], Math.max(map.getZoom(), 13), { duration: 0.4 });
-      } catch {
-        map.setView([focused.lat, focused.lng], Math.max(map.getZoom(), 13));
-      }
-      return;
-    }
-
-    const bounds = L.latLngBounds(stores.map((store) => [store.lat, store.lng] as [number, number]));
-    if (!bounds.isValid()) {
-      map.setView(FALLBACK_CENTER, 4);
-      return;
-    }
-
-    try {
-      map.flyToBounds(bounds, { padding: [24, 24], maxZoom: 11, duration: 0.45 });
-    } catch {
-      map.fitBounds(bounds, { padding: [24, 24], maxZoom: 11 });
-    }
-  }, [map, stores, focusedStoreId]);
-
-  return null;
-}
-
-function MapClickClear({ onClear }: { onClear: () => void }) {
-  useMapEvents({
-    click() {
-      onClear();
-    },
-  });
-  return null;
-}
-
-function buildDefaultPin(color: string, focused: boolean) {
-  const size = focused ? 26 : 20;
-  const focusedClass = focused ? 'picc-mobile-focused-pin' : '';
-  const border = focused ? '#4f8edf' : '#ffffff';
-
-  return L.divIcon({
-    className: '',
-    html: `<div class="${focusedClass}" style="width:${size}px;height:${size}px;background:${color};border:2px solid ${border};border-radius:50% 50% 50% 0;transform:rotate(-45deg);box-shadow:0 4px 9px rgba(0,0,0,0.26);"></div>`,
-    iconSize: [size, size],
-    iconAnchor: [Math.round(size / 2) - 1, size],
-  });
-}
-
-function buildSelectedPin(order: number, focused: boolean) {
-  const size = focused ? 32 : 26;
-  const focusedClass = focused ? 'picc-mobile-focused-pin' : '';
-  return L.divIcon({
-    className: '',
-    html: `<div class="${focusedClass}" style="position:relative;width:${size}px;height:${size}px;border-radius:50%;background:#47b649;border:3px solid #dff5d8;box-shadow:0 3px 8px rgba(0,0,0,0.3);display:grid;place-items:center;font-weight:700;font-size:14px;color:#18411a;">${order}</div>`,
-    iconSize: [size, size],
-    iconAnchor: [Math.round(size / 2), Math.round(size / 2)],
-  });
 }

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -33,6 +33,7 @@ type SavedFiltersPayload = {
   selectedReps: string[];
   showRouteOnly: boolean;
   pinColorMode: PinColorMode;
+  layerMode: 'pins' | 'heatmap' | 'hex';
   savedAt: string;
 };
 
@@ -66,6 +67,7 @@ export function TerritoryMobile() {
   const [selectedReps, setSelectedReps] = useState<string[]>([]);
   const [showFilters, setShowFilters] = useState(false);
   const [pinColorMode, setPinColorMode] = useState<PinColorMode>('status');
+  const [layerMode, setLayerMode] = useState<'pins' | 'heatmap' | 'hex'>('pins');
   const [savedFiltersAt, setSavedFiltersAt] = useState<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
 
@@ -89,6 +91,7 @@ export function TerritoryMobile() {
       setSelectedReps(Array.isArray(parsed.selectedReps) ? parsed.selectedReps.filter((value): value is string => typeof value === 'string') : []);
       setShowRouteOnly(Boolean(parsed.showRouteOnly));
       setPinColorMode(parsed.pinColorMode === 'rep' ? 'rep' : 'status');
+      setLayerMode(parsed.layerMode === 'heatmap' || parsed.layerMode === 'hex' ? parsed.layerMode : 'pins');
       setSavedFiltersAt(typeof parsed.savedAt === 'string' ? parsed.savedAt : null);
       toast.success('Loaded saved territory filters');
     } catch {
@@ -195,6 +198,7 @@ export function TerritoryMobile() {
       selectedReps,
       showRouteOnly,
       pinColorMode,
+      layerMode,
       savedAt: new Date().toISOString(),
     };
     window.localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(payload));
@@ -209,6 +213,7 @@ export function TerritoryMobile() {
     setSelectedReps([]);
     setShowRouteOnly(false);
     setPinColorMode('status');
+    setLayerMode('pins');
     setSavedFiltersAt(null);
     window.localStorage.removeItem(FILTER_STORAGE_KEY);
     toast.success('Filters cleared');
@@ -264,9 +269,45 @@ export function TerritoryMobile() {
               focusedStoreId={focusedStore?.id ?? null}
               routeCoordinates={routeCoordinates}
               pinColorMode={pinColorMode}
+              layerMode={layerMode}
               onSelectStore={setFocusedId}
             />
           </MapRenderBoundary>
+
+          <div className="absolute left-1/2 top-6 z-[1550] -translate-x-1/2 rounded-xl bg-white/92 p-1 shadow">
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                className={cn(
+                  'rounded-lg px-2.5 py-1 text-[12px] font-semibold',
+                  layerMode === 'pins' ? 'bg-[#cd3814] text-white' : 'text-[#4b4e55]',
+                )}
+                onClick={() => setLayerMode('pins')}
+              >
+                Pins
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  'rounded-lg px-2.5 py-1 text-[12px] font-semibold',
+                  layerMode === 'heatmap' ? 'bg-[#cd3814] text-white' : 'text-[#4b4e55]',
+                )}
+                onClick={() => setLayerMode('heatmap')}
+              >
+                Heat
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  'rounded-lg px-2.5 py-1 text-[12px] font-semibold',
+                  layerMode === 'hex' ? 'bg-[#cd3814] text-white' : 'text-[#4b4e55]',
+                )}
+                onClick={() => setLayerMode('hex')}
+              >
+                Grid
+              </button>
+            </div>
+          </div>
 
           {routePlan.selectedStopIds.length >= 2 ? (
             <div className="absolute bottom-4 left-3 z-[1500] rounded-xl bg-black/70 px-3 py-2 text-[13px] text-white">

--- a/components/territory/map-canvas-inner.tsx
+++ b/components/territory/map-canvas-inner.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
-import { MapContainer, Marker, Polyline, Popup, TileLayer, useMap, useMapEvents } from 'react-leaflet';
-import L from 'leaflet';
-import type { LatLngExpression } from 'leaflet';
-import { pinColorForStore } from '@/lib/territory/pin-colors';
 import type { TerritoryStorePin } from '@/lib/territory/types';
+import { MapLibreTerritoryMap } from '@/components/territory/maplibre-territory-map';
 
 interface MapCanvasInnerProps {
   stores: TerritoryStorePin[];
@@ -16,201 +12,27 @@ interface MapCanvasInnerProps {
   onSelectStore: (storeId: string | null) => void;
 }
 
-const FALLBACK_CENTER: LatLngExpression = [39.8283, -98.5795];
-
-function isFiniteLatLng(lat: unknown, lng: unknown) {
+export function TerritoryMapCanvasInner({
+  stores,
+  selectedStopIds,
+  orderedStopIds,
+  routeCoordinates,
+  focusedStoreId,
+  onSelectStore,
+}: MapCanvasInnerProps) {
   return (
-    typeof lat === 'number' &&
-    Number.isFinite(lat) &&
-    lat >= -90 &&
-    lat <= 90 &&
-    typeof lng === 'number' &&
-    Number.isFinite(lng) &&
-    lng >= -180 &&
-    lng <= 180
+    <MapLibreTerritoryMap
+      stores={stores}
+      selectedStopIds={selectedStopIds}
+      orderedStopIds={orderedStopIds}
+      focusedStoreId={focusedStoreId}
+      routeCoordinates={routeCoordinates}
+      layerMode="pins"
+      pinColorMode="status"
+      fitPadding={32}
+      maxFitZoom={11}
+      defaultZoom={6}
+      onSelectStore={onSelectStore}
+    />
   );
-}
-
-export function TerritoryMapCanvasInner({ stores, selectedStopIds, orderedStopIds, routeCoordinates, focusedStoreId, onSelectStore }: MapCanvasInnerProps) {
-  const safeStores = useMemo(() => stores.filter((store) => isFiniteLatLng(store.lat, store.lng)), [stores]);
-  const selectedSet = useMemo(() => new Set(selectedStopIds), [selectedStopIds]);
-
-  const orderMap = useMemo(() => {
-    const entries = new Map<string, number>();
-    orderedStopIds.forEach((id, index) => {
-      entries.set(id, index + 1);
-    });
-    return entries;
-  }, [orderedStopIds]);
-
-  const mapCenter = useMemo<LatLngExpression>(() => {
-    if (safeStores.length === 0) {
-      return FALLBACK_CENTER;
-    }
-
-    const focus = focusedStoreId ? safeStores.find((store) => store.id === focusedStoreId) : null;
-    if (focus && isFiniteLatLng(focus.lat, focus.lng)) {
-      return [focus.lat, focus.lng];
-    }
-
-    return [safeStores[0].lat, safeStores[0].lng];
-  }, [safeStores, focusedStoreId]);
-
-  const routeLatLngs = useMemo(
-    () =>
-      routeCoordinates
-        .filter((coord): coord is [number, number] => Array.isArray(coord) && coord.length === 2 && isFiniteLatLng(coord[1], coord[0]))
-        .map(([lng, lat]) => [lat, lng] as [number, number]),
-    [routeCoordinates],
-  );
-
-  return (
-    <>
-      <style>
-        {`
-          @keyframes picc-focused-pin-pulse {
-            0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.45); }
-            70% { box-shadow: 0 0 0 12px rgba(59, 130, 246, 0); }
-            100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
-          }
-
-          .picc-focused-pin {
-            animation: picc-focused-pin-pulse 1.6s ease-in-out infinite;
-          }
-        `}
-      </style>
-      <MapContainer
-        center={mapCenter}
-        zoom={6}
-        className="h-full w-full [filter:saturate(1.08)_contrast(1.03)]"
-        zoomControl={false}
-        preferCanvas
-        zoomAnimation
-        fadeAnimation
-        markerZoomAnimation
-        inertia
-        inertiaDeceleration={2200}
-        zoomSnap={0.25}
-        zoomDelta={0.5}
-      >
-      <TileLayer
-        attribution='&copy; OpenStreetMap contributors &copy; CARTO'
-        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-      />
-
-      <FitBounds stores={safeStores} focusedStoreId={focusedStoreId} />
-      <MapClickClear onClear={() => onSelectStore(null)} />
-
-      {routeLatLngs.length > 1 ? (
-        <>
-          <Polyline positions={routeLatLngs} color="#0f5f9e" weight={8} opacity={0.28} />
-          <Polyline positions={routeLatLngs} color="#20a8ff" weight={5} opacity={0.95} />
-        </>
-      ) : null}
-
-      {safeStores.map((store) => {
-        const selected = selectedSet.has(store.id);
-        const order = orderMap.get(store.id);
-        const focused = focusedStoreId === store.id;
-
-        return (
-          <Marker
-            key={store.id}
-            position={[store.lat, store.lng]}
-            icon={buildMarkerIcon(pinColorForStore(store, 'status'), selected, order, focused)}
-            bubblingMouseEvents={false}
-            eventHandlers={{
-              click: () => onSelectStore(store.id),
-            }}
-          >
-            <Popup>
-              <div className="space-y-1">
-                <p className="text-sm font-semibold">{store.name}</p>
-                <p className="text-xs text-slate-600">{store.status}</p>
-                <p className="text-xs text-slate-500">{store.locationAddress ?? store.locationLabel ?? 'No address available'}</p>
-              </div>
-            </Popup>
-          </Marker>
-        );
-      })}
-      </MapContainer>
-    </>
-  );
-}
-
-function FitBounds({ stores, focusedStoreId }: { stores: TerritoryStorePin[]; focusedStoreId: string | null }) {
-  const map = useMap();
-
-  useEffect(() => {
-    const size = map.getSize();
-    if (!size || size.x <= 0 || size.y <= 0) {
-      return;
-    }
-
-    const validStores = stores.filter((store) => isFiniteLatLng(store.lat, store.lng));
-    if (validStores.length === 0) {
-      map.setView(FALLBACK_CENTER, 4);
-      return;
-    }
-
-    const focus = focusedStoreId ? validStores.find((store) => store.id === focusedStoreId) : null;
-    if (focus && isFiniteLatLng(focus.lat, focus.lng)) {
-      try {
-        map.flyTo([focus.lat, focus.lng], Math.max(map.getZoom(), 12), {
-          duration: 0.45,
-        });
-      } catch {
-        map.setView([focus.lat, focus.lng], Math.max(map.getZoom(), 12));
-      }
-      return;
-    }
-
-    const bounds = L.latLngBounds(validStores.map((store) => [store.lat, store.lng] as [number, number]));
-    if (!bounds.isValid()) {
-      map.setView(FALLBACK_CENTER, 4);
-      return;
-    }
-
-    try {
-      map.flyToBounds(bounds, { padding: [32, 32], maxZoom: 11, duration: 0.45 });
-    } catch {
-      map.fitBounds(bounds, { padding: [32, 32], maxZoom: 11 });
-    }
-  }, [focusedStoreId, map, stores]);
-
-  return null;
-}
-
-function MapClickClear({ onClear }: { onClear: () => void }) {
-  useMapEvents({
-    click() {
-      onClear();
-    },
-  });
-  return null;
-}
-
-function buildMarkerIcon(color: string, selected: boolean, order: number | undefined, focused: boolean) {
-  const badge = order
-    ? `<span style="position:absolute;bottom:-8px;right:-8px;min-width:18px;height:18px;padding:0 4px;border-radius:999px;background:#0f172a;color:#fff;font-size:10px;line-height:18px;font-weight:700;text-align:center;">${order}</span>`
-    : '';
-
-  const size = focused ? 30 : selected ? 24 : 22;
-  const borderColor = focused ? '#3b82f6' : selected ? '#0f172a' : '#ffffff';
-  const shadow = focused ? '0 0 0 3px rgba(59,130,246,0.25)' : selected ? '0 0 0 2px rgba(15,23,42,0.25)' : '0 3px 8px rgba(15,23,42,0.28)';
-  const focusedClass = focused ? ' picc-focused-pin' : '';
-  const pinShape = selected
-    ? `position:relative;width:${size}px;height:${size}px;border-radius:50%;background:${color};border:3px solid ${borderColor};box-shadow:${shadow};transform:translateZ(0);`
-    : `position:relative;width:${size}px;height:${size}px;border-radius:50% 50% 50% 0;background:${color};border:3px solid ${borderColor};box-shadow:${shadow};transform:rotate(-45deg) translateZ(0);`;
-  const innerLabelStyle = selected
-    ? ''
-    : 'display:none;';
-
-  return L.divIcon({
-    className: '',
-    html: `<div class="${focusedClass.trim()}" style="${pinShape}"><span style="${innerLabelStyle}"></span>${badge}</div>`,
-    iconSize: [size, size],
-    iconAnchor: selected ? [Math.round(size / 2), Math.round(size / 2)] : [Math.round(size / 2) - 1, size],
-    popupAnchor: [0, -10],
-  });
 }

--- a/components/territory/maplibre-territory-map.tsx
+++ b/components/territory/maplibre-territory-map.tsx
@@ -1,0 +1,556 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import maplibregl, { type GeoJSONSource, type LngLatBoundsLike, type StyleSpecification } from 'maplibre-gl';
+import { pinColorForStore, type PinColorMode } from '@/lib/territory/pin-colors';
+import type { TerritoryStorePin } from '@/lib/territory/types';
+import { cn } from '@/lib/utils';
+
+export type TerritoryLayerMode = 'pins' | 'heatmap' | 'hex';
+
+interface MapLibreTerritoryMapProps {
+  stores: TerritoryStorePin[];
+  selectedStopIds: string[];
+  orderedStopIds: string[];
+  focusedStoreId: string | null;
+  routeCoordinates: [number, number][];
+  pinColorMode?: PinColorMode;
+  layerMode?: TerritoryLayerMode;
+  onSelectStore: (storeId: string | null) => void;
+  className?: string;
+  fitPadding?: number;
+  maxFitZoom?: number;
+  defaultZoom?: number;
+}
+
+const FALLBACK_CENTER: [number, number] = [-98.5795, 39.8283];
+const STYLE: StyleSpecification = {
+  version: 8,
+  glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+  sources: {
+    carto: {
+      type: 'raster',
+      tiles: ['https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', 'https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png'],
+      tileSize: 256,
+      attribution: '&copy; OpenStreetMap contributors &copy; CARTO',
+    },
+  },
+  layers: [{ id: 'carto-base', type: 'raster', source: 'carto' }],
+};
+
+function isFiniteLatLng(lat: unknown, lng: unknown) {
+  return (
+    typeof lat === 'number' &&
+    Number.isFinite(lat) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    typeof lng === 'number' &&
+    Number.isFinite(lng) &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+function toFollowUpUrgency(store: TerritoryStorePin) {
+  if (typeof store.metrics?.followUpUrgencyScore === 'number') {
+    return store.metrics.followUpUrgencyScore;
+  }
+
+  if (!store.followUpDate) {
+    return 0;
+  }
+
+  const date = new Date(store.followUpDate);
+  if (Number.isNaN(date.getTime())) {
+    return 0;
+  }
+
+  const daysUntil = Math.ceil((date.getTime() - Date.now()) / 86_400_000);
+  return Math.max(0, 14 - daysUntil);
+}
+
+function toHeatWeight(store: TerritoryStorePin) {
+  const followUp = toFollowUpUrgency(store);
+  const interactions = store.metrics?.interactionsScore ?? (store.lastCheckIn ? 1 : 0);
+  const purchases = store.metrics?.purchasesScore ?? 0;
+  return Math.max(1, followUp + interactions * 0.8 + purchases * 0.25);
+}
+
+function removeLayerIfPresent(map: maplibregl.Map, layerId: string) {
+  if (map.getLayer(layerId)) {
+    map.removeLayer(layerId);
+  }
+}
+
+function removeSourceIfPresent(map: maplibregl.Map, sourceId: string) {
+  if (map.getSource(sourceId)) {
+    map.removeSource(sourceId);
+  }
+}
+
+export function MapLibreTerritoryMap({
+  stores,
+  selectedStopIds,
+  orderedStopIds,
+  focusedStoreId,
+  routeCoordinates,
+  pinColorMode = 'status',
+  layerMode = 'pins',
+  onSelectStore,
+  className,
+  fitPadding = 36,
+  maxFitZoom = 12,
+  defaultZoom = 10,
+}: MapLibreTerritoryMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+
+  const safeStores = useMemo(
+    () => stores.filter((store) => isFiniteLatLng(store.lat, store.lng)),
+    [stores],
+  );
+
+  const orderMap = useMemo(() => {
+    const map = new Map<string, number>();
+    orderedStopIds.forEach((id, index) => map.set(id, index + 1));
+    return map;
+  }, [orderedStopIds]);
+
+  const selectedSet = useMemo(() => new Set(selectedStopIds), [selectedStopIds]);
+
+  const storesGeoJson = useMemo(() => {
+    return {
+      type: 'FeatureCollection' as const,
+      features: safeStores.map((store) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [store.lng, store.lat] as [number, number],
+        },
+        properties: {
+          id: store.id,
+          name: store.name,
+          color: pinColorForStore(store, pinColorMode),
+          selected: selectedSet.has(store.id) ? 1 : 0,
+          focused: focusedStoreId === store.id ? 1 : 0,
+          order: orderMap.get(store.id) ?? 0,
+          weight: toHeatWeight(store),
+        },
+      })),
+    };
+  }, [safeStores, pinColorMode, selectedSet, focusedStoreId, orderMap]);
+
+  const hexGeoJson = useMemo(() => {
+    const buckets = new Map<string, { lat: number; lng: number; count: number; weight: number }>();
+
+    for (const store of safeStores) {
+      const lat = Math.round(store.lat * 55) / 55;
+      const lng = Math.round(store.lng * 55) / 55;
+      const key = `${lat}:${lng}`;
+      const current = buckets.get(key) ?? { lat, lng, count: 0, weight: 0 };
+      current.count += 1;
+      current.weight += toHeatWeight(store);
+      buckets.set(key, current);
+    }
+
+    return {
+      type: 'FeatureCollection' as const,
+      features: [...buckets.values()].map((entry) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [entry.lng, entry.lat] as [number, number],
+        },
+        properties: {
+          count: entry.count,
+          weight: entry.weight,
+        },
+      })),
+    };
+  }, [safeStores]);
+
+  const selectedGeoJson = useMemo(() => {
+    const focused = safeStores.find((store) => store.id === focusedStoreId);
+    if (!focused) {
+      return {
+        type: 'FeatureCollection' as const,
+        features: [],
+      };
+    }
+
+    return {
+      type: 'FeatureCollection' as const,
+      features: [
+        {
+          type: 'Feature' as const,
+          geometry: {
+            type: 'Point' as const,
+            coordinates: [focused.lng, focused.lat] as [number, number],
+          },
+          properties: {
+            id: focused.id,
+          },
+        },
+      ],
+    };
+  }, [safeStores, focusedStoreId]);
+
+  const routeGeoJson = useMemo(() => {
+    const coordinates = routeCoordinates.filter(
+      (coord): coord is [number, number] =>
+        Array.isArray(coord) && coord.length === 2 && isFiniteLatLng(coord[1], coord[0]),
+    );
+
+    return {
+      type: 'FeatureCollection' as const,
+      features:
+        coordinates.length > 1
+          ? [
+              {
+                type: 'Feature' as const,
+                geometry: {
+                  type: 'LineString' as const,
+                  coordinates,
+                },
+                properties: {},
+              },
+            ]
+          : [],
+    };
+  }, [routeCoordinates]);
+
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) {
+      return;
+    }
+
+    const map = new maplibregl.Map({
+      container: containerRef.current,
+      style: STYLE,
+      center: FALLBACK_CENTER,
+      zoom: defaultZoom,
+      maxPitch: 45,
+      antialias: true,
+    });
+
+    mapRef.current = map;
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-left');
+
+    const onMapClick = (event: maplibregl.MapMouseEvent) => {
+      const features = map.queryRenderedFeatures(event.point, {
+        layers: ['unclustered-points', 'clusters', 'hex-points', 'focus-ring'],
+      });
+
+      if (features.length === 0) {
+        onSelectStore(null);
+      }
+    };
+
+    const onPointClick = (event: maplibregl.MapLayerMouseEvent) => {
+      const id = event.features?.[0]?.properties?.id;
+      if (typeof id === 'string' && id.length > 0) {
+        onSelectStore(id);
+      }
+    };
+
+    const onClusterClick = (event: maplibregl.MapLayerMouseEvent) => {
+      const feature = event.features?.[0];
+      if (!feature) return;
+      const clusterId = Number(feature.properties?.cluster_id);
+      const source = map.getSource('stores') as GeoJSONSource | undefined;
+      if (!source || !Number.isFinite(clusterId)) return;
+
+      source
+        .getClusterExpansionZoom(clusterId)
+        .then((zoom) => {
+          const geometry = feature.geometry as GeoJSON.Point;
+          map.easeTo({
+            center: geometry.coordinates as [number, number],
+            zoom: Math.max(zoom, 12),
+            duration: 500,
+          });
+        })
+        .catch(() => undefined);
+    };
+
+    map.on('click', onMapClick);
+    map.on('click', 'unclustered-points', onPointClick);
+    map.on('click', 'clusters', onClusterClick);
+    map.on('click', 'hex-points', onMapClick);
+
+    return () => {
+      map.off('click', onMapClick);
+      map.off('click', 'unclustered-points', onPointClick);
+      map.off('click', 'clusters', onClusterClick);
+      map.off('click', 'hex-points', onMapClick);
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [defaultZoom, onSelectStore]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const apply = () => {
+      removeLayerIfPresent(map, 'route-shadow');
+      removeLayerIfPresent(map, 'route-main');
+      removeLayerIfPresent(map, 'focus-ring');
+      removeLayerIfPresent(map, 'order-labels');
+      removeLayerIfPresent(map, 'unclustered-points');
+      removeLayerIfPresent(map, 'cluster-count');
+      removeLayerIfPresent(map, 'clusters');
+      removeLayerIfPresent(map, 'heatmap-layer');
+      removeLayerIfPresent(map, 'hex-points');
+
+      removeSourceIfPresent(map, 'selected');
+      removeSourceIfPresent(map, 'stores');
+      removeSourceIfPresent(map, 'route');
+      removeSourceIfPresent(map, 'hex');
+
+      map.addSource('route', {
+        type: 'geojson',
+        data: routeGeoJson,
+      });
+
+      map.addLayer({
+        id: 'route-shadow',
+        type: 'line',
+        source: 'route',
+        paint: {
+          'line-color': '#0f5f9e',
+          'line-width': 10,
+          'line-opacity': 0.28,
+        },
+      });
+
+      map.addLayer({
+        id: 'route-main',
+        type: 'line',
+        source: 'route',
+        paint: {
+          'line-color': '#20a8ff',
+          'line-width': 5,
+          'line-opacity': 0.95,
+        },
+      });
+
+      if (layerMode === 'hex') {
+        map.addSource('hex', {
+          type: 'geojson',
+          data: hexGeoJson,
+        });
+
+        map.addLayer({
+          id: 'hex-points',
+          type: 'circle',
+          source: 'hex',
+          paint: {
+            'circle-color': [
+              'interpolate',
+              ['linear'],
+              ['coalesce', ['to-number', ['get', 'weight']], 0],
+              0,
+              '#a5b4fc',
+              6,
+              '#f59e0b',
+              12,
+              '#dc2626',
+            ],
+            'circle-radius': [
+              'interpolate',
+              ['linear'],
+              ['coalesce', ['to-number', ['get', 'count']], 1],
+              1,
+              10,
+              10,
+              26,
+            ],
+            'circle-opacity': 0.62,
+            'circle-stroke-width': 1,
+            'circle-stroke-color': '#ffffff',
+          },
+        });
+
+        return;
+      }
+
+      map.addSource('stores', {
+        type: 'geojson',
+        data: storesGeoJson,
+        cluster: layerMode === 'pins',
+        clusterMaxZoom: 13,
+        clusterRadius: 42,
+      });
+
+      if (layerMode === 'heatmap') {
+        map.addLayer({
+          id: 'heatmap-layer',
+          type: 'heatmap',
+          source: 'stores',
+          paint: {
+            'heatmap-weight': ['interpolate', ['linear'], ['coalesce', ['to-number', ['get', 'weight']], 1], 0, 0, 15, 1],
+            'heatmap-intensity': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 12, 1.8],
+            'heatmap-color': [
+              'interpolate',
+              ['linear'],
+              ['heatmap-density'],
+              0,
+              'rgba(33,102,172,0)',
+              0.2,
+              'rgb(103,169,207)',
+              0.4,
+              'rgb(209,229,240)',
+              0.6,
+              'rgb(253,219,199)',
+              0.8,
+              'rgb(239,138,98)',
+              1,
+              'rgb(178,24,43)',
+            ],
+            'heatmap-radius': ['interpolate', ['linear'], ['zoom'], 4, 10, 10, 30],
+            'heatmap-opacity': 0.78,
+          },
+        });
+
+        return;
+      }
+
+      map.addLayer({
+        id: 'clusters',
+        type: 'circle',
+        source: 'stores',
+        filter: ['has', 'point_count'],
+        paint: {
+          'circle-color': ['step', ['get', 'point_count'], '#8ecae6', 15, '#219ebc', 40, '#023047'],
+          'circle-radius': ['step', ['get', 'point_count'], 17, 15, 21, 40, 26],
+          'circle-opacity': 0.9,
+          'circle-stroke-width': 2,
+          'circle-stroke-color': '#ffffff',
+        },
+      });
+
+      map.addLayer({
+        id: 'cluster-count',
+        type: 'symbol',
+        source: 'stores',
+        filter: ['has', 'point_count'],
+        layout: {
+          'text-field': ['get', 'point_count_abbreviated'],
+          'text-size': 12,
+          'text-font': ['Noto Sans Regular'],
+        },
+        paint: {
+          'text-color': '#ffffff',
+        },
+      });
+
+      map.addLayer({
+        id: 'unclustered-points',
+        type: 'circle',
+        source: 'stores',
+        filter: ['!', ['has', 'point_count']],
+        paint: {
+          'circle-color': ['coalesce', ['get', 'color'], '#ef4444'],
+          'circle-radius': ['case', ['==', ['get', 'focused'], 1], 11, ['==', ['get', 'selected'], 1], 9, 6],
+          'circle-opacity': 0.95,
+          'circle-stroke-width': ['case', ['==', ['get', 'focused'], 1], 3, 2],
+          'circle-stroke-color': '#ffffff',
+        },
+      });
+
+      map.addLayer({
+        id: 'order-labels',
+        type: 'symbol',
+        source: 'stores',
+        filter: ['all', ['!', ['has', 'point_count']], ['>', ['to-number', ['get', 'order']], 0]],
+        layout: {
+          'text-field': ['to-string', ['get', 'order']],
+          'text-size': 11,
+          'text-font': ['Noto Sans Bold'],
+        },
+        paint: {
+          'text-color': '#102a43',
+          'text-halo-color': '#ffffff',
+          'text-halo-width': 1,
+        },
+      });
+
+      map.addSource('selected', {
+        type: 'geojson',
+        data: selectedGeoJson,
+      });
+
+      map.addLayer({
+        id: 'focus-ring',
+        type: 'circle',
+        source: 'selected',
+        paint: {
+          'circle-radius': 15,
+          'circle-color': 'rgba(79,142,223,0.15)',
+          'circle-stroke-color': '#4f8edf',
+          'circle-stroke-width': 2,
+        },
+      });
+    };
+
+    if (map.isStyleLoaded()) {
+      apply();
+    } else {
+      map.once('load', apply);
+    }
+  }, [storesGeoJson, routeGeoJson, selectedGeoJson, layerMode, hexGeoJson]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || layerMode !== 'pins') return;
+
+    let tick = 0;
+    const timer = window.setInterval(() => {
+      if (!map.getLayer('focus-ring')) return;
+      tick += 0.35;
+      const radius = 13 + Math.max(0, Math.sin(tick)) * 4;
+      map.setPaintProperty('focus-ring', 'circle-radius', radius);
+    }, 110);
+
+    return () => window.clearInterval(timer);
+  }, [layerMode, focusedStoreId]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const fit = () => {
+      if (safeStores.length === 0) {
+        map.easeTo({ center: FALLBACK_CENTER, zoom: 3.5, duration: 450 });
+        return;
+      }
+
+      const focused = focusedStoreId ? safeStores.find((store) => store.id === focusedStoreId) : null;
+      if (focused) {
+        map.easeTo({ center: [focused.lng, focused.lat], zoom: Math.max(map.getZoom(), 13), duration: 450 });
+        return;
+      }
+
+      const bounds = safeStores.reduce(
+        (acc, store) => acc.extend([store.lng, store.lat]),
+        new maplibregl.LngLatBounds([safeStores[0].lng, safeStores[0].lat], [safeStores[0].lng, safeStores[0].lat]),
+      );
+
+      map.fitBounds(bounds as LngLatBoundsLike, {
+        padding: fitPadding,
+        maxZoom: maxFitZoom,
+        duration: 550,
+      });
+    };
+
+    if (map.isStyleLoaded()) {
+      fit();
+    } else {
+      map.once('load', fit);
+    }
+  }, [safeStores, focusedStoreId, fitPadding, maxFitZoom]);
+
+  return <div ref={containerRef} className={cn('h-full w-full rounded-xl [filter:saturate(1.08)_contrast(1.03)]', className)} />;
+}

--- a/lib/territory/types.ts
+++ b/lib/territory/types.ts
@@ -25,6 +25,15 @@ export interface TerritoryStorePin {
   followUpDate?: string | null;
   notes?: string | null;
   lastCheckIn?: string | null;
+  geometry?: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  metrics?: {
+    interactionsScore: number;
+    purchasesScore: number;
+    followUpUrgencyScore: number;
+  };
 }
 
 export interface TerritoryStoreContact {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "leaflet": "^1.9.4",
         "leaflet.heat": "^0.2.0",
         "lucide-react": "^0.475.0",
+        "maplibre-gl": "^4.7.1",
         "next": "^15.1.6",
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
@@ -1145,6 +1146,101 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -4213,8 +4309,16 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -4240,6 +4344,23 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -4249,6 +4370,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -4274,7 +4401,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
       "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -6580,6 +6706,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7864,6 +7996,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -8002,6 +8140,12 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8042,6 +8186,44 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -8282,6 +8464,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8361,6 +8563,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/inquirer": {
       "version": "6.5.2",
@@ -9115,6 +9326,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9145,6 +9362,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -9845,6 +10071,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -9996,7 +10263,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10052,6 +10318,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -10688,6 +10960,19 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -10772,6 +11057,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10828,6 +11119,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -10992,6 +11289,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -11331,6 +11634,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -11416,6 +11728,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
@@ -12418,6 +12736,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
     "node_modules/tldts-core": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
@@ -13393,6 +13717,17 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
       }
     },
     "node_modules/webdriver-bidi-protocol": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "leaflet": "^1.9.4",
     "leaflet.heat": "^0.2.0",
     "lucide-react": "^0.475.0",
+    "maplibre-gl": "^4.7.1",
     "next": "^15.1.6",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- migrate territory map surfaces from Leaflet to MapLibre GL JS
- add visualization modes for pins, heatmap, and grid overlays
- preserve and polish key map interactions:
  - pin select/deselect with map background click clear
  - selected pin enlargement/pulse animation
  - smooth camera transitions
- update mobile territory UX with filter/presentation mode controls
- keep account/contact interaction actions wired and functional

## Out of Scope
- routing solver/back-end optimization stack
- auth migration

## Validation
- npm run typecheck
- npm run build
