### PR TITLE
Add account/contact runtime freshness contract

### DIFF
--- a/app/(main)/contacts/page.tsx
+++ b/app/(main)/contacts/page.tsx
@@ -1,8 +1,9 @@
 import { ContactsTable } from '@/components/crm/contacts-table';
-import { loadLiveNotionContacts } from '@/lib/server/notion-live-crm';
+import { DataFreshnessBanner } from '@/components/shared/data-freshness';
+import { loadAccountContactRuntime } from '@/lib/server/account-contact-runtime';
 
 export default async function ContactsPage() {
-  const rows = await loadLiveNotionContacts();
+  const runtime = await loadAccountContactRuntime();
 
   return (
     <div className="space-y-6">
@@ -10,7 +11,11 @@ export default async function ContactsPage() {
         <h1 className="text-3xl font-bold">Contacts</h1>
         <p className="text-sm text-slate-500">High-turnover contact table. Mark inactive instantly while preserving account history.</p>
       </header>
-      <ContactsTable rows={rows} />
+      <section className="grid gap-3 lg:grid-cols-2" aria-label="Contact data freshness">
+        <DataFreshnessBanner freshness={runtime.freshness.contacts} compact />
+        <DataFreshnessBanner freshness={runtime.freshness.accounts} compact />
+      </section>
+      <ContactsTable rows={runtime.contacts} />
     </div>
   );
 }

--- a/app/api/runtime/account-contact/route.ts
+++ b/app/api/runtime/account-contact/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { requireTerritoryApiAccess } from '@/lib/auth/territory-access';
+import { loadAccountContactRuntime } from '@/lib/server/account-contact-runtime';
+import type { PreferredPartnerFilter } from '@/lib/territory/preferred-partner';
+
+export const dynamic = 'force-dynamic';
+
+function readMultiParam(searchParams: URLSearchParams, key: string) {
+  return searchParams
+    .getAll(key)
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export async function GET(request: Request) {
+  const access = await requireTerritoryApiAccess();
+  if ('error' in access) {
+    return access.error;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const preferredPartnerParam = (searchParams.get('preferredPartner') ?? 'all').trim().toLowerCase();
+  const preferredPartnerFilter: PreferredPartnerFilter =
+    preferredPartnerParam === 'preferred' || preferredPartnerParam === 'not_preferred'
+      ? preferredPartnerParam
+      : 'all';
+
+  try {
+    const payload = await loadAccountContactRuntime({
+      statuses: readMultiParam(searchParams, 'status'),
+      reps: readMultiParam(searchParams, 'rep'),
+      pppStatuses: readMultiParam(searchParams, 'pppStatus'),
+      headsetConnectionStatuses: readMultiParam(searchParams, 'headsetConnectionStatus'),
+      preferredPartnerFilter,
+      referralSources: readMultiParam(searchParams, 'referralSource'),
+      includeNoReferralSource: searchParams.get('noReferralSource') === '1',
+      vendorDayStatuses: readMultiParam(searchParams, 'vendorDayStatus'),
+      query: searchParams.get('q')?.trim() ?? '',
+      refresh: searchParams.get('refresh') === '1',
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        'Cache-Control': searchParams.get('refresh') === '1'
+          ? 'private, no-store, max-age=0, must-revalidate'
+          : 'private, max-age=60, stale-while-revalidate=300',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Account/contact runtime failed to load';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/components/mobile/accounts-mobile.tsx
+++ b/components/mobile/accounts-mobile.tsx
@@ -11,6 +11,8 @@ import { MobileHeader } from '@/components/mobile/mobile-header';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
 import { NotionOptionChip } from '@/components/shared/notion-option-chip';
+import { DataFreshnessBanner } from '@/components/shared/data-freshness';
+import { buildTerritoryFreshness } from '@/lib/runtime/account-contact-contract';
 import type { PreferredPartnerFilter } from '@/lib/territory/preferred-partner';
 import { useRoutePlan } from '@/lib/territory/route-plan-client';
 import type { TerritoryStorePin, TerritoryStoresResponse } from '@/lib/territory/types';
@@ -65,6 +67,10 @@ export function AccountsMobile() {
   });
 
   const allStores = useMemo(() => storesQuery.data?.stores ?? [], [storesQuery.data?.stores]);
+  const accountFreshness = useMemo(
+    () => (storesQuery.data ? buildTerritoryFreshness(storesQuery.data.meta) : null),
+    [storesQuery.data],
+  );
   const filterOptions = storesQuery.data?.filters;
   const stores = useMemo(() => {
     const source = allStores;
@@ -232,6 +238,35 @@ export function AccountsMobile() {
             <div className="mt-3 rounded-lg border border-[#e6b3a7] bg-[#fdebe7] px-3 py-2 text-[13px] text-[#8f2410]">
               Live sync warning: {storesQuery.error instanceof Error ? storesQuery.error.message : 'Failed to refresh accounts'}
             </div>
+          ) : null}
+
+          {accountFreshness ? (
+            <DataFreshnessBanner
+              freshness={{
+                ...accountFreshness,
+                syncing: accountFreshness.syncing || storesQuery.isFetching,
+                state: storesQuery.isFetching && accountFreshness.state === 'fresh' ? 'syncing' : accountFreshness.state,
+                detail:
+                  storesQuery.isFetching && accountFreshness.state === 'fresh'
+                    ? 'Refreshing account data in the background.'
+                    : accountFreshness.detail,
+              }}
+              compact
+              className="mt-3"
+              action={
+                <button
+                  type="button"
+                  className="inline-flex h-9 items-center gap-2 rounded-lg border border-current/20 bg-white/70 px-3 text-[12px] font-semibold"
+                  onClick={() => {
+                    void storesQuery.refetch();
+                  }}
+                  disabled={storesQuery.isFetching}
+                >
+                  <RefreshCw className={storesQuery.isFetching ? 'h-3.5 w-3.5 animate-spin' : 'h-3.5 w-3.5'} />
+                  Refresh
+                </button>
+              }
+            />
           ) : null}
 
           {grouped.length === 0 ? (

--- a/components/shared/data-freshness.tsx
+++ b/components/shared/data-freshness.tsx
@@ -1,0 +1,130 @@
+import { AlertCircle, CheckCircle2, Clock3, Loader2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Badge } from '@/components/ui';
+import type { RuntimeFreshness } from '@/lib/runtime/account-contact-contract';
+import { cn } from '@/lib/utils';
+
+function formatRelativeAge(ageSeconds: number | null) {
+  if (ageSeconds === null) {
+    return 'unknown';
+  }
+
+  if (ageSeconds < 60) {
+    return 'just now';
+  }
+
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) {
+    return `${hours}h ago`;
+  }
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return 'No sync recorded';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Invalid sync time';
+  }
+
+  return date.toLocaleString();
+}
+
+function stateTone(state: RuntimeFreshness['state']) {
+  if (state === 'fresh') {
+    return {
+      icon: CheckCircle2,
+      badge: 'success' as const,
+      label: 'Fresh',
+      className: 'border-emerald-200 bg-emerald-50 text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100',
+    };
+  }
+
+  if (state === 'syncing') {
+    return {
+      icon: Loader2,
+      badge: 'warning' as const,
+      label: 'Syncing',
+      className: 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100',
+    };
+  }
+
+  if (state === 'error') {
+    return {
+      icon: AlertCircle,
+      badge: 'danger' as const,
+      label: 'Sync issue',
+      className: 'border-red-200 bg-red-50 text-red-950 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-100',
+    };
+  }
+
+  return {
+    icon: Clock3,
+    badge: 'warning' as const,
+    label: state === 'stale' ? 'Stale' : 'Unknown',
+    className: 'border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-800 dark:bg-slate-950/40 dark:text-slate-100',
+  };
+}
+
+export function DataFreshnessBadge({ freshness }: { freshness: RuntimeFreshness }) {
+  const tone = stateTone(freshness.state);
+
+  return (
+    <Badge variant={tone.badge} title={`${freshness.label}: ${freshness.detail}`}>
+      {tone.label}
+    </Badge>
+  );
+}
+
+export function DataFreshnessBanner({
+  freshness,
+  action,
+  compact = false,
+  className,
+}: {
+  freshness: RuntimeFreshness;
+  action?: ReactNode;
+  compact?: boolean;
+  className?: string;
+}) {
+  const tone = stateTone(freshness.state);
+  const Icon = tone.icon;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-xl border px-3 py-3 text-sm sm:flex-row sm:items-center sm:justify-between',
+        tone.className,
+        compact ? 'py-2' : null,
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <Icon className={cn('mt-0.5 h-4 w-4 shrink-0', freshness.state === 'syncing' ? 'animate-spin' : null)} />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-semibold">{freshness.label}</span>
+            <DataFreshnessBadge freshness={freshness} />
+            <span className="text-xs opacity-75">{formatRelativeAge(freshness.ageSeconds)}</span>
+          </div>
+          <p className="mt-1 leading-5 opacity-85">{freshness.detail}</p>
+          <p className="mt-1 text-xs opacity-70">
+            Last sync: {formatTimestamp(freshness.syncedAt)} · Records: {freshness.recordsRead.toLocaleString()}
+            {freshness.error ? ` · ${freshness.error}` : ''}
+          </p>
+        </div>
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/docs/perf/baseline.md
+++ b/docs/perf/baseline.md
@@ -1,11 +1,36 @@
 # Baseline Metrics
 
-| Route | Lighthouse Performance (mobile) | LCP (ms) | Notes |
+Date: 2026-04-28
+
+Scope: account/contact runtime contract and sync freshness visibility.
+
+## Route/Data Baseline
+
+| Route | Current data path before this PR | Freshness metadata before this PR | User-visible gap |
 | --- | --- | --- | --- |
-| /dashboard | TODO | TODO | TODO |
-| /accounts | TODO | TODO | TODO |
-| /territory | TODO | TODO | TODO |
+| `/accounts` | Client fetches `/api/territory/stores`, which reads the territory read model/cache. | `meta.syncedAt`, `meta.stale`, `meta.syncing`, `meta.syncError`, `meta.recordsRead`, `meta.lastEditedMax`. | The account list had no clear source/freshness banner, so stale or cached data looked normal unless the request hard-failed. |
+| `/contacts` | Server page called `loadLiveNotionContacts()`, which reads `NotionCacheSnapshot` for contacts and may background-refresh Notion. | Contact cache had `syncedAt`, `recordsRead`, and `lastEditedMax` internally, but callers received only rows. | The contacts page could not tell users whether contact rows were fresh, stale, syncing, or served from the last usable cache. |
+| `/api/territory/account-contacts` | Reads contacts from the same Notion contact cache, filtered by account page ID. | Contact freshness stayed internal to `notion-live-crm`. | Account detail contacts could not expose contact source freshness yet. |
+| `/api/accounts` and `/api/contacts` | Read/write local Prisma `Account` and `Contact` models. | No shared runtime freshness contract. | These routes are not clearly the same records shown in the main mobile Accounts/Contacts flows. |
+
+## Pre-PR Findings
+
+- Account and contact screens were reading different truth layers.
+- Territory account data already had useful freshness metadata, but the mobile accounts UI did not surface it.
+- Contact cache freshness existed in storage but was discarded by `loadLiveNotionContacts()`.
+- No single account/contact payload existed for future GHL/Notion identity work.
+- Local browser Lighthouse numbers were not collected in this environment because the local database/bootstrap path is still being handled separately.
+
+## Route Timing Targets For Follow-Up
+
+| Route | Target measurement |
+| --- | --- |
+| `/api/territory/stores` | P50/P95 response time, payload size, source engine, stale/syncing/error counts. |
+| `/api/runtime/account-contact` | P50/P95 response time, account count, contact count, stale source count. |
+| `/accounts` | First account list paint, search response time, detail sheet open time. |
+| `/contacts` | Server render time, rows rendered, freshness state shown. |
 
 ## Bundle Notes
 
-- TODO: add pre-optimization bundle analyzer findings.
+- Bundle analyzer was not run for this baseline slice.
+- This PR should avoid adding large client dependencies; the new freshness UI uses existing `lucide-react` and local UI primitives.

--- a/lib/runtime/account-contact-contract.ts
+++ b/lib/runtime/account-contact-contract.ts
@@ -1,0 +1,202 @@
+import type { ContactTableRow } from '@/components/crm/contacts-table';
+import type { TerritoryStoresResponse } from '@/lib/territory/types';
+
+export type RuntimeDataSource = 'notion-territory' | 'notion-contacts' | 'postgres-read-model' | 'ghl';
+
+export type RuntimeFreshnessState = 'fresh' | 'stale' | 'syncing' | 'error' | 'unknown';
+
+export interface RuntimeFreshness {
+  source: RuntimeDataSource;
+  label: string;
+  state: RuntimeFreshnessState;
+  syncedAt: string | null;
+  lastEditedAt: string | null;
+  recordsRead: number;
+  ageSeconds: number | null;
+  stale: boolean;
+  syncing: boolean;
+  error: string | null;
+  detail: string;
+}
+
+export interface RuntimeAccountSummary {
+  id: string;
+  notionPageId: string;
+  name: string;
+  status: string;
+  statusKey: string;
+  repNames: string[];
+  repEmails: string[];
+  licenseNumber: string | null;
+  city: string | null;
+  state: string | null;
+  contactCount: number;
+  lastEditedAt: string | null;
+  source: 'territory-read-model';
+}
+
+export interface RuntimeContactSummary extends ContactTableRow {
+  notionPageId: string;
+  accountPageIds: string[];
+  lastEditedAt: string | null;
+  source: 'notion-contacts-cache';
+}
+
+export interface AccountContactRuntimePayload {
+  accounts: RuntimeAccountSummary[];
+  contacts: RuntimeContactSummary[];
+  freshness: {
+    accounts: RuntimeFreshness;
+    contacts: RuntimeFreshness;
+  };
+  summary: {
+    accountCount: number;
+    contactCount: number;
+    unlinkedContactCount: number;
+    staleSourceCount: number;
+  };
+}
+
+type TerritoryFreshnessMeta = TerritoryStoresResponse['meta'];
+
+export interface ContactsFreshnessMeta {
+  syncedAt: string | null;
+  lastEditedMax: string | null;
+  recordsRead: number;
+  stale: boolean;
+  syncing: boolean;
+  syncError: string | null;
+}
+
+function secondsSince(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  return Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+}
+
+function freshnessState(input: {
+  syncedAt: string | null;
+  stale: boolean;
+  syncing: boolean;
+  error: string | null;
+}): RuntimeFreshnessState {
+  if (input.error) {
+    return 'error';
+  }
+
+  if (input.syncing) {
+    return 'syncing';
+  }
+
+  if (input.stale) {
+    return 'stale';
+  }
+
+  if (!input.syncedAt) {
+    return 'unknown';
+  }
+
+  return 'fresh';
+}
+
+export function buildTerritoryFreshness(meta: TerritoryFreshnessMeta): RuntimeFreshness {
+  const syncedAt = meta.syncedAt ?? null;
+  const error = meta.syncError ?? null;
+  const state = freshnessState({
+    syncedAt,
+    stale: meta.stale,
+    syncing: meta.syncing,
+    error,
+  });
+  const engine = meta.sourceEngine === 'postgis' ? 'Postgres read model' : 'Notion cache';
+
+  return {
+    source: meta.sourceEngine === 'postgis' ? 'postgres-read-model' : 'notion-territory',
+    label: 'Accounts',
+    state,
+    syncedAt,
+    lastEditedAt: meta.lastEditedMax ?? null,
+    recordsRead: meta.recordsRead,
+    ageSeconds: secondsSince(syncedAt),
+    stale: meta.stale,
+    syncing: meta.syncing,
+    error,
+    detail:
+      state === 'fresh'
+        ? `${engine} is current.`
+        : state === 'syncing'
+          ? `Showing ${engine.toLowerCase()} while a refresh is running.`
+          : state === 'error'
+            ? `Showing the last usable ${engine.toLowerCase()} because the latest refresh failed.`
+            : state === 'stale'
+              ? `Showing stale ${engine.toLowerCase()} data.`
+              : `${engine} has not reported a sync time yet.`,
+  };
+}
+
+export function buildContactsFreshness(meta: ContactsFreshnessMeta): RuntimeFreshness {
+  const syncedAt = meta.syncedAt ?? null;
+  const error = meta.syncError ?? null;
+  const state = freshnessState({
+    syncedAt,
+    stale: meta.stale,
+    syncing: meta.syncing,
+    error,
+  });
+
+  return {
+    source: 'notion-contacts',
+    label: 'Contacts',
+    state,
+    syncedAt,
+    lastEditedAt: meta.lastEditedMax ?? null,
+    recordsRead: meta.recordsRead,
+    ageSeconds: secondsSince(syncedAt),
+    stale: meta.stale,
+    syncing: meta.syncing,
+    error,
+    detail:
+      state === 'fresh'
+        ? 'Notion contact cache is current.'
+        : state === 'syncing'
+          ? 'Showing cached contacts while a refresh is running.'
+          : state === 'error'
+            ? 'Showing the last usable contact cache because the latest refresh failed.'
+            : state === 'stale'
+              ? 'Showing stale contact data from the Notion cache.'
+              : 'Contact cache has not reported a sync time yet.',
+  };
+}
+
+export function buildRuntimeErrorFreshness(input: {
+  source: RuntimeDataSource;
+  label: string;
+  error: unknown;
+}): RuntimeFreshness {
+  const message = input.error instanceof Error ? input.error.message : String(input.error || 'Source failed to load');
+
+  return {
+    source: input.source,
+    label: input.label,
+    state: 'error',
+    syncedAt: null,
+    lastEditedAt: null,
+    recordsRead: 0,
+    ageSeconds: null,
+    stale: true,
+    syncing: false,
+    error: message,
+    detail: `${input.label} could not load. Showing no rows from this source until the connection recovers.`,
+  };
+}
+
+export function staleSourceCount(freshness: RuntimeFreshness[]) {
+  return freshness.filter((item) => item.state === 'stale' || item.state === 'syncing' || item.state === 'error').length;
+}

--- a/lib/server/account-contact-runtime.ts
+++ b/lib/server/account-contact-runtime.ts
@@ -1,0 +1,124 @@
+import 'server-only';
+
+import {
+  type AccountContactRuntimePayload,
+  buildContactsFreshness,
+  buildRuntimeErrorFreshness,
+  buildTerritoryFreshness,
+  staleSourceCount,
+  type RuntimeAccountSummary,
+} from '@/lib/runtime/account-contact-contract';
+import { loadLiveNotionContactsWithMeta } from '@/lib/server/notion-live-crm';
+import { loadTerritoryStores } from '@/lib/server/notion-territory';
+import type { PreferredPartnerFilter } from '@/lib/territory/preferred-partner';
+import type { TerritoryStoresResponse } from '@/lib/territory/types';
+
+export interface AccountContactRuntimeInput {
+  statuses?: string[];
+  reps?: string[];
+  pppStatuses?: string[];
+  headsetConnectionStatuses?: string[];
+  preferredPartnerFilter?: PreferredPartnerFilter;
+  referralSources?: string[];
+  includeNoReferralSource?: boolean;
+  vendorDayStatuses?: string[];
+  query?: string;
+  refresh?: boolean;
+}
+
+function normalizePageId(value: string) {
+  return value.replace(/-/g, '').trim().toLowerCase();
+}
+
+function buildContactCountByAccount(contacts: AccountContactRuntimePayload['contacts']) {
+  const counts = new Map<string, number>();
+
+  for (const contact of contacts) {
+    for (const accountPageId of contact.accountPageIds) {
+      const normalizedId = normalizePageId(accountPageId);
+      if (!normalizedId) {
+        continue;
+      }
+      counts.set(normalizedId, (counts.get(normalizedId) ?? 0) + 1);
+    }
+  }
+
+  return counts;
+}
+
+function mapAccounts(
+  territory: TerritoryStoresResponse,
+  contactCountByAccount: Map<string, number>,
+): RuntimeAccountSummary[] {
+  return territory.stores.map((store) => ({
+    id: store.id,
+    notionPageId: store.notionPageId,
+    name: store.name,
+    status: store.status,
+    statusKey: store.statusKey,
+    repNames: store.repNames,
+    repEmails: store.repEmails,
+    licenseNumber: store.licenseNumber ?? null,
+    city: store.city ?? null,
+    state: store.state ?? null,
+    contactCount: contactCountByAccount.get(normalizePageId(store.notionPageId)) ?? 0,
+    lastEditedAt: store.lastEditedTime ?? null,
+    source: 'territory-read-model',
+  }));
+}
+
+export async function loadAccountContactRuntime(
+  input: AccountContactRuntimeInput = {},
+): Promise<AccountContactRuntimePayload> {
+  const [territoryResult, contactsResult] = await Promise.allSettled([
+    loadTerritoryStores({
+      statuses: input.statuses,
+      reps: input.reps,
+      pppStatuses: input.pppStatuses,
+      headsetConnectionStatuses: input.headsetConnectionStatuses,
+      preferredPartnerFilter: input.preferredPartnerFilter,
+      referralSources: input.referralSources,
+      includeNoReferralSource: input.includeNoReferralSource,
+      vendorDayStatuses: input.vendorDayStatuses,
+      query: input.query,
+      refresh: input.refresh,
+    }),
+    loadLiveNotionContactsWithMeta(),
+  ]);
+
+  const contacts = contactsResult.status === 'fulfilled' ? contactsResult.value.rows : [];
+  const contactCountByAccount = buildContactCountByAccount(contacts);
+  const accounts = territoryResult.status === 'fulfilled'
+    ? mapAccounts(territoryResult.value, contactCountByAccount)
+    : [];
+  const freshness = {
+    accounts:
+      territoryResult.status === 'fulfilled'
+        ? buildTerritoryFreshness(territoryResult.value.meta)
+        : buildRuntimeErrorFreshness({
+            source: 'notion-territory',
+            label: 'Accounts',
+            error: territoryResult.reason,
+          }),
+    contacts:
+      contactsResult.status === 'fulfilled'
+        ? buildContactsFreshness(contactsResult.value.meta)
+        : buildRuntimeErrorFreshness({
+            source: 'notion-contacts',
+            label: 'Contacts',
+            error: contactsResult.reason,
+          }),
+  };
+
+  return {
+    accounts,
+    contacts,
+    freshness,
+    summary: {
+      accountCount: accounts.length,
+      contactCount: contacts.length,
+      unlinkedContactCount: contacts.filter((contact) => contact.accountPageIds.length === 0).length,
+      staleSourceCount: staleSourceCount([freshness.accounts, freshness.contacts]),
+    },
+  };
+}

--- a/lib/server/notion-live-crm.ts
+++ b/lib/server/notion-live-crm.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import type { AccountTableRow } from '@/components/crm/accounts-table';
 import type { ContactTableRow } from '@/components/crm/contacts-table';
+import type { ContactsFreshnessMeta, RuntimeContactSummary } from '@/lib/runtime/account-contact-contract';
 import {
   getSyncTtlMinutes,
   isSnapshotStale,
@@ -15,6 +16,7 @@ const NOTION_VERSION = '2022-06-28';
 const CONTACTS_SNAPSHOT_KEY = 'crm-contacts-v1';
 const DEFAULT_CONTACTS_SYNC_TTL_MINUTES = 20;
 let contactsSyncInFlight: Promise<void> | null = null;
+let contactsLastSyncError: string | null = null;
 
 interface NotionPage {
   id: string;
@@ -31,6 +33,16 @@ type NotionQueryResponse = {
 interface CachedContactRow extends ContactTableRow {
   accountPageIds: string[];
   lastEditedTime: string;
+}
+
+interface CachedContactsResult {
+  rows: CachedContactRow[];
+  syncedAt: string | null;
+  lastEditedMax: string | null;
+  recordsRead: number;
+  stale: boolean;
+  syncing: boolean;
+  syncError: string | null;
 }
 
 export interface LiveAccountContact {
@@ -306,8 +318,11 @@ function startContactsBackgroundSync() {
   }
 
   contactsSyncInFlight = syncContactsSnapshotFromNotion()
-    .then(() => undefined)
-    .catch(() => {
+    .then(() => {
+      contactsLastSyncError = null;
+    })
+    .catch((error) => {
+      contactsLastSyncError = error instanceof Error ? error.message : 'Contacts sync failed';
       // Background refresh failures should not block reads from existing cache.
       return undefined;
     })
@@ -338,26 +353,43 @@ async function getCachedContacts(input?: { refresh?: boolean }) {
     if (input?.refresh || !snapshot || snapshot.payload.length === 0) {
       try {
         const synced = await syncContactsSnapshotFromNotion();
+        contactsLastSyncError = null;
         return {
           rows: synced.rows,
           syncedAt: new Date().toISOString(),
-        };
+          lastEditedMax: synced.lastEditedMax,
+          recordsRead: synced.recordsRead,
+          stale: false,
+          syncing: false,
+          syncError: null,
+        } satisfies CachedContactsResult;
       } catch (error) {
         if (!snapshot) {
           throw error;
         }
 
+        contactsLastSyncError = error instanceof Error ? error.message : 'Contacts sync failed';
         return {
           rows: snapshot.payload,
           syncedAt: snapshot.syncedAt,
-        };
+          lastEditedMax: snapshot.lastEditedMax,
+          recordsRead: snapshot.recordsRead,
+          stale: true,
+          syncing: false,
+          syncError: contactsLastSyncError,
+        } satisfies CachedContactsResult;
       }
     } else {
       startContactsBackgroundSync();
       return {
         rows: snapshot.payload,
         syncedAt: snapshot.syncedAt,
-      };
+        lastEditedMax: snapshot.lastEditedMax,
+        recordsRead: snapshot.recordsRead,
+        stale: true,
+        syncing: true,
+        syncError: contactsLastSyncError,
+      } satisfies CachedContactsResult;
     }
   }
 
@@ -368,6 +400,45 @@ async function getCachedContacts(input?: { refresh?: boolean }) {
   return {
     rows: snapshot.payload,
     syncedAt: snapshot.syncedAt,
+    lastEditedMax: snapshot.lastEditedMax,
+    recordsRead: snapshot.recordsRead,
+    stale: false,
+    syncing: Boolean(contactsSyncInFlight),
+    syncError: contactsLastSyncError,
+  } satisfies CachedContactsResult;
+}
+
+function toContactTableRow(row: CachedContactRow): ContactTableRow {
+  return {
+    id: row.id,
+    name: row.name,
+    roleTitle: row.roleTitle,
+    accountName: row.accountName,
+    email: row.email,
+    phone: row.phone,
+    status: row.status,
+    linkedWork: row.linkedWork,
+  };
+}
+
+function toRuntimeContact(row: CachedContactRow): RuntimeContactSummary {
+  return {
+    ...toContactTableRow(row),
+    notionPageId: row.id,
+    accountPageIds: row.accountPageIds,
+    lastEditedAt: row.lastEditedTime,
+    source: 'notion-contacts-cache',
+  };
+}
+
+function toContactsFreshnessMeta(contacts: CachedContactsResult): ContactsFreshnessMeta {
+  return {
+    syncedAt: contacts.syncedAt,
+    lastEditedMax: contacts.lastEditedMax,
+    recordsRead: contacts.recordsRead,
+    stale: contacts.stale,
+    syncing: contacts.syncing,
+    syncError: contacts.syncError,
   };
 }
 
@@ -405,17 +476,18 @@ export async function loadLiveNotionAccounts(): Promise<AccountTableRow[]> {
 
 export async function loadLiveNotionContacts(): Promise<ContactTableRow[]> {
   const contacts = await getCachedContacts();
+  return contacts.rows.map(toContactTableRow);
+}
 
-  return contacts.rows.map((row) => ({
-    id: row.id,
-    name: row.name,
-    roleTitle: row.roleTitle,
-    accountName: row.accountName,
-    email: row.email,
-    phone: row.phone,
-    status: row.status,
-    linkedWork: row.linkedWork,
-  }));
+export async function loadLiveNotionContactsWithMeta(): Promise<{
+  rows: RuntimeContactSummary[];
+  meta: ContactsFreshnessMeta;
+}> {
+  const contacts = await getCachedContacts();
+  return {
+    rows: contacts.rows.map(toRuntimeContact),
+    meta: toContactsFreshnessMeta(contacts),
+  };
 }
 
 export async function loadLiveNotionContactsForAccount(accountPageId: string): Promise<LiveAccountContact[]> {


### PR DESCRIPTION
## Summary
- add a shared account/contact runtime contract and read endpoint
- expose contact cache freshness metadata instead of discarding it
- show account and contact freshness banners on Accounts/Contacts surfaces
- record the pre-change account/contact baseline in docs/perf/baseline.md

## Verification
- npm run typecheck
- npm run lint
- npm test
- local dev smoke: /contacts compiles and returns 200, but visible page remains blocked by missing local Clerk env; /api/runtime/account-contact returns the existing 503 auth-env guard without credentials

## Notes
- no Notion, GHL, Neon, Nabis, Vercel, or production data writes performed
- unrelated local dirty files were left uncommitted