### PR TITLE
chore: add local Postgres setup documentation and scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,26 @@ NODE_ENV=development
 DEMO_MODE=false
 
 # Core app
+# REQUIRED: Base URL for the application
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+# REQUIRED: Database connection string (defaults to local docker postgres)
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/picc_crm?schema=public
 
 # Clerk
+# REQUIRED: Clerk authentication keys for the application to start
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx
 CLERK_SECRET_KEY=sk_test_xxx
+# OPTIONAL: Clerk webhook secret
 CLERK_WEBHOOK_SECRET=whsec_xxx
+# REQUIRED: Clerk routing defaults
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/territory
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/territory
 
 # Integrations
+
+# OPTIONAL: Notion API keys
 NOTION_API_KEY=secret_xxx
 NOTION_MASTER_LIST_DATABASE_ID=267a86d999988078adcac47c306ab8ba
 NOTION_MEETING_NOTES_DATA_SOURCE_ID=
@@ -24,8 +31,12 @@ NOTION_VENDOR_DAY_DATABASE_ID=
 NOTION_VENDOR_DAY_EVENTS_DATABASE_ID=
 NOTION_CONTACTS_DATABASE_ID=3bce11e6de354ca0bac75ed6114a1b0f
 NOTION_SYNC_TTL_MINUTES=20
+
+# OPTIONAL: Territory sync limits
 TERRITORY_STALE_SYNC_GEOCODE_LOOKUPS=12
 TERRITORY_FORCE_SYNC_GEOCODE_LOOKUPS=80
+
+# OPTIONAL: Google Maps and Geocoding keys (Leave blank if not testing map features)
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=
 GOOGLE_MAPS_SERVER_API_KEY=
@@ -38,10 +49,16 @@ TERRITORY_GOOGLE_MONTHLY_BUDGET_USD=100
 TERRITORY_GOOGLE_GEOCODING_USD_PER_1000=5
 TERRITORY_GOOGLE_ROUTES_COMPUTE_USD_PER_1000=5
 TERRITORY_GOOGLE_ROUTE_OPTIMIZE_USD_PER_1000=10
+
+# OPTIONAL: Cron secret for background jobs
 CRON_SECRET=replace_with_random_secret
+
+# OPTIONAL: App organization settings
 TERRITORY_ORG_ID=org_picc_prod
 TERRITORY_ALLOWED_EMAILS=@piccplatform.com
 TERRITORY_ADMIN_EMAILS=ops-admin@piccplatform.com
+
+# OPTIONAL: Google sheets and Nabis sync (Leave blank if not testing sheet imports)
 GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"your-project"}
 NABIS_MASTER_SHEET_PATH=/Users/brycejohnson/Downloads/Nabis Notion Master Sheet.xlsx
 NABIS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ prisma/
 ## Local Setup
 Prerequisite:
 - Node.js LTS (`20.x` or `22.x`). Node `25.x` is not supported for this project and can cause Next build/lint hangs.
+- Docker and Docker Compose (for local Postgres DB)
 - If you use `nvm`, run `nvm use` from the repo root (uses `.nvmrc`).
 
 1. Install deps
@@ -123,32 +124,41 @@ Prerequisite:
 npm ci
 ```
 
-2. Create env file
+2. Create env files
+For Prisma commands to work correctly locally, environment variables (like `DATABASE_URL`) must be placed in a `.env` file rather than just `.env.local`.
 ```bash
+cp .env.example .env
 cp .env.example .env.local
 ```
 
-3. Configure `.env.local`
-- Set `DATABASE_URL`
+3. Configure `.env` and `.env.local`
+- Keep `DATABASE_URL` as the default local Docker string: `postgresql://postgres:postgres@localhost:5432/picc_crm?schema=public`
 - Set Clerk keys (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`)
 - Keep/adjust `NABIS_MASTER_SHEET_PATH`
 
-4. Generate Prisma client
+4. Start local Postgres database using Docker
+```bash
+npm run db:up
+```
+
+5. Generate Prisma client
 ```bash
 npx prisma generate
 ```
 
-5. Run migrations
+6. Run migrations
 ```bash
 npx prisma migrate dev
 ```
 
-6. Seed realistic demo data
+7. Seed realistic demo data
 ```bash
 npm run prisma:seed
 ```
 
-7. Start app
+*(Note: Steps 4, 6, and 7 can also be run together using `npm run db:setup`)*
+
+8. Start app
 ```bash
 npm run dev
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "native:typecheck": "npm --prefix apps/native run typecheck",
     "sync:directus": "tsx services/directus-sync/src/index.ts",
-    "sync:odoo": "tsx services/odoo-sync/src/index.ts"
+    "sync:odoo": "tsx services/odoo-sync/src/index.ts",
+    "db:up": "docker compose up -d postgres",
+    "db:down": "docker compose down",
+    "db:setup": "npm run db:up && npx prisma migrate dev && npm run prisma:seed",
+    "db:reset": "docker compose down -v && npm run db:setup"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.0.0",


### PR DESCRIPTION
Adds a documented local Postgres/PostGIS setup via Docker to remove dependency on production resources. 
Updates `.env.example` with clear REQUIRED/OPTIONAL tags, updates `README.md` with explicit local setup commands, and adds `db:up`, `db:down`, `db:setup`, and `db:reset` npm scripts.

Validation commands:
```bash
cp .env.example .env
DATABASE_URL=postgresql://postgres:postgres@localhost:5432/picc_crm?schema=public npx prisma validate
```

---
*PR created automatically by Jules for task [9647765591650329672](https://jules.google.com/task/9647765591650329672) started by @brycejohnson1417*