### PR TITLE
feat: improve tasks and reports empty states

### DIFF
--- a/app/(main)/reports/error.tsx
+++ b/app/(main)/reports/error.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Button } from '@/components/ui';
+import { WorkspaceHero, WorkspacePage } from '@/components/layout/workspace-page';
+import { AlertTriangle } from 'lucide-react';
+import { useEffect } from 'react';
+
+export default function ReportsError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error('Reports page error:', error);
+  }, [error]);
+
+  return (
+    <WorkspacePage>
+      <WorkspaceHero
+        eyebrow="Vendor Day Reporting"
+        title="ROI, payroll, and utilization in one reporting surface."
+        description="Reporting should read like the rest of the operating system. These metrics are driven by local payroll and ROI snapshots rather than generic CRM counts."
+      />
+      <div className="flex h-[400px] flex-col items-center justify-center rounded-2xl border border-dashed border-[#e0e3ea] bg-[#fbfcfe] p-8 text-center sm:p-12">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-50 mb-4">
+          <AlertTriangle className="h-6 w-6 text-red-500" />
+        </div>
+        <h2 className="text-lg font-semibold text-[#17181c]">Failed to load reports</h2>
+        <p className="mt-2 text-sm text-[#66707d] max-w-sm">
+          There was an error generating the reporting data. Please try again or check your data sources.
+        </p>
+        <div className="mt-6">
+          <Button onClick={() => reset()} variant="outline">
+            Try again
+          </Button>
+        </div>
+      </div>
+    </WorkspacePage>
+  );
+}

--- a/app/(main)/reports/loading.tsx
+++ b/app/(main)/reports/loading.tsx
@@ -1,0 +1,75 @@
+import { Card, CardContent, CardHeader, Skeleton } from '@/components/ui';
+import { WorkspaceHero, WorkspacePage } from '@/components/layout/workspace-page';
+
+export default function ReportsLoading() {
+  return (
+    <WorkspacePage>
+      <WorkspaceHero
+        eyebrow="Vendor Day Reporting"
+        title="ROI, payroll, and utilization in one reporting surface."
+        description="Reporting should read like the rest of the operating system. These metrics are driven by local payroll and ROI snapshots rather than generic CRM counts."
+      />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="border-[#d8d9de]">
+            <CardHeader>
+              <Skeleton className="h-4 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <Card className="border-[#d8d9de]">
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-2xl" />
+            ))}
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card className="border-[#d8d9de]">
+            <CardHeader>
+              <Skeleton className="h-6 w-40" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-8 w-32" />
+              <Skeleton className="h-4 w-40" />
+            </CardContent>
+          </Card>
+
+          <Card className="border-[#d8d9de]">
+            <CardHeader>
+              <Skeleton className="h-6 w-32" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-14 w-full rounded-2xl" />
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Card className="border-[#d8d9de]">
+        <CardHeader>
+          <Skeleton className="h-6 w-56" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-2xl" />
+          ))}
+        </CardContent>
+      </Card>
+    </WorkspacePage>
+  );
+}

--- a/app/(main)/reports/page.tsx
+++ b/app/(main)/reports/page.tsx
@@ -3,6 +3,7 @@ import { WorkspaceHero, WorkspacePage } from '@/components/layout/workspace-page
 import { requireWorkspaceContext } from '@/lib/auth/workspace';
 import { getPayrollOverview } from '@/lib/server/payroll';
 import { getVendorDayReportSummary } from '@/lib/server/roi';
+import { Banknote, LineChart, Tag, UsersRound } from 'lucide-react';
 
 function currency(value: number) {
   return value.toLocaleString(undefined, {
@@ -43,7 +44,15 @@ export default async function ReportsPage() {
             <CardTitle>BA Utilization</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            {report.byWorker.length === 0 ? <p className="text-sm text-[#66707d]">No worker ROI or payroll records yet.</p> : null}
+            {report.byWorker.length === 0 ? (
+              <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[#e0e3ea] bg-[#fbfcfe] p-8 text-center">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 mb-3">
+                  <UsersRound className="h-5 w-5 text-slate-500" />
+                </div>
+                <p className="text-sm font-medium text-[#17181c]">No utilization data</p>
+                <p className="text-sm text-[#66707d] mt-1">No worker ROI or payroll records have been captured for the current reporting period.</p>
+              </div>
+            ) : null}
             {report.byWorker.map((worker) => (
               <div key={worker.label} className="rounded-2xl border border-[#e0e3ea] bg-[#fbfcfe] px-4 py-3">
                 <div className="flex items-center justify-between gap-4">
@@ -81,7 +90,13 @@ export default async function ReportsPage() {
                   </p>
                 </>
               ) : (
-                <p className="text-sm text-[#66707d]">No payroll batch yet.</p>
+                <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[#e0e3ea] bg-[#fbfcfe] p-8 text-center">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 mb-3">
+                    <Banknote className="h-5 w-5 text-slate-500" />
+                  </div>
+                  <p className="text-sm font-medium text-[#17181c]">No active payroll batch</p>
+                  <p className="text-sm text-[#66707d] mt-1">There are currently no active or pending payroll batches.</p>
+                </div>
               )}
             </CardContent>
           </Card>
@@ -91,7 +106,15 @@ export default async function ReportsPage() {
               <CardTitle>Brand Summary</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              {report.byBrand.length === 0 ? <p className="text-sm text-[#66707d]">No brand-tagged ROI records yet.</p> : null}
+              {report.byBrand.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[#e0e3ea] bg-[#fbfcfe] p-8 text-center">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 mb-3">
+                    <Tag className="h-5 w-5 text-slate-500" />
+                  </div>
+                  <p className="text-sm font-medium text-[#17181c]">No brand data</p>
+                  <p className="text-sm text-[#66707d] mt-1">No brand-tagged ROI records have been generated for this period.</p>
+                </div>
+              ) : null}
               {report.byBrand.map((brand) => (
                 <div key={brand.label} className="flex items-center justify-between rounded-2xl border border-[#e0e3ea] bg-[#fbfcfe] px-4 py-3">
                   <div>
@@ -111,7 +134,15 @@ export default async function ReportsPage() {
           <CardTitle>Recent Vendor Day ROI Snapshots</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          {report.snapshots.length === 0 ? <p className="text-sm text-[#66707d]">No completed vendor-day ROI snapshots yet.</p> : null}
+          {report.snapshots.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[#e0e3ea] bg-[#fbfcfe] p-8 text-center sm:p-12">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 mb-4">
+                <LineChart className="h-6 w-6 text-slate-500" />
+              </div>
+              <p className="text-base font-medium text-[#17181c]">No snapshots available</p>
+              <p className="text-sm text-[#66707d] mt-1 max-w-sm">No completed vendor-day ROI snapshots have been recorded yet. Check back after vendor days have been processed.</p>
+            </div>
+          ) : null}
           {report.snapshots.slice(0, 20).map((snapshot) => (
             <div key={snapshot.id} className="rounded-2xl border border-[#e0e3ea] bg-[#fbfcfe] px-4 py-3">
               <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">

--- a/app/(main)/tasks/error.tsx
+++ b/app/(main)/tasks/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui';
+import { AlertTriangle } from 'lucide-react';
+import { useEffect } from 'react';
+
+export default function TasksError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error('Tasks page error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex h-[400px] flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center sm:p-12">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-50 mb-4">
+        <AlertTriangle className="h-6 w-6 text-red-500" />
+      </div>
+      <h2 className="text-lg font-semibold text-slate-900">Failed to load tasks</h2>
+      <p className="mt-2 text-sm text-slate-500 max-w-sm">
+        There was an error retrieving the task queue. Please try again.
+      </p>
+      <div className="mt-6">
+        <Button onClick={() => reset()} variant="outline">
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/tasks/loading.tsx
+++ b/app/(main)/tasks/loading.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent, CardHeader, Skeleton } from '@/components/ui';
+
+export default function TasksLoading() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-5 w-96" />
+      </header>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-24" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-48" />
+                <Skeleton className="h-4 w-72" />
+              </div>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-16 rounded-full" />
+                <Skeleton className="h-5 w-16 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(main)/tasks/page.tsx
+++ b/app/(main)/tasks/page.tsx
@@ -1,6 +1,8 @@
 import { requireWorkspaceContext } from '@/lib/auth/workspace';
-import { Badge, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
 import { prisma } from '@/lib/db/prisma';
+import { ClipboardCheck } from 'lucide-react';
+import Link from 'next/link';
 
 export default async function TasksPage() {
   const { orgId } = await requireWorkspaceContext();
@@ -23,18 +25,38 @@ export default async function TasksPage() {
           <CardTitle>Task Queue</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
-          {tasks.map((task) => (
-            <div key={task.id} className="flex items-center justify-between rounded-lg border p-3">
-              <div>
-                <p className="font-semibold">{task.title}</p>
-                <p className="text-xs text-slate-500">{task.account.name} · {task.contact ? `${task.contact.firstName} ${task.contact.lastName}` : 'No contact'} · Due {task.dueDate ? new Date(task.dueDate).toLocaleDateString() : 'unscheduled'}</p>
+          {tasks.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center sm:p-12">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-100">
+                <ClipboardCheck className="h-6 w-6 text-slate-600" />
               </div>
-              <div className="flex items-center gap-2">
-                <Badge variant={task.priority === 'URGENT' ? 'danger' : task.priority === 'HIGH' ? 'warning' : 'secondary'}>{task.priority}</Badge>
-                <Badge variant={task.status === 'DONE' ? 'success' : 'secondary'}>{task.status}</Badge>
+              <h2 className="mt-4 text-lg font-semibold text-slate-900">You&apos;re all caught up!</h2>
+              <p className="mt-2 text-sm text-slate-500 max-w-sm">
+                There are currently no tasks in the queue for this workspace.
+                Any new assignments for sales, ops, finance, or ambassadors will appear here.
+              </p>
+              <div className="mt-6">
+                <Button asChild variant="default">
+                  <Link href="/tasks?new=1">
+                    Create new task
+                  </Link>
+                </Button>
               </div>
             </div>
-          ))}
+          ) : (
+            tasks.map((task) => (
+              <div key={task.id} className="flex items-center justify-between rounded-lg border p-3">
+                <div>
+                  <p className="font-semibold">{task.title}</p>
+                  <p className="text-xs text-slate-500">{task.account.name} · {task.contact ? `${task.contact.firstName} ${task.contact.lastName}` : 'No contact'} · Due {task.dueDate ? new Date(task.dueDate).toLocaleDateString() : 'unscheduled'}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={task.priority === 'URGENT' ? 'danger' : task.priority === 'HIGH' ? 'warning' : 'secondary'}>{task.priority}</Badge>
+                  <Badge variant={task.status === 'DONE' ? 'success' : 'secondary'}>{task.status}</Badge>
+                </div>
+              </div>
+            ))
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
This PR addresses the UI task to improve production empty states for the Tasks and Reports pages. 

Changes include:
- Tasks page: Added a comprehensive empty state when no tasks are present, utilizing `lucide-react` icons and providing context and a "next action" link (`/tasks?new=1`).
- Reports page: Enhanced the `BA Utilization`, `Current Payroll Batch`, `Brand Summary`, and `Recent Vendor Day ROI Snapshots` panels with explicit empty states containing relevant icons and contextual messaging explaining why data is absent.
- Both routes: Implemented `loading.tsx` using `Skeleton` components matching the layout structure, and `error.tsx` using standard error boundary components.

These changes make the screens feel like fully operational surfaces rather than abandoned placeholders. The layout relies entirely on existing `shadcn/ui` components and Tailwind utility classes.

---
*PR created automatically by Jules for task [17171027943834179669](https://jules.google.com/task/17171027943834179669) started by @brycejohnson1417*