### PR TITLE
[codex] Add anti-slop issue and PR scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -46,6 +46,27 @@ body:
         - [ ] ...
     validations:
       required: true
+  - type: textarea
+    id: owned-paths
+    attributes:
+      label: Owned Path Globs
+      description: Files or directories this issue expects to own. Use globs such as `lib/server/nabis-*` or `components/dashboard/**`.
+      placeholder: |
+        -
+    validations:
+      required: true
+  - type: textarea
+    id: coordination
+    attributes:
+      label: Dependencies / Parallel Safety
+      description: List blocked-by issues, issues this blocks, expected `parallel:*` label, and whether this is fast lane or approval lane.
+      placeholder: |
+        Blocked by:
+        Blocks:
+        Parallel label:
+        Lane:
+    validations:
+      required: true
   - type: dropdown
     id: priority
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,92 @@
+name: Bug
+description: Track a broken behavior with clear reproduction and validation.
+title: "fix(scope): "
+labels: ["bug", "type:bug", "status:needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is broken, who sees it, and why it matters?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Exact steps, URL, role, account, command, or data needed to reproduce.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Expected ...
+        4. Actual ...
+    validations:
+      required: true
+  - type: textarea
+    id: intended-outcome
+    attributes:
+      label: Intended Outcome
+      description: What should be true when this is fixed?
+    validations:
+      required: true
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-Goals
+      description: What should not be bundled into this fix?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Testable checklist for review.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:critical
+        - priority:high
+        - priority:medium
+        - priority:low
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - area:frontend
+        - area:backend
+        - area:data
+        - area:ci
+        - area:infra
+    validations:
+      required: true
+  - type: checkboxes
+    id: review-flags
+    attributes:
+      label: Review Flags
+      options:
+        - label: Add `needs-prod-proof` if the fix makes claims about production data, sync state, customer-visible totals, or live integration behavior.
+        - label: Add `agent-generated` to PRs opened by Codex, Claude, Cursor, or another agent.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Test / Verification Expectations
+      description: Unit, integration, Playwright, browser, production read-only proof, or explicit TDD exception.
+    validations:
+      required: true
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture / Data Impact
+      description: Boundaries touched, external systems involved, schema/data risks, rollback notes.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Production safety rule
+    url: https://github.com/bryce-picc/Picc-web-app/blob/main/AGENTS.md
+    about: Review repo operating rules before requesting production writes or schema changes.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -40,6 +40,27 @@ body:
         - [ ] ...
     validations:
       required: true
+  - type: textarea
+    id: owned-paths
+    attributes:
+      label: Owned Path Globs
+      description: Files or directories this issue expects to own. Use globs such as `app/(main)/dashboard/**` or `lib/dashboard/**`.
+      placeholder: |
+        -
+    validations:
+      required: true
+  - type: textarea
+    id: coordination
+    attributes:
+      label: Dependencies / Parallel Safety
+      description: List blocked-by issues, issues this blocks, expected `parallel:*` label, and whether this is fast lane or approval lane.
+      placeholder: |
+        Blocked by:
+        Blocks:
+        Parallel label:
+        Lane:
+    validations:
+      required: true
   - type: dropdown
     id: priority
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,86 @@
+name: Feature
+description: Define a user-facing capability before implementation.
+title: "feat(scope): "
+labels: ["enhancement", "type:feature", "status:needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Opportunity
+      description: What user workflow or business need does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: intended-outcome
+    attributes:
+      label: Intended Outcome
+      description: What should be possible directly from the polished UI when this is done?
+    validations:
+      required: true
+  - type: textarea
+    id: user-flow
+    attributes:
+      label: User Flow
+      description: Describe the complete browser workflow, including settings, loading, error, save/cancel, and success states.
+    validations:
+      required: true
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-Goals
+      description: What tempting work is explicitly out of scope?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:critical
+        - priority:high
+        - priority:medium
+        - priority:low
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - area:frontend
+        - area:backend
+        - area:data
+        - area:ci
+        - area:infra
+    validations:
+      required: true
+  - type: checkboxes
+    id: review-flags
+    attributes:
+      label: Review Flags
+      options:
+        - label: Add `needs-prod-proof` if the feature depends on production data, sync state, customer-visible totals, or live integration behavior.
+        - label: Add `agent-generated` to PRs opened by Codex, Claude, Cursor, or another agent.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Test / Verification Expectations
+      description: Include browser/Playwright expectations for UI work and unit/integration expectations for logic.
+    validations:
+      required: true
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture / Integration Impact
+      description: Data models, external systems, env vars, permissions, and rollback implications.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -33,6 +33,27 @@ body:
         - [ ] ...
     validations:
       required: true
+  - type: textarea
+    id: owned-paths
+    attributes:
+      label: Owned Path Globs
+      description: Files or directories this task expects to own. Use globs such as `.github/**` or `AGENTS.md`.
+      placeholder: |
+        -
+    validations:
+      required: true
+  - type: textarea
+    id: coordination
+    attributes:
+      label: Dependencies / Parallel Safety
+      description: List blocked-by issues, issues this blocks, expected `parallel:*` label, and whether this is fast lane or approval lane.
+      placeholder: |
+        Blocked by:
+        Blocks:
+        Parallel label:
+        Lane:
+    validations:
+      required: true
   - type: dropdown
     id: priority
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,72 @@
+name: Task
+description: Track bounded maintenance, docs, CI, sync, or operational work.
+title: "chore(scope): "
+labels: ["type:task", "status:needs-triage"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this task need to happen now?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What exact files, modules, systems, or docs are in scope?
+    validations:
+      required: true
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-Goals
+      description: What should not be bundled into this task?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:critical
+        - priority:high
+        - priority:medium
+        - priority:low
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - area:frontend
+        - area:backend
+        - area:data
+        - area:ci
+        - area:infra
+    validations:
+      required: true
+  - type: checkboxes
+    id: review-flags
+    attributes:
+      label: Review Flags
+      options:
+        - label: Add `needs-prod-proof` if the task makes claims about production data, sync state, customer-visible totals, or live integration behavior.
+        - label: Add `agent-generated` to PRs opened by Codex, Claude, Cursor, or another agent.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Commands, review steps, screenshots, read-only production proof, or documented exception.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,12 +14,24 @@ Explain the user or operational problem this PR solves. Include the root cause f
 - Files changed:
 - If this PR changes more than 10 files, explain why:
 
+## Coordination
+
+- Owned path globs:
+- Open PRs checked for overlap:
+- Blocked by:
+- Blocks:
+- Parallel label: `parallel:ok` / `parallel:blocked` / `parallel:exclusive`
+- Lane: fast lane / approval lane
+- Approval-lane reason, if any:
+
 ## Labels And Review Flags
 
 - [ ] PR has the right `type:*`, `priority:*`, `area:*`, and status labels
 - [ ] PR has `agent-generated` if opened or substantially authored by an agent
 - [ ] PR has `needs-prod-proof` if it discusses production data, sync state, customer-visible totals, or live integration behavior
+- [ ] PR has the right `parallel:*` label and `meta:protocol-change` when it changes repo rules
 - [ ] Title and commit use a conventional prefix (`fix:`, `feat:`, `chore:`, `docs:`, `test:`, or `refactor:`)
+- [ ] Draft PR was opened at claim time before non-test source edits
 
 ## Validation
 
@@ -38,6 +50,7 @@ Add screenshots, video, or a clear note that this PR has no visual/browser surfa
 ## Production Proof
 
 If this PR makes claims about production data or behavior, include the exact read-only verification performed. Do not paste secrets or connection strings.
+If production verification fails after merge, rollback first, open a follow-up issue, and comment here with the follow-up link.
 
 ## Risk And Rollback
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Summary
+
+- Closes #
+- 
+
+## Why
+
+Explain the user or operational problem this PR solves. Include the root cause for fixes.
+
+## Scope
+
+- In scope:
+- Out of scope:
+- Files changed:
+- If this PR changes more than 10 files, explain why:
+
+## Labels And Review Flags
+
+- [ ] PR has the right `type:*`, `priority:*`, `area:*`, and status labels
+- [ ] PR has `agent-generated` if opened or substantially authored by an agent
+- [ ] PR has `needs-prod-proof` if it discusses production data, sync state, customer-visible totals, or live integration behavior
+- [ ] Title and commit use a conventional prefix (`fix:`, `feat:`, `chore:`, `docs:`, `test:`, or `refactor:`)
+
+## Validation
+
+- [ ] `npm test`
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] Browser/UI proof attached when UI behavior changed
+- [ ] Read-only production proof included when production data/state is discussed
+- [ ] `SESSION.md` describes current scope, out-of-scope items, and constraints
+
+## Screenshots / Browser Proof
+
+Add screenshots, video, or a clear note that this PR has no visual/browser surface.
+
+## Production Proof
+
+If this PR makes claims about production data or behavior, include the exact read-only verification performed. Do not paste secrets or connection strings.
+
+## Risk And Rollback
+
+- Risk:
+- Rollback:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm test
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the canonical source of truth for the live PICC app.
 
 ## Canonical Context
 
-- GitHub repo: `https://github.com/bryce-picc/Picc-web-app.git`
+- GitHub repo: `https://github.com/brycejohnson1417/Picc-web-app.git`
 - Canonical branch: `main`
 - Production app: `https://piccnewyork.org`
 - Main production route to verify: `https://piccnewyork.org/territory`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Before implementation:
 4. Identify the validation plan before editing.
 5. For behavior changes, add or update the failing test first unless the PR explains why TDD is not practical.
 6. Create or update `SESSION.md` with the current session scope, out-of-scope items, and constraints before substantial agent work.
+7. Claim the issue before non-test edits by setting `status:in-progress`, creating a feature branch, opening a draft PR immediately, and listing owned path globs in the issue or PR.
+8. Check currently open PRs for overlapping owned path globs and document which PRs were checked. If globs overlap, the later PR blocks or rebases; the first PR to land wins.
 
 During implementation:
 
@@ -69,6 +71,11 @@ During implementation:
 - Do not silently mix refactors with bug fixes.
 - Put business logic in server/domain modules and keep UI components thin.
 - Keep Notion, Nabis, GHL, Neon, Supabase, Vercel, and other external systems behind explicit boundaries.
+- Use `parallel:ok` only when owned path globs do not overlap active PRs.
+- Use `parallel:blocked` when another issue must land first.
+- Use `parallel:exclusive` for protocol, CI, branch protection, schema, sync architecture, production data, or other shared-resource work.
+- Use `meta:protocol-change` for changes to AGENTS, issue templates, PR templates, CI, branch protection docs, or repo workflow rules.
+- Stale draft or in-progress claims are releasable if there are no commits or comments for 24 hours.
 
 Before PR:
 
@@ -79,6 +86,13 @@ Before PR:
 - Include read-only production proof for production data claims.
 - List remaining risk honestly.
 
+Fast lane / approval lane:
+
+- Fast-lane PRs may be merged by an agent when scoped, labeled, green, and protected by branch rules. Examples: frontend polish, copy/UI improvements, scoped bug fixes, tests, docs, templates, and non-destructive backend fixes.
+- Approval-lane PRs must pause for explicit user approval before merge. Examples: production data writes/backfills, schema migrations, auth/RLS/access-control changes, secrets/env vars, payment logic, destructive deletes, and broad refactors.
+- Approval mechanism: post a PR comment exactly in this form: `@bryce approval requested: <one-sentence reason>`. Do not merge until the user replies `approved` on that PR/comment.
+- Broad refactor threshold: approval lane is required when a PR touches more than 3 distinct modules in `lib/server/**` or `lib/shared/**`, or exceeds 200 net changed lines.
+
 Production data rule:
 
 - Local `.env.local` is not production proof.
@@ -86,3 +100,9 @@ Production data rule:
 - Pull production env only into a temporary ignored file, report counts/timestamps/status only, and delete it immediately.
 - Do not print secrets or connection strings.
 - Do not perform production writes, schema changes, or destructive operations without explicit user approval.
+- For production backfills, CI must include clearly named tests for `lease-refusal`, `stale-recovery`, `429-backoff`, and `batch-cutoff` before any production run is considered safe.
+
+Production verification and rollback:
+
+- After merge, verify production behavior and comment on the PR with deployed URL, tested behavior, screenshots/browser proof when UI changed, and remaining risk.
+- If production verification fails, rollback first using the previous Vercel deployment, open a follow-up issue with failure details, comment on the original PR with the follow-up link, and debug from the clean baseline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,5 +44,45 @@ This repository is the canonical source of truth for the live PICC app.
 
 - Run `npm run typecheck`
 - Run `npm run lint`
+- Run `npm test`
 - Run `npm run build`
 - Prefer additive fixes against current behavior rather than architecture rewrites
+
+## Anti-Slop Delivery Contract
+
+Every meaningful code change must be traceable, reviewable, and revertable.
+
+Before implementation:
+
+1. Link the GitHub issue. If none exists, create one before editing code.
+2. Work on a feature branch, not `main`.
+3. Write down scope and out-of-scope items.
+4. Identify the validation plan before editing.
+5. For behavior changes, add or update the failing test first unless the PR explains why TDD is not practical.
+6. Create or update `SESSION.md` with the current session scope, out-of-scope items, and constraints before substantial agent work.
+
+During implementation:
+
+- Keep one concern per PR.
+- Keep production triage surgical.
+- Keep UI features fully usable from the browser.
+- Do not silently mix refactors with bug fixes.
+- Put business logic in server/domain modules and keep UI components thin.
+- Keep Notion, Nabis, GHL, Neon, Supabase, Vercel, and other external systems behind explicit boundaries.
+
+Before PR:
+
+- Self-review the diff.
+- Keep the PR at 10 changed files or fewer whenever possible. If it must exceed 10 files, explain why in the PR body.
+- Run the repo validation commands.
+- Include screenshots or browser proof for UI changes.
+- Include read-only production proof for production data claims.
+- List remaining risk honestly.
+
+Production data rule:
+
+- Local `.env.local` is not production proof.
+- Production facts require a safe read-only production verification path.
+- Pull production env only into a temporary ignored file, report counts/timestamps/status only, and delete it immediately.
+- Do not print secrets or connection strings.
+- Do not perform production writes, schema changes, or destructive operations without explicit user approval.

--- a/AI_HANDOFF.md
+++ b/AI_HANDOFF.md
@@ -4,8 +4,8 @@ Use this file as the canonical handoff context for any other AI working on this 
 
 ## Canonical Project
 
-- Local repo path: `/Users/brycejohnson/Documents/New project/Picc-web-app`
-- GitHub repo: `https://github.com/bryce-picc/Picc-web-app.git`
+- Local repo path: `/Users/brycejohnson/Code/PICC-Web-App`
+- GitHub repo: `https://github.com/brycejohnson1417/Picc-web-app.git`
 - Canonical branch: `main`
 - Current canonical snapshot commit: `cdbe07389dce9465666def8099335bc6b523c8c2`
 
@@ -77,4 +77,4 @@ Use this file as the canonical handoff context for any other AI working on this 
 
 ## Short Prompt To Give Another AI
 
-Work only in `/Users/brycejohnson/Documents/New project/Picc-web-app`, which is the canonical repo for the live PICC app. Use `main` in `https://github.com/bryce-picc/Picc-web-app.git`. The canonical production deployment is `https://piccnewyork.org`, backed by the Vercel project `picc-push` (`prj_zKro1cfUOP9D2MTh0ZahYDREcRUA`). Do not use legacy repos, old Vercel projects, old map providers, or rebuild a separate app surface. Keep Google Maps, the mobile-first PWA shell, Clerk Google-only auth, comment-first check-ins, and Dispensary Master List vendor-day properties as the current baseline.
+Work only in `/Users/brycejohnson/Code/PICC-Web-App`, which is the canonical repo for the live PICC app. Use `main` in `https://github.com/brycejohnson1417/Picc-web-app.git`. The canonical production deployment is `https://piccnewyork.org`, backed by the Vercel project `picc-push` (`prj_zKro1cfUOP9D2MTh0ZahYDREcRUA`). Do not use legacy repos, old Vercel projects, old map providers, or rebuild a separate app surface. Keep Google Maps, the mobile-first PWA shell, Clerk Google-only auth, comment-first check-ins, and Dispensary Master List vendor-day properties as the current baseline.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ npm run db:local:studio
 All mutating endpoints are guarded by org scope + RBAC and write to `ActivityLog` for account-level timeline integrity.
 
 ## Deployment (Vercel)
-1. Push repo to GitHub (`bryce-picc/Picc-web-app`).
+1. Push repo to GitHub (`brycejohnson1417/Picc-web-app`).
 2. Import project in Vercel.
 3. Set all environment variables from `.env.example`.
 4. Add Postgres connection string (`DATABASE_URL`).

--- a/SESSION.md
+++ b/SESSION.md
@@ -4,6 +4,7 @@
 - Add GitHub issue templates for bugs, features, and tasks.
 - Add a pull request template that requires issue linkage, scope, validation, risk, and production proof.
 - Add the agent/prod-proof/type/priority/area label contract that future issues and PRs will use.
+- Add the fast-lane/approval-lane, parallel-label, owned-glob, stale-claim, and production rollback rules.
 - Add `npm test` to CI so tests are part of the merge gate.
 
 # Out Of Scope
@@ -12,6 +13,7 @@
 - Do not change application runtime behavior.
 - Do not modify production data, schemas, Vercel settings, or GitHub branch protection from this PR.
 - Do not add broad architecture rewrites, Playwright suites, or secret-scanning workflows until tracked in their own issues.
+- Do not implement Nabis lease/backfill/dashboard work in this PR.
 
 # Constraints
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,0 +1,21 @@
+# Current Session
+
+- Install the anti-slop operating contract for this repo.
+- Add GitHub issue templates for bugs, features, and tasks.
+- Add a pull request template that requires issue linkage, scope, validation, risk, and production proof.
+- Add the agent/prod-proof/type/priority/area label contract that future issues and PRs will use.
+- Add `npm test` to CI so tests are part of the merge gate.
+
+# Out Of Scope
+
+- Do not implement Nabis sync/dashboard issues #41-#45 in this PR.
+- Do not change application runtime behavior.
+- Do not modify production data, schemas, Vercel settings, or GitHub branch protection from this PR.
+- Do not add broad architecture rewrites, Playwright suites, or secret-scanning workflows until tracked in their own issues.
+
+# Constraints
+
+- Keep this as a repo-governance slice tied to issue #47.
+- Keep PR size near the 10-file limit.
+- Use issue #47 for the repo-specific rollout and keep PR #46 focused on PPP cached Nabis lines.
+- Branch protection and org-default `.github` setup require separate admin verification.


### PR DESCRIPTION
## Summary
- Adds the repo-level anti-slop delivery contract to `AGENTS.md`.
- Adds GitHub issue templates for bugs, features, and tasks.
- Adds a PR template that forces scope, why, labels, coordination, validation, browser proof, production proof, and rollback notes.
- Adds `npm test` to the existing PR CI gate before lint, typecheck, and build.
- Adds `SESSION.md` for this work slice.
- Creates and applies the repo label set: `type:*`, `priority:*`, `status:*`, `area:*`, `parallel:*`, `agent-generated`, `needs-prod-proof`, `meta:protocol-change`, `tech-debt`, and `security`.
- Adds the final fast-lane/approval-lane, owned-glob, stale-claim, overlap-check, and production rollback rules.

## Why
This is the first concrete slice of the cross-repo anti-slop operating system requested in issue #47. The goal is to make future agent work issue-scoped, PR-gated, validated, labeled, parallel-safe, and easier to review without relying on chat context.

Refs #47. Transfer verification evidence: https://github.com/brycejohnson1417/Picc-web-app/issues/47#issuecomment-4401496363

## Scope
Changed files:
- `.github/ISSUE_TEMPLATE/bug.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/ISSUE_TEMPLATE/feature.yml`
- `.github/ISSUE_TEMPLATE/task.yml`
- `.github/pull_request_template.md`
- `.github/workflows/ci.yml`
- `AGENTS.md`
- `AI_HANDOFF.md`
- `README.md`
- `SESSION.md`

Coordination:
- Owned path globs: `.github/**`, `AGENTS.md`, `README.md`, `AI_HANDOFF.md`, `SESSION.md`
- Open PRs checked for overlap: #46; no blocking overlap because #46 owns Nabis/PPP server files and tests.
- Parallel label: `parallel:exclusive`
- Lane: fast lane, docs/templates/CI governance only

Out of scope:
- Product/runtime fixes from #41-#45.
- App runtime behavior changes.
- Production data writes, schema changes, or Vercel settings changes.
- TypeScript strictness changes, Playwright E2E, reusable skills/rules/packages, or app architecture rewrites.

## Validation
- `git diff --check` passed.
- `npm test` passed: 5 files, 43 tests.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run build` passed.

Note: local install previously required `npm ci`; it completed with an `EBADENGINE` warning because this machine was running Node `v25.4.0` while `package.json` requires `>=20 <25`.

## Risk / Rollback
Low runtime risk. This changes repo process files, labels, docs, and CI only; the only executable-path change is adding the existing `npm test` script to CI. Rollback is reverting this PR and deleting the added labels if the workflow needs to be redesigned.