### PR TITLE
[codex] Speed up protocol CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: ci
 on:
   pull_request:
   push:
-    branches: [main, codex/**]
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   web-checks:


### PR DESCRIPTION
## Summary
- Removes duplicate full CI runs for feature-branch pushes by keeping CI on `pull_request` and `main` pushes only.
- Adds GitHub Actions concurrency cancellation so stale runs stop when a newer commit arrives.

## Linked Issue
Closes #52

## Scope
- In scope: `.github/workflows/ci.yml`
- Out of scope: app code, production behavior, required check weakening

## Protocol
- Lane: fast lane
- Approval reason, if approval lane: n/a
- Owned path globs: `.github/workflows/**`
- Open PR overlap check: no overlapping open PICC PRs on this path when claimed.

## Validation
- `git diff --check`
- GitHub PR checks

## Remaining Risk
- Required checks keep their names, so branch protection should continue to work.
