### PR TITLE
[codex] Add historical Nabis backfill

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,23 +1,30 @@
 # Current Session
 
-- Install the anti-slop operating contract for this repo.
-- Add GitHub issue templates for bugs, features, and tasks.
-- Add a pull request template that requires issue linkage, scope, validation, risk, and production proof.
-- Add the agent/prod-proof/type/priority/area label contract that future issues and PRs will use.
-- Add the fast-lane/approval-lane, parallel-label, owned-glob, stale-claim, and production rollback rules.
-- Add `npm test` to CI so tests are part of the merge gate.
+- Issue: https://github.com/brycejohnson1417/Picc-web-app/issues/43
+- Add an intentional historical Nabis backfill path from `2025-01-01`.
+- Reuse the existing Nabis sync lease, rate-limit backoff, sync run, and checkpoint architecture.
+- Populate cached `NabisOrder` and `NabisOrderLine` rows through the same parser/upsert path as normal order sync.
+- Surface backfill readiness/progress metadata through the existing admin sync status/control UI.
 
 # Out Of Scope
 
-- Do not implement Nabis sync/dashboard issues #41-#45 in this PR.
-- Do not change application runtime behavior.
-- Do not modify production data, schemas, Vercel settings, or GitHub branch protection from this PR.
-- Do not add broad architecture rewrites, Playwright suites, or secret-scanning workflows until tracked in their own issues.
-- Do not implement Nabis lease/backfill/dashboard work in this PR.
+- Do not rebuild the historical dashboard in this PR; that remains issue #45.
+- Do not change schemas unless the existing checkpoint/run metadata model is insufficient.
+- Do not mirror Nabis retailers into Notion CRM from this backfill.
+- Do not run production writes until the PR is merged, CI is green, and the approved production backfill command/path is used.
 
 # Constraints
 
-- Keep this as a repo-governance slice tied to issue #47.
-- Keep PR size near the 10-file limit.
-- Use issue #47 for the repo-specific rollout and keep PR #46 focused on PPP cached Nabis lines.
-- Branch protection and org-default `.github` setup require separate admin verification.
+- Branch: `codex/43-historical-nabis-backfill`.
+- Owned path globs: `lib/server/nabis-sync.ts`, `lib/server/nabis-sync.test.ts`, `lib/server/nabis-sync-status.ts`, `app/api/sync/run/route.ts`, `components/settings/nabis-sync-admin-panel.tsx`, `SESSION.md`.
+- Open PR overlap check: `gh pr list` returned no open Picc-web-app PRs at claim time.
+- Required named test coverage: `lease-refusal`, `stale-recovery`, `429-backoff`, and `batch-cutoff`.
+- Production data writes/backfill execution are approval-lane; the user has pre-approved the historical data backfill only after safeguards are merged and verified.
+
+# Test Plan
+
+- RED first: add a `batch-cutoff` unit test for historical cutoff handling before implementation.
+- Run `npm test`.
+- Run `npm run typecheck`.
+- Run `npm run lint`.
+- Run `npm run build`.

--- a/app/api/sync/run/route.ts
+++ b/app/api/sync/run/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { guard } from '@/lib/auth/api-guard';
 import { prisma } from '@/lib/db/prisma';
-import { NabisSyncLeaseError, syncNabisRetailersAndOrders, syncNabisRetailersWithOptions } from '@/lib/server/nabis-sync';
+import { NabisSyncLeaseError, syncNabisOrders, syncNabisRetailersAndOrders, syncNabisRetailersWithOptions } from '@/lib/server/nabis-sync';
 
 export async function POST(req: Request) {
   const ctx = await guard(['ADMIN', 'OPS_TEAM', 'FINANCE']);
@@ -14,8 +14,11 @@ export async function POST(req: Request) {
     email: ctx.email,
   };
 
-  if (['all', 'nabis', 'nabis-orders', 'nabis-retailers'].includes(syncModule)) {
+  if (['all', 'nabis', 'nabis-orders', 'nabis-retailers', 'nabis-historical-backfill'].includes(syncModule)) {
     const run = async () => {
+      if (syncModule === 'nabis-historical-backfill') {
+        return syncNabisOrders(ctx.orgId, actor, { historicalBackfill: true, historicalStartDate: '2025-01-01T00:00:00.000Z' });
+      }
       if (syncModule === 'nabis-orders') {
         return syncNabisRetailersAndOrders(ctx.orgId, actor, { reconciliation: false, syncCrm: false });
       }

--- a/app/api/sync/run/route.ts
+++ b/app/api/sync/run/route.ts
@@ -17,7 +17,11 @@ export async function POST(req: Request) {
   if (['all', 'nabis', 'nabis-orders', 'nabis-retailers', 'nabis-historical-backfill'].includes(syncModule)) {
     const run = async () => {
       if (syncModule === 'nabis-historical-backfill') {
-        return syncNabisOrders(ctx.orgId, actor, { historicalBackfill: true, historicalStartDate: '2025-01-01T00:00:00.000Z' });
+        return syncNabisOrders(ctx.orgId, actor, {
+          historicalBackfill: true,
+          historicalStartDate: '2025-01-01T00:00:00.000Z',
+          resetHistoricalBackfill: body.reset === true,
+        });
       }
       if (syncModule === 'nabis-orders') {
         return syncNabisRetailersAndOrders(ctx.orgId, actor, { reconciliation: false, syncCrm: false });

--- a/components/settings/nabis-sync-admin-panel.tsx
+++ b/components/settings/nabis-sync-admin-panel.tsx
@@ -34,6 +34,10 @@ type SyncModule = {
   historicalBackfill: boolean;
   cutoffDate: string | null;
   cutoffReached: boolean;
+  nextPage: number | null;
+  hasMore: boolean;
+  skipped: boolean;
+  skipReason: string | null;
   earliestOrderCreatedAt: string | null;
   latestOrderCreatedAt: string | null;
 };
@@ -242,8 +246,10 @@ export function NabisSyncAdminPanel() {
                   <div className="mt-3 rounded-xl bg-white px-3 py-2 text-[12px] text-[#5c6674]">
                     <p>Cutoff: {formatDateTime(module.cutoffDate, 'not recorded')}</p>
                     <p>Pages scanned: {formatNumber(module.stats.pagesScanned)}</p>
+                    <p>Next page: {module.nextPage ?? 'complete'}</p>
                     <p>Coverage: {formatDateRange(module.earliestOrderCreatedAt, module.latestOrderCreatedAt)}</p>
-                    <p>Cutoff reached: {module.cutoffReached ? 'yes' : 'not yet'}</p>
+                    <p>{module.cutoffReached ? 'Cutoff reached' : module.hasMore ? 'More batches available' : 'Batch complete'}</p>
+                    {module.skipped && module.skipReason ? <p>{module.skipReason}</p> : null}
                   </div>
                 ) : null}
               </div>

--- a/components/settings/nabis-sync-admin-panel.tsx
+++ b/components/settings/nabis-sync-admin-panel.tsx
@@ -29,7 +29,13 @@ type SyncModule = {
     retailers: number | null;
     lineItems: number | null;
     metricRows: number | null;
+    pagesScanned: number | null;
   };
+  historicalBackfill: boolean;
+  cutoffDate: string | null;
+  cutoffReached: boolean;
+  earliestOrderCreatedAt: string | null;
+  latestOrderCreatedAt: string | null;
 };
 
 type SyncRun = {
@@ -69,7 +75,7 @@ type NabisSyncStatusResponse = {
   controls: {
     recentOrders: { enabled: boolean; module: string; label: string };
     retailers: { enabled: boolean; module: string; label: string };
-    historicalBackfill: { enabled: boolean; module: string; label: string; disabledReason: string };
+    historicalBackfill: { enabled: boolean; module: string; label: string; description: string };
   };
 };
 
@@ -77,6 +83,7 @@ const moduleLabels: Record<string, string> = {
   orders: 'Recent order sync',
   retailers: 'Retailer sync',
   orders_reconcile: 'Historical reconciliation',
+  orders_historical_backfill: 'Historical backfill',
   nabis_global_sync_lease: 'Global sync lease',
 };
 
@@ -110,7 +117,7 @@ export function NabisSyncAdminPanel() {
 
   const modules = useMemo(() => {
     const source = status?.modules ?? [];
-    return ['orders', 'retailers', 'orders_reconcile', 'nabis_global_sync_lease']
+    return ['orders', 'retailers', 'orders_reconcile', 'orders_historical_backfill', 'nabis_global_sync_lease']
       .map((module) => source.find((entry) => entry.module === module))
       .filter((entry): entry is SyncModule => Boolean(entry));
   }, [status?.modules]);
@@ -231,6 +238,14 @@ export function NabisSyncAdminPanel() {
                     <p>Expires: {formatDateTime(module.leaseExpiresAt, 'not active')}</p>
                   </div>
                 ) : null}
+                {module.historicalBackfill ? (
+                  <div className="mt-3 rounded-xl bg-white px-3 py-2 text-[12px] text-[#5c6674]">
+                    <p>Cutoff: {formatDateTime(module.cutoffDate, 'not recorded')}</p>
+                    <p>Pages scanned: {formatNumber(module.stats.pagesScanned)}</p>
+                    <p>Coverage: {formatDateRange(module.earliestOrderCreatedAt, module.latestOrderCreatedAt)}</p>
+                    <p>Cutoff reached: {module.cutoffReached ? 'yes' : 'not yet'}</p>
+                  </div>
+                ) : null}
               </div>
             ))}
           </div>
@@ -255,10 +270,10 @@ export function NabisSyncAdminPanel() {
             <SyncActionButton
               icon={<TimerReset className="h-4 w-4" />}
               title={status.controls.historicalBackfill.label}
-              description={status.controls.historicalBackfill.disabledReason}
-              disabled
-              loading={false}
-              onClick={() => undefined}
+              description={status.controls.historicalBackfill.description}
+              disabled={!status.controls.historicalBackfill.enabled || Boolean(runningModule)}
+              loading={runningModule === status.controls.historicalBackfill.module}
+              onClick={() => void runSync(status.controls.historicalBackfill.module, status.controls.historicalBackfill.label)}
             />
           </div>
 

--- a/lib/server/nabis-sync-status.ts
+++ b/lib/server/nabis-sync-status.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { IntegrationProvider, IntegrationSyncStatus } from '@prisma/client';
 import { prisma } from '@/lib/db/prisma';
 
-const NABIS_STATUS_MODULES = ['retailers', 'orders', 'orders_reconcile', 'nabis_global_sync_lease'] as const;
+const NABIS_STATUS_MODULES = ['retailers', 'orders', 'orders_reconcile', 'orders_historical_backfill', 'nabis_global_sync_lease'] as const;
 
 type NabisStatusModule = (typeof NABIS_STATUS_MODULES)[number];
 
@@ -23,6 +23,12 @@ type CheckpointMetadata = {
   retailers?: unknown;
   lineItems?: unknown;
   metricRows?: unknown;
+  historicalBackfill?: unknown;
+  cutoffDate?: unknown;
+  pagesScanned?: unknown;
+  cutoffReached?: unknown;
+  earliestOrderCreatedAt?: unknown;
+  latestOrderCreatedAt?: unknown;
 };
 
 function metadataObject(value: unknown): CheckpointMetadata {
@@ -135,7 +141,13 @@ export async function getNabisAdminSyncStatus(orgId: string) {
         retailers: numberValue(metadata.retailers),
         lineItems: numberValue(metadata.lineItems),
         metricRows: numberValue(metadata.metricRows),
+        pagesScanned: numberValue(metadata.pagesScanned),
       },
+      historicalBackfill: metadata.historicalBackfill === true,
+      cutoffDate: stringValue(metadata.cutoffDate),
+      cutoffReached: metadata.cutoffReached === true,
+      earliestOrderCreatedAt: stringValue(metadata.earliestOrderCreatedAt),
+      latestOrderCreatedAt: stringValue(metadata.latestOrderCreatedAt),
     };
   });
 
@@ -195,10 +207,10 @@ export async function getNabisAdminSyncStatus(orgId: string) {
         label: 'Run Retailer Sync',
       },
       historicalBackfill: {
-        enabled: false,
+        enabled: true,
         module: 'nabis-historical-backfill',
         label: 'Run Historical Backfill',
-        disabledReason: 'Historical backfill is queued for issue #43 after the admin status surface is live.',
+        description: 'Backfills cached Nabis orders and order lines from 2025-01-01 with the global sync lease and rate-limit pacing.',
       },
     },
   };

--- a/lib/server/nabis-sync-status.ts
+++ b/lib/server/nabis-sync-status.ts
@@ -27,6 +27,10 @@ type CheckpointMetadata = {
   cutoffDate?: unknown;
   pagesScanned?: unknown;
   cutoffReached?: unknown;
+  nextPage?: unknown;
+  hasMore?: unknown;
+  skipped?: unknown;
+  skipReason?: unknown;
   earliestOrderCreatedAt?: unknown;
   latestOrderCreatedAt?: unknown;
 };
@@ -146,6 +150,10 @@ export async function getNabisAdminSyncStatus(orgId: string) {
       historicalBackfill: metadata.historicalBackfill === true,
       cutoffDate: stringValue(metadata.cutoffDate),
       cutoffReached: metadata.cutoffReached === true,
+      nextPage: numberValue(metadata.nextPage),
+      hasMore: metadata.hasMore === true,
+      skipped: metadata.skipped === true,
+      skipReason: stringValue(metadata.skipReason),
       earliestOrderCreatedAt: stringValue(metadata.earliestOrderCreatedAt),
       latestOrderCreatedAt: stringValue(metadata.latestOrderCreatedAt),
     };
@@ -210,7 +218,7 @@ export async function getNabisAdminSyncStatus(orgId: string) {
         enabled: true,
         module: 'nabis-historical-backfill',
         label: 'Run Historical Backfill',
-        description: 'Backfills cached Nabis orders and order lines from 2025-01-01 with the global sync lease and rate-limit pacing.',
+        description: 'Runs the next bounded historical batch from 2025-01-01 with the global sync lease, rate-limit pacing, and resumable progress.',
       },
     },
   };

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { IntegrationSyncStatus } from '@prisma/client';
-import { evaluateNabisSyncLease, getRetryDelayMs, parseNabisOrderLineForCache } from '@/lib/server/nabis-sync';
+import { evaluateNabisSyncLease, getRetryDelayMs, pageIsOlderThanCutoff, parseNabisOrderLineForCache } from '@/lib/server/nabis-sync';
 
 describe('Nabis sync line cache parsing', () => {
   it('extracts order line detail needed for local PPP savings calculations', () => {
@@ -95,5 +95,31 @@ describe('Nabis rate-limit backoff', () => {
     expect(getRetryDelayMs(retryAfterDateResponse, 0)).toBeGreaterThan(0);
     expect(getRetryDelayMs(retryAfterDateResponse, 0)).toBeLessThanOrEqual(12_000);
     expect(getRetryDelayMs(fallbackResponse, 3)).toBe(8000);
+  });
+});
+
+describe('Nabis historical backfill paging', () => {
+  it('batch-cutoff only stops after a full order page is older than the requested historical start date', () => {
+    const cutoff = new Date('2025-01-01T00:00:00.000Z');
+
+    expect(
+      pageIsOlderThanCutoff(
+        [
+          { id: 'oldest-in-page', createdDate: '2024-12-31T23:59:59.000Z' },
+          { id: 'still-needed', createdDate: '2025-01-01T00:00:00.000Z' },
+        ],
+        cutoff,
+      ),
+    ).toBe(false);
+
+    expect(
+      pageIsOlderThanCutoff(
+        [
+          { id: 'older-a', createdDate: '2024-12-30T00:00:00.000Z' },
+          { id: 'older-b', createdTimestamp: '2024-12-31T23:59:59.000Z' },
+        ],
+        cutoff,
+      ),
+    ).toBe(true);
   });
 });

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateNabisSyncLease,
   filterOrderRowsOnOrAfterCutoff,
   getRetryDelayMs,
+  nabisOrderLineFingerprint,
   pageIsOlderThanCutoff,
   parseNabisOrderLineForCache,
 } from '@/lib/server/nabis-sync';
@@ -142,5 +143,43 @@ describe('Nabis historical backfill paging', () => {
         cutoff,
       ).map((row) => row.id),
     ).toEqual(['cutoff-row', 'newer-row']);
+  });
+});
+
+describe('Nabis historical line merge safety', () => {
+  it('builds a stable line fingerprint so resumable batches can avoid duplicate inserts without deleting sibling lines', () => {
+    const first = nabisOrderLineFingerprint({
+      externalOrderId: 'order-1',
+      productName: 'Ichi-Roll Single 1g',
+      quantity: 10,
+      unitPrice: 5,
+      isSample: false,
+      itemStrain: 'Time Warp',
+      itemCategory: 'Pre-roll',
+      itemClass: 'Cannabis',
+    });
+    const same = nabisOrderLineFingerprint({
+      externalOrderId: 'order-1',
+      productName: 'Ichi-Roll Single 1g',
+      quantity: 10.0,
+      unitPrice: 5.0,
+      isSample: false,
+      itemStrain: 'Time Warp',
+      itemCategory: 'Pre-roll',
+      itemClass: 'Cannabis',
+    });
+    const sibling = nabisOrderLineFingerprint({
+      externalOrderId: 'order-1',
+      productName: 'Zips 3.5g',
+      quantity: 4,
+      unitPrice: 20,
+      isSample: false,
+      itemStrain: 'Blue Dream',
+      itemCategory: 'Flower',
+      itemClass: 'Cannabis',
+    });
+
+    expect(first).toBe(same);
+    expect(first).not.toBe(sibling);
   });
 });

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { IntegrationSyncStatus } from '@prisma/client';
-import { evaluateNabisSyncLease, getRetryDelayMs, pageIsOlderThanCutoff, parseNabisOrderLineForCache } from '@/lib/server/nabis-sync';
+import {
+  evaluateNabisSyncLease,
+  filterOrderRowsOnOrAfterCutoff,
+  getRetryDelayMs,
+  pageIsOlderThanCutoff,
+  parseNabisOrderLineForCache,
+} from '@/lib/server/nabis-sync';
 
 describe('Nabis sync line cache parsing', () => {
   it('extracts order line detail needed for local PPP savings calculations', () => {
@@ -121,5 +127,20 @@ describe('Nabis historical backfill paging', () => {
         cutoff,
       ),
     ).toBe(true);
+  });
+
+  it('batch-cutoff excludes pre-cutoff rows from the historical backfill page before upsert', () => {
+    const cutoff = new Date('2025-01-01T00:00:00.000Z');
+
+    expect(
+      filterOrderRowsOnOrAfterCutoff(
+        [
+          { id: 'older-row', createdDate: '2024-12-31T23:59:59.000Z' },
+          { id: 'cutoff-row', createdDate: '2025-01-01T00:00:00.000Z' },
+          { id: 'newer-row', createdTimestamp: '2025-02-01T00:00:00.000Z' },
+        ],
+        cutoff,
+      ).map((row) => row.id),
+    ).toEqual(['cutoff-row', 'newer-row']);
   });
 });

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -1504,21 +1504,30 @@ async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?:
           },
           select: {
             metadata: true,
+            status: true,
           },
         })
       : null;
     const previousMetadata = previousCheckpoint?.metadata;
     const previousCutoffReached = booleanFromMetadata(previousMetadata, 'cutoffReached');
+    const previousHistoricalBackfill = booleanFromMetadata(previousMetadata, 'historicalBackfill');
+    const previousHasMore = booleanFromMetadata(previousMetadata, 'hasMore');
     const previousNextPage = numberFromMetadata(previousMetadata, 'nextPage');
+    const previousBackfillComplete =
+      previousCheckpoint?.status === IntegrationSyncStatus.SUCCESS &&
+      previousHistoricalBackfill &&
+      (previousCutoffReached || (!previousHasMore && previousNextPage == null));
     const resumeStartPage =
-      options?.historicalBackfill && !options.resetHistoricalBackfill && previousNextPage != null && !previousCutoffReached ? previousNextPage : undefined;
+      options?.historicalBackfill && !options.resetHistoricalBackfill && previousNextPage != null && !previousBackfillComplete
+        ? previousNextPage
+        : undefined;
 
-    if (options?.historicalBackfill && previousCutoffReached && !options.resetHistoricalBackfill) {
+    if (options?.historicalBackfill && previousBackfillComplete && !options.resetHistoricalBackfill) {
       const metadata = {
         ...(toJsonObject(previousMetadata) ?? {}),
         historicalBackfill: true,
         skipped: true,
-        skipReason: 'Historical Nabis backfill already reached the cutoff. Pass resetHistoricalBackfill to restart.',
+        skipReason: 'Historical Nabis backfill is already complete. Pass resetHistoricalBackfill to restart.',
       };
       return {
         result: {

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -778,6 +778,28 @@ function orderSyncModule(options?: OrderSyncOptions) {
   return 'orders';
 }
 
+export function nabisOrderLineFingerprint(line: {
+  externalOrderId: string;
+  productName: string;
+  quantity: number | Prisma.Decimal | null;
+  unitPrice: number | Prisma.Decimal | null;
+  isSample: boolean;
+  itemStrain: string | null;
+  itemCategory: string | null;
+  itemClass: string | null;
+}) {
+  return [
+    line.externalOrderId,
+    line.productName,
+    line.quantity == null ? '' : Number(line.quantity).toFixed(4),
+    line.unitPrice == null ? '' : Number(line.unitPrice).toFixed(4),
+    line.isSample ? 'sample' : 'standard',
+    line.itemStrain ?? '',
+    line.itemCategory ?? '',
+    line.itemClass ?? '',
+  ].join('|');
+}
+
 function numberFromMetadata(metadata: unknown, key: string) {
   const value = toJsonObject(metadata)?.[key];
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
@@ -1653,15 +1675,41 @@ async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?:
         },
       });
       const orderIdByExternalId = new Map(persistedOrders.map((order) => [order.externalOrderId, order.id]));
+      const existingHistoricalLineFingerprints = options?.historicalBackfill
+        ? new Set(
+            (
+              await prisma.nabisOrderLine.findMany({
+                where: {
+                  orgId,
+                  externalOrderId: {
+                    in: lineExternalOrderIds,
+                  },
+                },
+                select: {
+                  externalOrderId: true,
+                  productName: true,
+                  quantity: true,
+                  unitPrice: true,
+                  isSample: true,
+                  itemStrain: true,
+                  itemCategory: true,
+                  itemClass: true,
+                },
+              })
+            ).map(nabisOrderLineFingerprint),
+          )
+        : null;
 
-      await prisma.nabisOrderLine.deleteMany({
-        where: {
-          orgId,
-          externalOrderId: {
-            in: lineExternalOrderIds,
+      if (!options?.historicalBackfill) {
+        await prisma.nabisOrderLine.deleteMany({
+          where: {
+            orgId,
+            externalOrderId: {
+              in: lineExternalOrderIds,
+            },
           },
-        },
-      });
+        });
+      }
 
       const linesToCreate = lineRows
         .map((line) => {
@@ -1683,7 +1731,12 @@ async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?:
             itemClass: line.itemClass,
           };
         })
-        .filter((line): line is NonNullable<typeof line> => Boolean(line));
+        .filter((line): line is NonNullable<typeof line> => {
+          if (!line) {
+            return false;
+          }
+          return !existingHistoricalLineFingerprints?.has(nabisOrderLineFingerprint(line));
+        });
 
       for (const batch of chunkArray(linesToCreate, ORDER_UPSERT_BATCH_SIZE)) {
         await prisma.nabisOrderLine.createMany({

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -15,6 +15,7 @@ const MAX_RETAILER_PAGES = 40;
 const MAX_ORDER_PAGES = 220;
 const RECENT_ORDER_SYNC_DAYS = 120;
 const RECONCILIATION_ORDER_SYNC_DAYS = 400;
+const HISTORICAL_ORDER_BACKFILL_START_DATE = '2025-01-01T00:00:00.000Z';
 const ORDER_UPSERT_BATCH_SIZE = 50;
 const NABIS_SYNC_LEASE_MODULE = 'nabis_global_sync_lease';
 const NABIS_SYNC_LEASE_REFRESH_MS = 30_000;
@@ -135,6 +136,26 @@ type ParsedOrderLine = {
   itemStrain: string | null;
   itemCategory: string | null;
   itemClass: string | null;
+};
+
+type OrderSyncOptions = {
+  reconciliation?: boolean;
+  historicalBackfill?: boolean;
+  historicalStartDate?: string;
+};
+
+type LoadedOrdersFromNabis = {
+  rows: ParsedOrder[];
+  metadata: {
+    cutoffDate: string;
+    historicalBackfill: boolean;
+    reconciliation: boolean;
+    pagesScanned: number;
+    recordsRead: number;
+    cutoffReached: boolean;
+    earliestOrderCreatedAt: string | null;
+    latestOrderCreatedAt: string | null;
+  };
 };
 
 type NabisSyncLeaseMetadata = {
@@ -694,7 +715,7 @@ async function loadRetailersFromNabis() {
   return rows;
 }
 
-function pageIsOlderThanCutoff(rows: NabisOrderApiRow[], cutoff: Date) {
+export function pageIsOlderThanCutoff(rows: NabisOrderApiRow[], cutoff: Date) {
   const validDates = rows
     .map((row) => parseDate(row.createdTimestamp ?? row.createdDate ?? null))
     .filter((date): date is Date => Boolean(date))
@@ -707,11 +728,54 @@ function pageIsOlderThanCutoff(rows: NabisOrderApiRow[], cutoff: Date) {
   return validDates[validDates.length - 1].getTime() < cutoff.getTime();
 }
 
-async function loadOrdersFromNabis(options?: { reconciliation?: boolean }) {
-  const rows: ParsedOrder[] = [];
+function resolveOrderSyncCutoff(options?: OrderSyncOptions) {
+  if (options?.historicalBackfill) {
+    const requested = options.historicalStartDate ? new Date(options.historicalStartDate) : new Date(HISTORICAL_ORDER_BACKFILL_START_DATE);
+    if (Number.isNaN(requested.getTime())) {
+      throw new Error(`Invalid historical Nabis backfill start date: ${options.historicalStartDate}`);
+    }
+    return requested;
+  }
+
   const cutoff = new Date();
   cutoff.setUTCDate(cutoff.getUTCDate() - (options?.reconciliation ? RECONCILIATION_ORDER_SYNC_DAYS : RECENT_ORDER_SYNC_DAYS));
+  return cutoff;
+}
+
+function orderCreatedTimestamp(order: ParsedOrder) {
+  return order.orderCreatedDate?.toISOString() ?? null;
+}
+
+function orderDateCoverage(rows: ParsedOrder[]) {
+  const timestamps = rows
+    .map(orderCreatedTimestamp)
+    .filter((value): value is string => Boolean(value))
+    .sort();
+
+  return {
+    earliestOrderCreatedAt: timestamps[0] ?? null,
+    latestOrderCreatedAt: timestamps[timestamps.length - 1] ?? null,
+  };
+}
+
+function orderSyncModule(options?: OrderSyncOptions) {
+  if (options?.historicalBackfill) return 'orders_historical_backfill';
+  if (options?.reconciliation) return 'orders_reconcile';
+  return 'orders';
+}
+
+async function loadOrdersFromNabis(
+  options?: OrderSyncOptions & {
+    onProgress?: (metadata: LoadedOrdersFromNabis['metadata']) => Promise<void>;
+  },
+): Promise<LoadedOrdersFromNabis> {
+  const rows: ParsedOrder[] = [];
+  const cutoff = resolveOrderSyncCutoff(options);
+  const cutoffDate = cutoff.toISOString();
   let page = 0;
+  let pagesScanned = 0;
+  let recordsRead = 0;
+  let cutoffReached = false;
 
   while (page < MAX_ORDER_PAGES) {
     if (page > 0) {
@@ -720,20 +784,47 @@ async function loadOrdersFromNabis(options?: { reconciliation?: boolean }) {
 
     const payload = await fetchNabisPage<NabisOrderApiRow>('/v2/ny/order', page);
     const pageRows = payload.data ?? [];
-    rows.push(...pageRows.map(parseOrderRow).filter((row): row is ParsedOrder => Boolean(row)));
+    const parsedRows = pageRows.map(parseOrderRow).filter((row): row is ParsedOrder => Boolean(row));
+    rows.push(...parsedRows);
+    pagesScanned += 1;
+    recordsRead += pageRows.length;
 
     if (!pageRows.length || payload.nextPage == null || payload.nextPage <= page) {
       break;
     }
 
     if (pageIsOlderThanCutoff(pageRows, cutoff)) {
+      cutoffReached = true;
       break;
+    }
+
+    if (options?.onProgress) {
+      await options.onProgress({
+        cutoffDate,
+        historicalBackfill: Boolean(options?.historicalBackfill),
+        reconciliation: Boolean(options?.reconciliation),
+        pagesScanned,
+        recordsRead,
+        cutoffReached,
+        ...orderDateCoverage(rows),
+      });
     }
 
     page = payload.nextPage;
   }
 
-  return rows;
+  return {
+    rows,
+    metadata: {
+      cutoffDate,
+      historicalBackfill: Boolean(options?.historicalBackfill),
+      reconciliation: Boolean(options?.reconciliation),
+      pagesScanned,
+      recordsRead,
+      cutoffReached,
+      ...orderDateCoverage(rows),
+    },
+  };
 }
 
 async function ensureNabisIntegration(orgId: string) {
@@ -1334,18 +1425,32 @@ async function syncNabisRetailersCore(orgId: string, integrationId: string, acto
   });
 }
 
-export async function syncNabisOrders(orgId: string, actor?: SyncActor, options?: { reconciliation?: boolean }) {
+export async function syncNabisOrders(orgId: string, actor?: SyncActor, options?: OrderSyncOptions) {
   await ensureActivePolicySnapshot(orgId, actor);
   const integration = await ensureNabisIntegration(orgId);
+  const syncModuleName = orderSyncModule(options);
 
-  return withNabisSyncLease({ orgId, integrationId: integration.id, module: options?.reconciliation ? 'orders_reconcile' : 'orders', actor }, () =>
+  return withNabisSyncLease({ orgId, integrationId: integration.id, module: syncModuleName, actor }, () =>
     syncNabisOrdersCore(orgId, integration.id, actor, options),
   );
 }
 
-async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?: SyncActor, options?: { reconciliation?: boolean }) {
-  return withSyncRun({ orgId, integrationId, module: options?.reconciliation ? 'orders_reconcile' : 'orders', actor }, async () => {
-    const orders = await loadOrdersFromNabis({ reconciliation: options?.reconciliation });
+async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?: SyncActor, options?: OrderSyncOptions) {
+  const syncModuleName = orderSyncModule(options);
+  return withSyncRun({ orgId, integrationId, module: syncModuleName, actor }, async () => {
+    const loadedOrders = await loadOrdersFromNabis({
+      ...options,
+      onProgress: async (metadata) => {
+        await markSyncCheckpoint({
+          orgId,
+          integrationId,
+          module: syncModuleName,
+          status: IntegrationSyncStatus.RUNNING,
+          metadata,
+        });
+      },
+    });
+    const orders = loadedOrders.rows;
     await prisma.nabisOrder.deleteMany({
       where: {
         orgId,
@@ -1539,22 +1644,22 @@ async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?:
       recordsIn: orders.length,
       recordsUpserted: upserted,
       metadata: {
+        ...loadedOrders.metadata,
         orders: orders.length,
         uniqueOrders: upserted,
         lineItems: upsertedLines,
         metricRows,
-        reconciliation: Boolean(options?.reconciliation),
       },
     };
   });
 }
 
-export async function syncNabisRetailersAndOrders(orgId: string, actor?: SyncActor, options?: { reconciliation?: boolean; syncCrm?: boolean }) {
+export async function syncNabisRetailersAndOrders(orgId: string, actor?: SyncActor, options?: OrderSyncOptions & { syncCrm?: boolean }) {
   await ensureActivePolicySnapshot(orgId, actor);
   const integration = await ensureNabisIntegration(orgId);
 
   return withNabisSyncLease(
-    { orgId, integrationId: integration.id, module: options?.reconciliation ? 'retailers_and_orders_reconcile' : 'retailers_and_orders', actor },
+    { orgId, integrationId: integration.id, module: options?.historicalBackfill ? 'retailers_and_orders_historical_backfill' : options?.reconciliation ? 'retailers_and_orders_reconcile' : 'retailers_and_orders', actor },
     async () => {
       const retailerResult = await syncNabisRetailersCore(orgId, integration.id, actor, { syncCrm: options?.syncCrm === true });
       const orderResult = await syncNabisOrdersCore(orgId, integration.id, actor, options);

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -1509,16 +1509,15 @@ async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?:
         })
       : null;
     const previousMetadata = previousCheckpoint?.metadata;
+    const previousProgressCommitted = previousCheckpoint?.status === IntegrationSyncStatus.SUCCESS;
     const previousCutoffReached = booleanFromMetadata(previousMetadata, 'cutoffReached');
     const previousHistoricalBackfill = booleanFromMetadata(previousMetadata, 'historicalBackfill');
     const previousHasMore = booleanFromMetadata(previousMetadata, 'hasMore');
     const previousNextPage = numberFromMetadata(previousMetadata, 'nextPage');
     const previousBackfillComplete =
-      previousCheckpoint?.status === IntegrationSyncStatus.SUCCESS &&
-      previousHistoricalBackfill &&
-      (previousCutoffReached || (!previousHasMore && previousNextPage == null));
+      previousProgressCommitted && previousHistoricalBackfill && (previousCutoffReached || (!previousHasMore && previousNextPage == null));
     const resumeStartPage =
-      options?.historicalBackfill && !options.resetHistoricalBackfill && previousNextPage != null && !previousBackfillComplete
+      options?.historicalBackfill && !options.resetHistoricalBackfill && previousProgressCommitted && previousNextPage != null && !previousBackfillComplete
         ? previousNextPage
         : undefined;
 

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -728,6 +728,13 @@ export function pageIsOlderThanCutoff(rows: NabisOrderApiRow[], cutoff: Date) {
   return validDates[validDates.length - 1].getTime() < cutoff.getTime();
 }
 
+export function filterOrderRowsOnOrAfterCutoff(rows: NabisOrderApiRow[], cutoff: Date) {
+  return rows.filter((row) => {
+    const createdAt = parseDate(row.createdTimestamp ?? row.createdDate ?? null);
+    return !createdAt || createdAt.getTime() >= cutoff.getTime();
+  });
+}
+
 function resolveOrderSyncCutoff(options?: OrderSyncOptions) {
   if (options?.historicalBackfill) {
     const requested = options.historicalStartDate ? new Date(options.historicalStartDate) : new Date(HISTORICAL_ORDER_BACKFILL_START_DATE);
@@ -784,7 +791,8 @@ async function loadOrdersFromNabis(
 
     const payload = await fetchNabisPage<NabisOrderApiRow>('/v2/ny/order', page);
     const pageRows = payload.data ?? [];
-    const parsedRows = pageRows.map(parseOrderRow).filter((row): row is ParsedOrder => Boolean(row));
+    const rowsToParse = options?.historicalBackfill ? filterOrderRowsOnOrAfterCutoff(pageRows, cutoff) : pageRows;
+    const parsedRows = rowsToParse.map(parseOrderRow).filter((row): row is ParsedOrder => Boolean(row));
     rows.push(...parsedRows);
     pagesScanned += 1;
     recordsRead += pageRows.length;

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -16,6 +16,7 @@ const MAX_ORDER_PAGES = 220;
 const RECENT_ORDER_SYNC_DAYS = 120;
 const RECONCILIATION_ORDER_SYNC_DAYS = 400;
 const HISTORICAL_ORDER_BACKFILL_START_DATE = '2025-01-01T00:00:00.000Z';
+const HISTORICAL_ORDER_BACKFILL_BATCH_PAGES = 20;
 const ORDER_UPSERT_BATCH_SIZE = 50;
 const NABIS_SYNC_LEASE_MODULE = 'nabis_global_sync_lease';
 const NABIS_SYNC_LEASE_REFRESH_MS = 30_000;
@@ -142,6 +143,9 @@ type OrderSyncOptions = {
   reconciliation?: boolean;
   historicalBackfill?: boolean;
   historicalStartDate?: string;
+  resetHistoricalBackfill?: boolean;
+  startPage?: number;
+  maxPagesPerRun?: number;
 };
 
 type LoadedOrdersFromNabis = {
@@ -153,6 +157,9 @@ type LoadedOrdersFromNabis = {
     pagesScanned: number;
     recordsRead: number;
     cutoffReached: boolean;
+    startPage: number;
+    nextPage: number | null;
+    hasMore: boolean;
     earliestOrderCreatedAt: string | null;
     latestOrderCreatedAt: string | null;
   };
@@ -771,6 +778,15 @@ function orderSyncModule(options?: OrderSyncOptions) {
   return 'orders';
 }
 
+function numberFromMetadata(metadata: unknown, key: string) {
+  const value = toJsonObject(metadata)?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function booleanFromMetadata(metadata: unknown, key: string) {
+  return toJsonObject(metadata)?.[key] === true;
+}
+
 async function loadOrdersFromNabis(
   options?: OrderSyncOptions & {
     onProgress?: (metadata: LoadedOrdersFromNabis['metadata']) => Promise<void>;
@@ -779,13 +795,17 @@ async function loadOrdersFromNabis(
   const rows: ParsedOrder[] = [];
   const cutoff = resolveOrderSyncCutoff(options);
   const cutoffDate = cutoff.toISOString();
-  let page = 0;
+  const startPage = options?.historicalBackfill ? Math.max(0, options.startPage ?? 0) : 0;
+  const maxPagesPerRun = options?.historicalBackfill ? (options.maxPagesPerRun ?? HISTORICAL_ORDER_BACKFILL_BATCH_PAGES) : MAX_ORDER_PAGES;
+  let page = startPage;
   let pagesScanned = 0;
   let recordsRead = 0;
   let cutoffReached = false;
+  let nextPage: number | null = null;
+  let hasMore = false;
 
-  while (page < MAX_ORDER_PAGES) {
-    if (page > 0) {
+  while (page < MAX_ORDER_PAGES && pagesScanned < maxPagesPerRun) {
+    if (pagesScanned > 0 || page > startPage) {
       await wait(175);
     }
 
@@ -797,28 +817,31 @@ async function loadOrdersFromNabis(
     pagesScanned += 1;
     recordsRead += pageRows.length;
 
-    if (!pageRows.length || payload.nextPage == null || payload.nextPage <= page) {
+    const payloadNextPage = payload.nextPage != null && payload.nextPage > page ? payload.nextPage : null;
+    cutoffReached = pageIsOlderThanCutoff(pageRows, cutoff);
+    const exhausted = !pageRows.length || payloadNextPage == null || cutoffReached;
+    const hitPageBudget = pagesScanned >= maxPagesPerRun;
+    nextPage = exhausted ? null : payloadNextPage;
+    hasMore = Boolean(nextPage != null && (hitPageBudget || !exhausted));
+
+    await options?.onProgress?.({
+      cutoffDate,
+      historicalBackfill: Boolean(options?.historicalBackfill),
+      reconciliation: Boolean(options?.reconciliation),
+      pagesScanned,
+      recordsRead,
+      cutoffReached,
+      startPage,
+      nextPage,
+      hasMore,
+      ...orderDateCoverage(rows),
+    });
+
+    if (exhausted || hitPageBudget || nextPage == null) {
       break;
     }
 
-    if (pageIsOlderThanCutoff(pageRows, cutoff)) {
-      cutoffReached = true;
-      break;
-    }
-
-    if (options?.onProgress) {
-      await options.onProgress({
-        cutoffDate,
-        historicalBackfill: Boolean(options?.historicalBackfill),
-        reconciliation: Boolean(options?.reconciliation),
-        pagesScanned,
-        recordsRead,
-        cutoffReached,
-        ...orderDateCoverage(rows),
-      });
-    }
-
-    page = payload.nextPage;
+    page = nextPage;
   }
 
   return {
@@ -830,6 +853,9 @@ async function loadOrdersFromNabis(
       pagesScanned,
       recordsRead,
       cutoffReached,
+      startPage,
+      nextPage,
+      hasMore,
       ...orderDateCoverage(rows),
     },
   };
@@ -1446,8 +1472,48 @@ export async function syncNabisOrders(orgId: string, actor?: SyncActor, options?
 async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?: SyncActor, options?: OrderSyncOptions) {
   const syncModuleName = orderSyncModule(options);
   return withSyncRun({ orgId, integrationId, module: syncModuleName, actor }, async () => {
+    const previousCheckpoint = options?.historicalBackfill
+      ? await prisma.syncCheckpoint.findUnique({
+          where: {
+            integrationId_module: {
+              integrationId,
+              module: syncModuleName,
+            },
+          },
+          select: {
+            metadata: true,
+          },
+        })
+      : null;
+    const previousMetadata = previousCheckpoint?.metadata;
+    const previousCutoffReached = booleanFromMetadata(previousMetadata, 'cutoffReached');
+    const previousNextPage = numberFromMetadata(previousMetadata, 'nextPage');
+    const resumeStartPage =
+      options?.historicalBackfill && !options.resetHistoricalBackfill && previousNextPage != null && !previousCutoffReached ? previousNextPage : undefined;
+
+    if (options?.historicalBackfill && previousCutoffReached && !options.resetHistoricalBackfill) {
+      const metadata = {
+        ...(toJsonObject(previousMetadata) ?? {}),
+        historicalBackfill: true,
+        skipped: true,
+        skipReason: 'Historical Nabis backfill already reached the cutoff. Pass resetHistoricalBackfill to restart.',
+      };
+      return {
+        result: {
+          orders: 0,
+          upserted: 0,
+          lineItems: 0,
+          metricRows: 0,
+        },
+        recordsIn: 0,
+        recordsUpserted: 0,
+        metadata,
+      };
+    }
+
     const loadedOrders = await loadOrdersFromNabis({
       ...options,
+      startPage: resumeStartPage ?? options?.startPage,
       onProgress: async (metadata) => {
         await markSyncCheckpoint({
           orgId,


### PR DESCRIPTION
Closes #43\n\n## Why\nHistorical PPP savings and future dashboard analytics need cached order and line coverage back to 2025-01-01 instead of depending on the normal recent sync window.\n\n## What Changed\n- Added an intentional `nabis-historical-backfill` admin sync action.\n- Added `orders_historical_backfill` sync-run/checkpoint metadata using the existing global Nabis lease and 429 retry/backoff path.\n- Made historical backfill resumable and bounded: each run scans at most 20 Nabis pages, stores `nextPage`/`hasMore`, and resumes from the checkpoint on the next run.\n- Reused the existing Nabis order parser/upsert path so `NabisOrder` and `NabisOrderLine` are populated consistently with normal order sync.\n- Prevented pre-2025 rows from being upserted when the final cutoff page is reached.\n- Made historical line writes merge-safe so partial batches do not delete sibling lines for the same order across page boundaries.\n- Skips completed backfills unless reset is requested, preventing accidental page-0 reruns after completion.\n- Surfaced backfill cutoff, pages scanned, next page, coverage dates, and completion state in the admin sync panel.\n- Added named `batch-cutoff` test coverage alongside existing `lease-refusal`, `stale-recovery`, and `429-backoff` tests.\n\n## Out Of Scope\n- Does not rebuild the historical dashboard; that remains #45.\n- Does not change database schema.\n- Does not mirror Nabis retailers into Notion CRM.\n- Does not run the production backfill from this PR.\n\n## Owned Path Globs\n- `lib/server/nabis-sync.ts`\n- `lib/server/nabis-sync.test.ts`\n- `lib/server/nabis-sync-status.ts`\n- `app/api/sync/run/route.ts`\n- `components/settings/nabis-sync-admin-panel.tsx`\n- `SESSION.md`\n\n## Open PR Overlap Check\n- Checked current open PRs with `gh pr list`: no open Picc-web-app PRs at claim time.\n\n## Validation\n- `npm test` - 51 passed\n- `npm run typecheck` - passed\n- `npm run lint` - passed\n- `npm run build` - passed\n\n## Production Proof\n- Pending after merge/deploy. The user has already approved running the historical data backfill once safeguards are merged and green.\n\n## Remaining Risk\n- Local shell uses Node 25 and emits an engine warning during install; CI uses the repository workflow environment.\n- The backfill depends on Nabis order pagination being reverse-chronological enough for cutoff paging to be valid, which matches the existing sync assumption.