### PR TITLE
Rebuild Nabis sales dashboard around cached analytics

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,30 +1,26 @@
-# Current Session
+# Session: Issue #45 Nabis Sales Dashboard
 
-- Issue: https://github.com/brycejohnson1417/Picc-web-app/issues/43
-- Add an intentional historical Nabis backfill path from `2025-01-01`.
-- Reuse the existing Nabis sync lease, rate-limit backoff, sync run, and checkpoint architecture.
-- Populate cached `NabisOrder` and `NabisOrderLine` rows through the same parser/upsert path as normal order sync.
-- Surface backfill readiness/progress metadata through the existing admin sync status/control UI.
+## Scope
 
-# Out Of Scope
+- Rebuild the Nabis sales dashboard around cached Postgres analytics by default.
+- Support current month, YTD, trailing 12 months, and custom date ranges.
+- Show selected-range revenue, historical monthly revenue, sales by rep, and rep/month metrics.
+- Keep selected-range drilldowns, CSV export, and PDF export useful.
+- Show cache coverage, freshness, and partial-cache states clearly.
+- Use the Sales NY Rep Metrics PDF as a reconciliation reference only.
 
-- Do not rebuild the historical dashboard in this PR; that remains issue #45.
-- Do not change schemas unless the existing checkpoint/run metadata model is insufficient.
-- Do not mirror Nabis retailers into Notion CRM from this backfill.
-- Do not run production writes until the PR is merged, CI is green, and the approved production backfill command/path is used.
+## Out Of Scope
 
-# Constraints
+- Redoing transfer cleanup.
+- Production writes, schema changes, destructive operations, or Notion/Nabis writes.
+- Treating the PDF sheet as authoritative.
+- Moving the full rep metrics workflow to Home.
 
-- Branch: `codex/43-historical-nabis-backfill`.
-- Owned path globs: `lib/server/nabis-sync.ts`, `lib/server/nabis-sync.test.ts`, `lib/server/nabis-sync-status.ts`, `app/api/sync/run/route.ts`, `components/settings/nabis-sync-admin-panel.tsx`, `SESSION.md`.
-- Open PR overlap check: `gh pr list` returned no open Picc-web-app PRs at claim time.
-- Required named test coverage: `lease-refusal`, `stale-recovery`, `429-backoff`, and `batch-cutoff`.
-- Production data writes/backfill execution are approval-lane; the user has pre-approved the historical data backfill only after safeguards are merged and verified.
+## Constraints
 
-# Test Plan
-
-- RED first: add a `batch-cutoff` unit test for historical cutoff handling before implementation.
-- Run `npm test`.
-- Run `npm run typecheck`.
-- Run `npm run lint`.
-- Run `npm run build`.
+- Worktree: `/Users/brycejohnson/Code/worktrees/45-nabis-sales-dashboard`
+- Branch: `codex/45-nabis-sales-dashboard`
+- Issue: `https://github.com/brycejohnson1417/Picc-web-app/issues/45`
+- Draft PR: `https://github.com/brycejohnson1417/Picc-web-app/pull/55`
+- Keep UI components thin and put analytics logic in `lib/dashboard`.
+- Cached Nabis coverage starts at the proven earliest order unless current cache evidence shows otherwise.

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -6,6 +6,7 @@ import { getUserRole } from '@/lib/rbac/guards';
 export const dynamic = 'force-dynamic';
 
 const DASHBOARD_RESPONSE_CACHE_TTL_MS = 1000 * 60;
+const DEFAULT_DASHBOARD_DATA_ORG_ID = 'picc_company_workspace';
 
 type DashboardCacheEntry = {
   expiresAt: number;
@@ -25,6 +26,15 @@ function responseHeaders(forceRefresh: boolean) {
 
 function cacheKey(orgId: string, start: string, end: string) {
   return `${orgId}::${start}::${end}`;
+}
+
+function dashboardDataOrgId(fallbackOrgId: string) {
+  return (
+    process.env.PICC_SHARED_ORG_ID?.trim() ||
+    process.env.PICC_WORKSPACE_ORG_ID?.trim() ||
+    DEFAULT_DASHBOARD_DATA_ORG_ID ||
+    fallbackOrgId
+  );
 }
 
 function readDashboardCache(key: string) {
@@ -54,7 +64,8 @@ export async function GET(request: Request) {
       end: searchParams.get('end'),
     });
     const forceRefresh = searchParams.get('refresh') === '1';
-    const key = cacheKey(ctx.orgId, start, end);
+    const dataOrgId = dashboardDataOrgId(ctx.orgId);
+    const key = cacheKey(dataOrgId, start, end);
 
     if (forceRefresh) {
       const role = await getUserRole(ctx.orgId, ctx.userId);
@@ -77,7 +88,7 @@ export async function GET(request: Request) {
     }
 
     const payload = await getDashboardPayload({
-      orgId: ctx.orgId,
+      orgId: dataOrgId,
       start,
       end,
       forceRefresh,
@@ -99,7 +110,7 @@ export async function GET(request: Request) {
     const statusCode = Number((error as Error & { statusCode?: number })?.statusCode || 500);
     const publicMessage =
       statusCode >= 500
-        ? 'Unable to sync data from the Nabis API right now.'
+        ? 'Unable to load cached Nabis dashboard data right now.'
         : error instanceof Error
           ? error.message
           : 'Request failed.';

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -21,18 +21,20 @@ import {
 } from 'lucide-react';
 import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { toast } from 'sonner';
-import type { DashboardDateRange, NabisDashboardMetadata, NabisDashboardResponse, ProcessedNabisOrder, RepStat, SerializedNabisOrder } from '@/lib/dashboard/nabis-types';
-import { deserializeOrders, formatCurrency, formatTimestamp, getDefaultDateRange, isDateRangeValid } from '@/lib/dashboard/nabis-client';
+import type { NabisDashboardAnalytics } from '@/lib/dashboard/nabis-analytics';
+import type { DashboardDateRange, NabisDashboardMetadata, NabisDashboardResponse, ProcessedNabisOrder, SerializedNabisOrder } from '@/lib/dashboard/nabis-types';
+import { deserializeOrders, formatCurrency, formatTimestamp, getDefaultDateRange, getPresetDateRange, isDateRangeValid, type DashboardRangePreset } from '@/lib/dashboard/nabis-client';
 import { SalesTrendChart } from '@/components/dashboard/sales-trend-chart';
 
 const REP_COLORS = ['#1d4ed8', '#2563eb', '#0f766e', '#0284c7', '#7c3aed', '#db2777', '#f97316', '#eab308', '#16a34a', '#475569'];
 const DASHBOARD_SNAPSHOT_TTL_MS = 1000 * 60 * 5;
-const DASHBOARD_SNAPSHOT_KEY_PREFIX = 'picc:nabis-dashboard';
+const DASHBOARD_SNAPSHOT_KEY_PREFIX = 'picc:nabis-dashboard:v3';
 
 type DashboardSnapshot = {
   fetchedAt: number;
   orders: SerializedNabisOrder[];
   metadata: NabisDashboardMetadata;
+  analytics: NabisDashboardAnalytics;
 };
 
 function dashboardSnapshotKey(range: DashboardDateRange) {
@@ -69,8 +71,10 @@ function writeDashboardSnapshot(range: DashboardDateRange, payload: DashboardSna
 
 export function NabisSalesDashboard() {
   const [dateRange, setDateRange] = useState<DashboardDateRange>(() => getDefaultDateRange());
+  const [rangePreset, setRangePreset] = useState<DashboardRangePreset>('current-month');
   const [orders, setOrders] = useState<ProcessedNabisOrder[]>([]);
   const [metadata, setMetadata] = useState<NabisDashboardMetadata | null>(null);
+  const [analytics, setAnalytics] = useState<NabisDashboardAnalytics | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -86,6 +90,7 @@ export function NabisSalesDashboard() {
     if (snapshot) {
       setOrders(deserializeOrders(snapshot.orders));
       setMetadata(snapshot.metadata);
+      setAnalytics(snapshot.analytics);
       setError(null);
     } else {
       if (initial) {
@@ -123,11 +128,13 @@ export function NabisSalesDashboard() {
 
       setOrders(deserializeOrders(payload.orders));
       setMetadata(payload.metadata);
+      setAnalytics(payload.analytics);
       setError(null);
       writeDashboardSnapshot(nextRange, {
         fetchedAt: Date.now(),
         orders: payload.orders,
         metadata: payload.metadata,
+        analytics: payload.analytics,
       });
     } catch (caughtError) {
       const message = caughtError instanceof Error ? caughtError.message : 'Failed to load dashboard data.';
@@ -145,32 +152,8 @@ export function NabisSalesDashboard() {
     void loadDashboard(getDefaultDateRange(), { initial: true });
   }, []);
 
-  const { availableMonths, monthlyTrend } = useMemo(() => {
-    const months = new Set<string>();
-    const trendMap = new Map<string, number>();
-
-    for (const order of orders) {
-      months.add(order.monthKey);
-      if (!order.isCanceled) {
-        trendMap.set(order.monthKey, (trendMap.get(order.monthKey) || 0) + order.total);
-      }
-    }
-
-    const sortedMonths = [...months].sort();
-    return {
-      availableMonths: sortedMonths,
-      monthlyTrend: [...trendMap.entries()]
-        .map(([monthKey, revenue]) => ({
-          monthKey,
-          name: new Date(`${monthKey}-15T12:00:00`).toLocaleDateString('en-US', {
-            month: 'short',
-            year: 'numeric',
-          }),
-          revenue,
-        }))
-        .sort((left, right) => left.monthKey.localeCompare(right.monthKey)),
-    };
-  }, [orders]);
+  const monthlyTrend = useMemo(() => analytics?.monthlyTrend ?? [], [analytics]);
+  const availableMonths = useMemo(() => monthlyTrend.map((month) => month.monthKey), [monthlyTrend]);
 
   useEffect(() => {
     const latestMonth = availableMonths[availableMonths.length - 1] || '';
@@ -187,40 +170,38 @@ export function NabisSalesDashboard() {
   const monthlyData = useMemo(() => orders.filter((order) => order.monthKey === selectedMonth), [orders, selectedMonth]);
 
   const tableData = useMemo(() => {
-    const base = showCanceled ? monthlyData : monthlyData.filter((order) => !order.isCanceled);
+    const base = showCanceled ? orders : orders.filter((order) => !order.isCanceled);
     return [...base].sort((left, right) => {
       if (left.createdDate.getTime() === right.createdDate.getTime()) {
         return right.orderNumber.localeCompare(left.orderNumber);
       }
       return right.createdDate.getTime() - left.createdDate.getTime();
     });
-  }, [monthlyData, showCanceled]);
+  }, [orders, showCanceled]);
 
-  const stats = useMemo(() => {
-    const validOrders = monthlyData.filter((order) => !order.isCanceled);
-    const totalRevenue = validOrders.reduce((sum, order) => sum + order.total, 0);
-    const totalOrders = validOrders.length;
+  const stats = analytics ?? {
+    totalRevenue: 0,
+    totalOrders: 0,
+    activeSalesReps: 0,
+    monthlyTrend: [],
+    repStats: [],
+    repMonthlyMetrics: [],
+    dataNotes: [],
+  };
 
-    const repMap = new Map<string, RepStat>();
-    for (const order of validOrders) {
-      const current = repMap.get(order.salesRep) || { name: order.salesRep, revenue: 0, orderCount: 0 };
-      current.revenue += order.total;
-      current.orderCount += 1;
-      repMap.set(order.salesRep, current);
-    }
-
-    return {
-      totalRevenue,
-      totalOrders,
-      repStats: [...repMap.values()].sort((left, right) => right.revenue - left.revenue),
-    };
-  }, [monthlyData]);
-
-  const selectedMonthLabel = selectedMonth
-    ? new Date(`${selectedMonth}-15T12:00:00`).toLocaleDateString('en-US', { year: 'numeric', month: 'long' })
-    : 'Selected Month';
+  const selectedRangeLabel = `${dateRange.start} to ${dateRange.end}`;
   const rangeIsValid = isDateRangeValid(dateRange);
   const actionLocked = isRefreshing || isGeneratingPDF;
+
+  const handlePresetChange = (preset: DashboardRangePreset) => {
+    setRangePreset(preset);
+    if (preset === 'custom') {
+      return;
+    }
+    const nextRange = getPresetDateRange(preset);
+    setDateRange(nextRange);
+    void loadDashboard(nextRange);
+  };
 
   const handleExportCSV = () => {
     if (tableData.length === 0) {
@@ -244,7 +225,7 @@ export function NabisSalesDashboard() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `nabis_orders_${selectedMonth || 'live'}.csv`;
+    link.download = `nabis_orders_${dateRange.start}_to_${dateRange.end}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -294,11 +275,11 @@ export function NabisSalesDashboard() {
       doc.text('PICC Nabis Sales Dashboard', margin, currentY + 6);
       doc.setFontSize(10);
       doc.setTextColor(100, 116, 139);
-      const monthText = `Month: ${selectedMonthLabel}`;
+      const monthText = `Range: ${selectedRangeLabel}`;
       doc.text(monthText, pageWidth - margin - doc.getTextWidth(monthText), currentY + 6);
       currentY += 15;
 
-      for (const sectionId of ['kpi-section', 'trend-chart-section', 'sales-trend-section', 'rep-revenue-chart', 'market-share-card']) {
+      for (const sectionId of ['kpi-section', 'trend-chart-section', 'sales-trend-section', 'rep-revenue-chart', 'rep-month-metrics-card', 'market-share-card']) {
         await addSection(sectionId);
       }
 
@@ -308,7 +289,7 @@ export function NabisSalesDashboard() {
       } else {
         doc.setFontSize(12);
         doc.setTextColor(30, 41, 59);
-        doc.text(`Order Details (${selectedMonthLabel})`, margin, currentY);
+        doc.text(`Order Details (${selectedRangeLabel})`, margin, currentY);
         currentY += 5;
       }
 
@@ -329,7 +310,7 @@ export function NabisSalesDashboard() {
         margin: { left: margin, right: margin, bottom: margin },
       });
 
-      doc.save(`Nabis_Sales_Report_${selectedMonth}.pdf`);
+      doc.save(`Nabis_Sales_Report_${dateRange.start}_to_${dateRange.end}.pdf`);
     } catch (caughtError) {
       console.error('PDF generation failed', caughtError);
       toast.error('Failed to generate the PDF report.');
@@ -401,6 +382,26 @@ export function NabisSalesDashboard() {
             </div>
 
             <div className={`flex flex-col gap-3 xl:items-end ${isGeneratingPDF ? 'opacity-0' : ''}`}>
+              <div className="grid w-full grid-cols-2 gap-2 rounded-2xl border border-[#d3d9e2] bg-white p-1 shadow-sm sm:grid-cols-4 xl:w-auto">
+                {[
+                  ['current-month', 'Current Month'],
+                  ['ytd', 'YTD'],
+                  ['trailing-12', 'Trailing 12'],
+                  ['custom', 'Custom'],
+                ].map(([value, label]) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => handlePresetChange(value as DashboardRangePreset)}
+                    disabled={actionLocked}
+                    className={`h-9 rounded-xl px-3 text-sm font-semibold transition ${
+                      rangePreset === value ? 'bg-[#18212d] text-white shadow-sm' : 'text-[#536070] hover:bg-[#f2f5f9]'
+                    } disabled:cursor-not-allowed disabled:opacity-60`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
               <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-[180px_160px_160px_auto_auto]">
                 <div className="relative">
                   <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
@@ -424,7 +425,10 @@ export function NabisSalesDashboard() {
                   <input
                     type="date"
                     value={dateRange.start}
-                    onChange={(event) => setDateRange((current) => ({ ...current, start: event.target.value }))}
+                    onChange={(event) => {
+                      setRangePreset('custom');
+                      setDateRange((current) => ({ ...current, start: event.target.value }));
+                    }}
                     className="min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-[#243040] outline-none"
                   />
                 </label>
@@ -434,7 +438,10 @@ export function NabisSalesDashboard() {
                   <input
                     type="date"
                     value={dateRange.end}
-                    onChange={(event) => setDateRange((current) => ({ ...current, end: event.target.value }))}
+                    onChange={(event) => {
+                      setRangePreset('custom');
+                      setDateRange((current) => ({ ...current, end: event.target.value }));
+                    }}
                     className="min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-[#243040] outline-none"
                   />
                 </label>
@@ -456,7 +463,7 @@ export function NabisSalesDashboard() {
                   className="inline-flex items-center justify-center rounded-xl border border-[#d3d9e2] bg-white px-4 py-2.5 text-sm font-semibold text-[#243040] shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                  Refresh
+                  Sync Now
                 </button>
               </div>
 
@@ -485,7 +492,7 @@ export function NabisSalesDashboard() {
 
           {metadata ? (
             <div className="mt-4 grid grid-cols-1 gap-3 text-sm md:grid-cols-3">
-              <InfoCard label="Requested Range" value={`${metadata.range.startCreatedAt} to ${metadata.range.endCreatedAt}`} />
+              <InfoCard label="Selected Range" value={`${metadata.range.startCreatedAt} to ${metadata.range.endCreatedAt}`} />
               <InfoCard
                 label="Valid Orders Loaded"
                 value={metadata.uniqueOrders.toLocaleString()}
@@ -499,9 +506,9 @@ export function NabisSalesDashboard() {
                   .join(' · ')}
               />
               <InfoCard
-                label="Local Rows Loaded"
-                value={`${metadata.lineItems.toLocaleString()} synced order row${metadata.lineItems === 1 ? '' : 's'}`}
-                note={metadata.syncLagSeconds != null ? `Sync lag ${Math.max(1, Math.round(metadata.syncLagSeconds / 60))} min` : undefined}
+                label="Cache Coverage"
+                value={metadata.cacheCoverage.fullyCovered ? 'Fully covered' : 'Partial cache'}
+                note={`${metadata.cacheCoverage.cachedOrderCount.toLocaleString()} cached orders · ${metadata.cacheCoverage.cachedLineItemCount.toLocaleString()} cached lines`}
               />
             </div>
           ) : null}
@@ -515,9 +522,15 @@ export function NabisSalesDashboard() {
 
           {metadata?.staleWarning ? <Banner tone="info">{metadata.staleWarning}</Banner> : null}
 
-          {metadata?.partialScan ? (
+          {metadata?.cacheCoverage ? <Banner tone={metadata.cacheCoverage.fullyCovered ? 'info' : 'warning'}>{metadata.cacheCoverage.message}</Banner> : null}
+
+          {metadata?.territorySnapshot.available === false ? (
+            <Banner tone="warning">Territory status cache is unavailable, so customer, VMI, and sampled-lead metrics are hidden until the cache is restored.</Banner>
+          ) : null}
+
+          {metadata?.territorySnapshot.available && metadata.territorySnapshot.syncedAt ? (
             <Banner tone="info">
-              The NY feed is scanned incrementally from newest to oldest. If a broader date range looks incomplete, narrow the window and reload.
+              Store status metrics use the cached territory snapshot from {formatTimestamp(metadata.territorySnapshot.syncedAt)}. Historical VMI status changes are not cached, so New VMI is a current-status proxy.
             </Banner>
           ) : null}
 
@@ -537,9 +550,9 @@ export function NabisSalesDashboard() {
           ) : (
             <>
               <div id="kpi-section" className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-                <KpiCard icon={<DollarSign className="h-7 w-7 text-emerald-600" />} iconBg="bg-emerald-50" label={`Total Revenue (${selectedMonth})`} value={formatCurrency(stats.totalRevenue)} helper="Net sales" />
-                <KpiCard icon={<ShoppingBag className="h-7 w-7 text-blue-600" />} iconBg="bg-blue-50" label={`Total Orders (${selectedMonth})`} value={String(stats.totalOrders)} helper="Valid orders" />
-                <KpiCard icon={<Users className="h-7 w-7 text-indigo-600" />} iconBg="bg-indigo-50" label="Active Sales Reps" value={String(stats.repStats.length)} helper="Contributors" />
+                <KpiCard icon={<DollarSign className="h-7 w-7 text-emerald-600" />} iconBg="bg-emerald-50" label="Total Revenue" value={formatCurrency(stats.totalRevenue)} helper={selectedRangeLabel} />
+                <KpiCard icon={<ShoppingBag className="h-7 w-7 text-blue-600" />} iconBg="bg-blue-50" label="Paid Orders" value={String(stats.totalOrders)} helper="Canceled and transfers excluded" />
+                <KpiCard icon={<Users className="h-7 w-7 text-indigo-600" />} iconBg="bg-indigo-50" label="Active Sales Reps" value={String(stats.activeSalesReps)} helper="With paid orders in range" />
               </div>
 
               <div id="trend-chart-section" className="rounded-[24px] border border-[#dfe3ea] bg-white p-5 shadow-sm">
@@ -575,7 +588,7 @@ export function NabisSalesDashboard() {
 
               <div className="grid gap-6 lg:grid-cols-3">
                 <div id="rep-revenue-chart" className="rounded-[24px] border border-[#dfe3ea] bg-white p-5 shadow-sm lg:col-span-2">
-                  <h2 className="mb-5 text-lg font-semibold text-[#18212d]">Revenue by Sales Rep ({selectedMonth})</h2>
+                  <h2 className="mb-5 text-lg font-semibold text-[#18212d]">Revenue by Sales Rep ({selectedRangeLabel})</h2>
                   <div className="h-[420px] w-full min-w-0">
                     <ResponsiveContainer width="100%" height="100%">
                       <BarChart data={stats.repStats} layout="vertical" margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -598,7 +611,7 @@ export function NabisSalesDashboard() {
                 </div>
 
                 <div id="market-share-card" className="flex min-w-0 flex-col rounded-[24px] border border-[#dfe3ea] bg-white p-5 shadow-sm">
-                  <h2 className="mb-4 text-lg font-semibold text-[#18212d]">Market Share ({selectedMonth})</h2>
+                  <h2 className="mb-4 text-lg font-semibold text-[#18212d]">Rep Share ({selectedRangeLabel})</h2>
                   <div className="mb-6 h-[250px] w-full min-w-0 shrink-0">
                     <ResponsiveContainer width="100%" height="100%">
                       <PieChart>
@@ -635,11 +648,65 @@ export function NabisSalesDashboard() {
                 </div>
               </div>
 
+              <div id="rep-month-metrics-card" className="overflow-hidden rounded-[24px] border border-[#dfe3ea] bg-white shadow-sm">
+                <div className="border-b border-[#e3e7ee] px-5 py-4">
+                  <h2 className="text-lg font-semibold text-[#18212d]">Rep Metrics by Month</h2>
+                  <p className="mt-1 text-sm text-[#5f6773]">VMI is Preferred Partner. Store counts use the cached territory status snapshot; sales and reorders use cached Nabis paid orders.</p>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="min-w-[1180px] divide-y divide-[#e5e7eb]">
+                    <thead className="bg-[#f7f9fc]">
+                      <tr>
+                        {[
+                          'Month',
+                          'Rep',
+                          'Sales',
+                          'Stores',
+                          'New Stores',
+                          'VMI',
+                          'New VMI',
+                          'Non-VMI',
+                          'Non-VMI Reorders',
+                          'Reorder %',
+                          'Sampled Leads',
+                        ].map((label) => (
+                          <th key={label} className={`px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.08em] text-[#6c7480] ${['Sales', 'Stores', 'New Stores', 'VMI', 'New VMI', 'Non-VMI', 'Non-VMI Reorders', 'Reorder %', 'Sampled Leads'].includes(label) ? 'text-right' : ''}`}>
+                            {label}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[#eef1f5] bg-white">
+                      {stats.repMonthlyMetrics.map((row) => (
+                        <tr key={`${row.monthKey}-${row.repName}`}>
+                          <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-[#243040]">{row.monthLabel}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-sm font-semibold text-[#18212d]">{row.repName}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-semibold text-[#18212d]">{formatCurrency(row.salesInTerritory)}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.customerStoreCount.toLocaleString()}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.newStoreCount.toLocaleString()}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.vmiStoreCount.toLocaleString()}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.newVmiStoreCount.toLocaleString()}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.nonVmiStoreCount.toLocaleString()}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.nonVmiReorderCount.toLocaleString()}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-semibold text-[#18212d]">{row.reorderPercent == null ? 'N/A' : `${row.reorderPercent.toFixed(2)}%`}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-[#5f6773]">{row.nonClosedSampledStoreCount.toLocaleString()}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                {stats.dataNotes.length > 0 ? (
+                  <div className="border-t border-[#e3e7ee] bg-[#f9fafc] px-5 py-3 text-xs leading-5 text-[#66707d]">
+                    {stats.dataNotes.join(' ')}
+                  </div>
+                ) : null}
+              </div>
+
               <div className="overflow-hidden rounded-[24px] border border-[#dfe3ea] bg-white shadow-sm">
                 <div className="flex flex-col gap-4 border-b border-[#e3e7ee] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
-                    <h2 className="text-lg font-semibold text-[#18212d]">Order Details ({selectedMonthLabel})</h2>
-                    <p className="mt-1 text-sm text-[#5f6773]">Live order-level view deduplicated from the NY line-item feed.</p>
+                    <h2 className="text-lg font-semibold text-[#18212d]">Order Details ({selectedRangeLabel})</h2>
+                    <p className="mt-1 text-sm text-[#5f6773]">Cached Postgres order-level view deduplicated from the NY line-item feed.</p>
                   </div>
                   <div className={`flex items-center gap-2 ${isGeneratingPDF ? 'hidden' : ''}`}>
                     <input

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -28,7 +28,7 @@ import { SalesTrendChart } from '@/components/dashboard/sales-trend-chart';
 
 const REP_COLORS = ['#1d4ed8', '#2563eb', '#0f766e', '#0284c7', '#7c3aed', '#db2777', '#f97316', '#eab308', '#16a34a', '#475569'];
 const DASHBOARD_SNAPSHOT_TTL_MS = 1000 * 60 * 5;
-const DASHBOARD_SNAPSHOT_KEY_PREFIX = 'picc:nabis-dashboard:v3';
+const DASHBOARD_SNAPSHOT_KEY_PREFIX = 'picc:nabis-dashboard:v4';
 
 type DashboardSnapshot = {
   fetchedAt: number;

--- a/lib/dashboard/nabis-analytics.test.ts
+++ b/lib/dashboard/nabis-analytics.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCacheCoverage,
+  summarizeNabisDashboardAnalytics,
+  type AnalyticsOrder,
+  type AnalyticsTerritoryStore,
+} from '@/lib/dashboard/nabis-analytics';
+
+const orders: AnalyticsOrder[] = [
+  {
+    id: 'march-ben-first',
+    orderNumber: '1001',
+    createdDate: '2026-03-04',
+    status: 'DELIVERED',
+    customerName: 'Albany Wellness',
+    total: 100,
+    salesRep: 'Ben',
+    licensedLocationId: 'NABIS-LOCATION-1',
+  },
+  {
+    id: 'april-ben-reorder',
+    orderNumber: '1002',
+    createdDate: '2026-04-10',
+    status: 'DELIVERED',
+    customerName: 'Albany Wellness',
+    total: 125,
+    salesRep: 'Ben',
+    licensedLocationId: 'NABIS-LOCATION-1',
+  },
+  {
+    id: 'april-ben-territory-order-from-other-sales-rep',
+    orderNumber: '1002-B',
+    createdDate: '2026-04-11',
+    status: 'DELIVERED',
+    customerName: 'Albany Wellness',
+    total: 50,
+    salesRep: 'Mario',
+    licensedLocationId: 'NABIS-LOCATION-1',
+  },
+  {
+    id: 'april-roxy-new-vmi',
+    orderNumber: '1003',
+    createdDate: '2026-04-12',
+    status: 'DELIVERED',
+    customerName: 'Hudson House',
+    total: 250,
+    salesRep: 'Roxy',
+    licensedLocationId: 'NABIS-LOCATION-2',
+  },
+  {
+    id: 'april-canceled',
+    orderNumber: '1004',
+    createdDate: '2026-04-13',
+    status: 'CANCELED',
+    customerName: 'Canceled Shop',
+    total: 999,
+    salesRep: 'Ben',
+    licensedLocationId: 'LIC-4',
+  },
+];
+
+const territoryStores: AnalyticsTerritoryStore[] = [
+  {
+    id: 'store-1',
+    name: 'Albany Wellness',
+    statusKey: 'customer',
+    repNames: ['Ben'],
+    licenseNumber: 'OCM-1',
+    isPreferredPartner: false,
+  },
+  {
+    id: 'store-2',
+    name: 'Hudson House',
+    statusKey: 'customer overdue',
+    repNames: ['Roxy'],
+    licenseNumber: 'OCM-2',
+    isPreferredPartner: true,
+  },
+  {
+    id: 'store-3',
+    name: 'Lead With Samples',
+    statusKey: 'lead',
+    repNames: ['Roxy'],
+    licenseNumber: 'LIC-3',
+    isPreferredPartner: false,
+    lastSampleDeliveryDate: '2026-03-20',
+  },
+];
+
+describe('Nabis dashboard cached analytics', () => {
+  it('summarizes selected-range revenue, monthly trend, and rep/month metrics from cached orders', () => {
+    const summary = summarizeNabisDashboardAnalytics({
+      orders,
+      territoryStores,
+      range: { start: '2026-03-01', end: '2026-04-30' },
+    });
+
+    expect(summary.totalRevenue).toBe(525);
+    expect(summary.totalOrders).toBe(4);
+    expect(summary.monthlyTrend).toEqual([
+      { monthKey: '2026-03', name: 'Mar 2026', revenue: 100, orderCount: 1 },
+      { monthKey: '2026-04', name: 'Apr 2026', revenue: 425, orderCount: 3 },
+    ]);
+    expect(summary.repStats).toEqual([
+      { name: 'Roxy', revenue: 250, orderCount: 1 },
+      { name: 'Ben', revenue: 225, orderCount: 2 },
+      { name: 'Mario', revenue: 50, orderCount: 1 },
+    ]);
+
+    const benApril = summary.repMonthlyMetrics.find((row) => row.repName === 'Ben' && row.monthKey === '2026-04');
+    expect(benApril).toMatchObject({
+      salesInTerritory: 175,
+      customerStoreCount: 1,
+      newStoreCount: 0,
+      vmiStoreCount: 0,
+      nonVmiStoreCount: 1,
+      nonVmiReorderCount: 1,
+      reorderPercent: 100,
+    });
+    const marioApril = summary.repMonthlyMetrics.find((row) => row.repName === 'Mario' && row.monthKey === '2026-04');
+    expect(marioApril).toMatchObject({
+      salesInTerritory: 0,
+      customerStoreCount: 0,
+      nonVmiStoreCount: 0,
+      nonVmiReorderCount: 0,
+      reorderPercent: null,
+    });
+
+    const roxyApril = summary.repMonthlyMetrics.find((row) => row.repName === 'Roxy' && row.monthKey === '2026-04');
+    expect(roxyApril).toMatchObject({
+      salesInTerritory: 250,
+      customerStoreCount: 1,
+      newStoreCount: 1,
+      vmiStoreCount: 1,
+      newVmiStoreCount: 1,
+      nonVmiStoreCount: 0,
+      nonClosedSampledStoreCount: 1,
+    });
+    expect(roxyApril?.dataNotes).toContain('VMI counts use current territory status; historical VMI status changes are not cached.');
+  });
+
+  it('marks requested ranges before the proven cache start as partial coverage', () => {
+    const coverage = buildCacheCoverage({
+      requestedRange: { start: '2025-01-01', end: '2026-05-07' },
+      earliestOrderCreatedAt: '2025-07-02T22:26:28.786Z',
+      latestOrderCreatedAt: '2026-05-07T20:23:36.527Z',
+      cachedOrderCount: 1579,
+      cachedLineItemCount: 27701,
+    });
+
+    expect(coverage.status).toBe('partial-before-cache');
+    expect(coverage.fullyCovered).toBe(false);
+    expect(coverage.message).toContain('starts before the earliest cached Nabis order');
+  });
+});

--- a/lib/dashboard/nabis-analytics.test.ts
+++ b/lib/dashboard/nabis-analytics.test.ts
@@ -38,6 +38,16 @@ const orders: AnalyticsOrder[] = [
     licensedLocationId: 'NABIS-LOCATION-1',
   },
   {
+    id: 'april-unmatched-old-sales-rep',
+    orderNumber: '1002-C',
+    createdDate: '2026-04-15',
+    status: 'DELIVERED',
+    customerName: 'Legacy Shop',
+    total: 75,
+    salesRep: 'Kali',
+    licensedLocationId: 'LEGACY-LOCATION',
+  },
+  {
     id: 'april-roxy-new-vmi',
     orderNumber: '1003',
     createdDate: '2026-04-12',
@@ -95,16 +105,27 @@ describe('Nabis dashboard cached analytics', () => {
       range: { start: '2026-03-01', end: '2026-04-30' },
     });
 
-    expect(summary.totalRevenue).toBe(525);
-    expect(summary.totalOrders).toBe(4);
+    expect(summary.totalRevenue).toBe(600);
+    expect(summary.totalOrders).toBe(5);
     expect(summary.monthlyTrend).toEqual([
       { monthKey: '2026-03', name: 'Mar 2026', revenue: 100, orderCount: 1 },
-      { monthKey: '2026-04', name: 'Apr 2026', revenue: 425, orderCount: 3 },
+      { monthKey: '2026-04', name: 'Apr 2026', revenue: 500, orderCount: 4 },
     ]);
     expect(summary.repStats).toEqual([
       { name: 'Roxy', revenue: 250, orderCount: 1 },
       { name: 'Ben', revenue: 225, orderCount: 2 },
+      { name: 'Kali', revenue: 75, orderCount: 1 },
       { name: 'Mario', revenue: 50, orderCount: 1 },
+    ]);
+
+    expect(summary.repMonthlyMetrics.filter((row) => row.monthKey === '2026-04').map((row) => row.repName)).toEqual([
+      'Ben',
+      'Donovan',
+      'Eric',
+      'Bryce J',
+      'Roxy',
+      'Matt M',
+      'Unassigned',
     ]);
 
     const benApril = summary.repMonthlyMetrics.find((row) => row.repName === 'Ben' && row.monthKey === '2026-04');
@@ -117,9 +138,12 @@ describe('Nabis dashboard cached analytics', () => {
       nonVmiReorderCount: 1,
       reorderPercent: 100,
     });
-    const marioApril = summary.repMonthlyMetrics.find((row) => row.repName === 'Mario' && row.monthKey === '2026-04');
-    expect(marioApril).toMatchObject({
-      salesInTerritory: 0,
+    expect(summary.repMonthlyMetrics.find((row) => row.repName === 'Mario')).toBeUndefined();
+    expect(summary.repMonthlyMetrics.find((row) => row.repName === 'Kali')).toBeUndefined();
+
+    const unassignedApril = summary.repMonthlyMetrics.find((row) => row.repName === 'Unassigned' && row.monthKey === '2026-04');
+    expect(unassignedApril).toMatchObject({
+      salesInTerritory: 75,
       customerStoreCount: 0,
       nonVmiStoreCount: 0,
       nonVmiReorderCount: 0,

--- a/lib/dashboard/nabis-analytics.ts
+++ b/lib/dashboard/nabis-analytics.ts
@@ -3,6 +3,8 @@ import type { DashboardDateRange } from '@/lib/dashboard/nabis-types';
 const CANCELED_STATUSES = new Set(['CANCELED', 'CANCELLED', 'VOID', 'VOIDED', 'REJECTED', 'REFUNDED']);
 const CUSTOMER_STATUS_KEYS = new Set(['customer', 'customer overdue']);
 const HISTORICAL_VMI_NOTE = 'VMI counts use current territory status; historical VMI status changes are not cached.';
+const REP_METRIC_LABELS = ['Ben', 'Donovan', 'Eric', 'Bryce J', 'Roxy', 'Matt M', 'Unassigned'];
+const REP_METRIC_LABEL_SET = new Set(REP_METRIC_LABELS);
 
 export type CacheCoverageStatus = 'empty' | 'covered' | 'partial-before-cache' | 'partial-after-cache' | 'partial-both';
 
@@ -148,8 +150,13 @@ export function formatNabisSalesRep(value: string | null | undefined) {
   return aliases.get(key) ?? (normalized || 'Unassigned');
 }
 
-function repLabelsForStore(store: AnalyticsTerritoryStore) {
-  const labels = [...new Set((store.repNames ?? []).map(formatNabisSalesRep).filter(Boolean))];
+function repMetricLabel(value: string | null | undefined) {
+  const label = formatNabisSalesRep(value);
+  return REP_METRIC_LABEL_SET.has(label) ? label : 'Unassigned';
+}
+
+function repMetricLabelsForStore(store: AnalyticsTerritoryStore) {
+  const labels = [...new Set((store.repNames ?? []).map(repMetricLabel).filter(Boolean))];
   return labels.length > 0 ? labels : ['Unassigned'];
 }
 
@@ -313,7 +320,7 @@ export function summarizeNabisDashboardAnalytics(input: {
     repBucket.orderCount += 1;
     repBuckets.set(repName, repBucket);
 
-    const territoryRepLabels = matchedStore ? repLabelsForStore(matchedStore) : [repName];
+    const territoryRepLabels = matchedStore ? repMetricLabelsForStore(matchedStore) : [repMetricLabel(repName)];
 
     for (const territoryRepLabel of territoryRepLabels) {
       const repMonthKey = `${territoryRepLabel}::${monthKey}`;
@@ -349,7 +356,7 @@ export function summarizeNabisDashboardAnalytics(input: {
 
   for (const store of input.territoryStores) {
     const storeKey = territoryStoreKey(store);
-    const labels = repLabelsForStore(store);
+    const labels = repMetricLabelsForStore(store);
     const customer = isCustomerStore(store);
     const preferred = Boolean(store.isPreferredPartner);
     const hasSampleDelivery = Boolean(store.lastSampleDeliveryDate);
@@ -375,15 +382,9 @@ export function summarizeNabisDashboardAnalytics(input: {
     }
   }
 
-  const repNames = new Set<string>();
-  for (const order of rangeOrders) repNames.add(formatNabisSalesRep(order.salesRep));
-  for (const store of input.territoryStores) {
-    for (const label of repLabelsForStore(store)) repNames.add(label);
-  }
-
   const repMonthlyMetrics: RepMonthlyMetric[] = [];
   for (const monthKey of months) {
-    for (const repName of [...repNames].sort((a, b) => a.localeCompare(b))) {
+    for (const repName of REP_METRIC_LABELS) {
       const repMonthKey = `${repName}::${monthKey}`;
       const sales = repMonthSales.get(repMonthKey) ?? { revenue: 0, orderCount: 0 };
       const nonVmiStoreCount = nonVmiStoresByRep.get(repName)?.size ?? 0;

--- a/lib/dashboard/nabis-analytics.ts
+++ b/lib/dashboard/nabis-analytics.ts
@@ -1,0 +1,427 @@
+import type { DashboardDateRange } from '@/lib/dashboard/nabis-types';
+
+const CANCELED_STATUSES = new Set(['CANCELED', 'CANCELLED', 'VOID', 'VOIDED', 'REJECTED', 'REFUNDED']);
+const CUSTOMER_STATUS_KEYS = new Set(['customer', 'customer overdue']);
+const HISTORICAL_VMI_NOTE = 'VMI counts use current territory status; historical VMI status changes are not cached.';
+
+export type CacheCoverageStatus = 'empty' | 'covered' | 'partial-before-cache' | 'partial-after-cache' | 'partial-both';
+
+export interface AnalyticsOrder {
+  id: string;
+  orderNumber: string;
+  createdDate: string;
+  status: string;
+  customerName: string;
+  total: number;
+  salesRep: string;
+  licensedLocationId: string | null;
+  matchedAccountId?: string | null;
+  matchedAccountName?: string | null;
+  isInternalTransfer?: boolean | null;
+}
+
+export interface AnalyticsTerritoryStore {
+  id: string;
+  name: string;
+  statusKey: string;
+  repNames: string[];
+  licenseNumber?: string | null;
+  licensedLocationId?: string | null;
+  nabisRetailerId?: string | null;
+  isPreferredPartner?: boolean | null;
+  lastSampleOrderDate?: string | null;
+  lastSampleDeliveryDate?: string | null;
+}
+
+export interface MonthlyRevenueTrend {
+  monthKey: string;
+  name: string;
+  revenue: number;
+  orderCount: number;
+}
+
+export interface RepRevenueStat {
+  name: string;
+  revenue: number;
+  orderCount: number;
+}
+
+export interface RepMonthlyMetric {
+  repName: string;
+  monthKey: string;
+  monthLabel: string;
+  salesInTerritory: number;
+  orderCount: number;
+  customerStoreCount: number;
+  newStoreCount: number;
+  vmiStoreCount: number;
+  newVmiStoreCount: number;
+  nonVmiStoreCount: number;
+  nonVmiReorderCount: number;
+  reorderPercent: number | null;
+  nonClosedSampledStoreCount: number;
+  dataNotes: string[];
+}
+
+export interface NabisDashboardAnalytics {
+  totalRevenue: number;
+  totalOrders: number;
+  activeSalesReps: number;
+  monthlyTrend: MonthlyRevenueTrend[];
+  repStats: RepRevenueStat[];
+  repMonthlyMetrics: RepMonthlyMetric[];
+  dataNotes: string[];
+}
+
+export interface CacheCoverage {
+  status: CacheCoverageStatus;
+  fullyCovered: boolean;
+  requestedStart: string;
+  requestedEnd: string;
+  earliestOrderCreatedAt: string | null;
+  latestOrderCreatedAt: string | null;
+  cachedOrderCount: number;
+  cachedLineItemCount: number;
+  message: string;
+}
+
+function toDateKey(value: string | Date | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+function toMonthKey(value: string | Date | null | undefined) {
+  return toDateKey(value)?.slice(0, 7) ?? null;
+}
+
+function monthLabel(monthKey: string) {
+  return new Date(`${monthKey}-15T12:00:00`).toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function addMonths(date: Date, count: number) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + count, 1));
+}
+
+function monthKeysForRange(range: DashboardDateRange) {
+  const start = new Date(`${range.start}T00:00:00.000Z`);
+  const end = new Date(`${range.end}T00:00:00.000Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start > end) {
+    return [];
+  }
+
+  const months: string[] = [];
+  let cursor = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1));
+  const last = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+
+  while (cursor <= last) {
+    months.push(cursor.toISOString().slice(0, 7));
+    cursor = addMonths(cursor, 1);
+  }
+
+  return months;
+}
+
+function normalizeKey(value: string | null | undefined) {
+  return (value ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export function formatNabisSalesRep(value: string | null | undefined) {
+  const normalized = (value ?? '').trim().replace(/\s+/g, ' ');
+  const key = normalized.toLowerCase();
+  const aliases = new Map<string, string>([
+    ['b rosenthal', 'Ben'],
+    ['benjamin rosenthal', 'Ben'],
+    ['bryce', 'Bryce J'],
+    ['bryce johnson', 'Bryce J'],
+    ['donovan snyder', 'Donovan'],
+    ['eric acosta', 'Eric'],
+    ['matthew masi', 'Matt M'],
+    ['matt masi', 'Matt M'],
+    ['mm', 'Matt M'],
+    ['roxy', 'Roxy'],
+  ]);
+  return aliases.get(key) ?? (normalized || 'Unassigned');
+}
+
+function repLabelsForStore(store: AnalyticsTerritoryStore) {
+  const labels = [...new Set((store.repNames ?? []).map(formatNabisSalesRep).filter(Boolean))];
+  return labels.length > 0 ? labels : ['Unassigned'];
+}
+
+function orderMatchingKeys(order: AnalyticsOrder) {
+  return [order.licensedLocationId, order.matchedAccountName, order.customerName].map(normalizeKey).filter(Boolean);
+}
+
+function territoryStoreKey(store: AnalyticsTerritoryStore) {
+  return `territory:${store.id}`;
+}
+
+function orderStoreKey(order: AnalyticsOrder, matchedStore?: AnalyticsTerritoryStore | null) {
+  return (matchedStore ? territoryStoreKey(matchedStore) : null) ?? orderMatchingKeys(order)[0] ?? '';
+}
+
+function storeKeys(store: AnalyticsTerritoryStore) {
+  return [
+    store.id,
+    store.licensedLocationId,
+    store.licenseNumber,
+    store.nabisRetailerId,
+    store.name,
+  ]
+    .map(normalizeKey)
+    .filter(Boolean);
+}
+
+function isCanceledStatus(status: string | null | undefined) {
+  return CANCELED_STATUSES.has(String(status || '').toUpperCase());
+}
+
+function isValidPaidOrder(order: AnalyticsOrder) {
+  return !order.isInternalTransfer && !isCanceledStatus(order.status) && order.total > 0;
+}
+
+function isCustomerStore(store: AnalyticsTerritoryStore) {
+  return CUSTOMER_STATUS_KEYS.has(normalizeKey(store.statusKey));
+}
+
+function isInRange(order: AnalyticsOrder, range: DashboardDateRange) {
+  return order.createdDate >= range.start && order.createdDate <= range.end;
+}
+
+export function buildCacheCoverage(input: {
+  requestedRange: DashboardDateRange;
+  earliestOrderCreatedAt: string | null;
+  latestOrderCreatedAt: string | null;
+  cachedOrderCount: number;
+  cachedLineItemCount: number;
+}): CacheCoverage {
+  const earliest = toDateKey(input.earliestOrderCreatedAt);
+  const latest = toDateKey(input.latestOrderCreatedAt);
+
+  if (!earliest || !latest || input.cachedOrderCount === 0) {
+    return {
+      status: 'empty',
+      fullyCovered: false,
+      requestedStart: input.requestedRange.start,
+      requestedEnd: input.requestedRange.end,
+      earliestOrderCreatedAt: input.earliestOrderCreatedAt,
+      latestOrderCreatedAt: input.latestOrderCreatedAt,
+      cachedOrderCount: input.cachedOrderCount,
+      cachedLineItemCount: input.cachedLineItemCount,
+      message: 'No cached Nabis orders are available yet.',
+    };
+  }
+
+  const startsBeforeCache = input.requestedRange.start < earliest;
+  const endsAfterCache = input.requestedRange.end > latest;
+  const status: CacheCoverageStatus =
+    startsBeforeCache && endsAfterCache
+      ? 'partial-both'
+      : startsBeforeCache
+        ? 'partial-before-cache'
+        : endsAfterCache
+          ? 'partial-after-cache'
+          : 'covered';
+
+  const message =
+    status === 'covered'
+      ? `Cache covers the selected range from ${earliest} through ${latest}.`
+      : status === 'partial-before-cache'
+        ? `Selected range starts before the earliest cached Nabis order (${earliest}); revenue before that date is not included.`
+        : status === 'partial-after-cache'
+          ? `Selected range ends after the latest cached Nabis order (${latest}); newer revenue is not included yet.`
+          : `Selected range extends outside cached Nabis coverage (${earliest} through ${latest}).`;
+
+  return {
+    status,
+    fullyCovered: status === 'covered',
+    requestedStart: input.requestedRange.start,
+    requestedEnd: input.requestedRange.end,
+    earliestOrderCreatedAt: input.earliestOrderCreatedAt,
+    latestOrderCreatedAt: input.latestOrderCreatedAt,
+    cachedOrderCount: input.cachedOrderCount,
+    cachedLineItemCount: input.cachedLineItemCount,
+    message,
+  };
+}
+
+export function summarizeNabisDashboardAnalytics(input: {
+  orders: AnalyticsOrder[];
+  territoryStores: AnalyticsTerritoryStore[];
+  range: DashboardDateRange;
+}): NabisDashboardAnalytics {
+  const validOrders = input.orders.filter(isValidPaidOrder);
+  const rangeOrders = validOrders.filter((order) => isInRange(order, input.range));
+  const months = monthKeysForRange(input.range);
+
+  const storesByKey = new Map<string, AnalyticsTerritoryStore>();
+  for (const store of input.territoryStores) {
+    for (const key of storeKeys(store)) {
+      if (!storesByKey.has(key)) {
+        storesByKey.set(key, store);
+      }
+    }
+  }
+
+  const firstPaidOrderMonthByStore = new Map<string, string>();
+  for (const order of validOrders) {
+    const monthKey = toMonthKey(order.createdDate);
+    if (!monthKey) continue;
+    const matchedStore = orderMatchingKeys(order).map((key) => storesByKey.get(key)).find(Boolean) ?? null;
+    const storeKey = orderStoreKey(order, matchedStore);
+    const current = firstPaidOrderMonthByStore.get(storeKey);
+    if (!current || monthKey < current) {
+      firstPaidOrderMonthByStore.set(storeKey, monthKey);
+    }
+  }
+
+  const monthlyBuckets = new Map<string, MonthlyRevenueTrend>();
+  for (const monthKey of months) {
+    monthlyBuckets.set(monthKey, {
+      monthKey,
+      name: monthLabel(monthKey),
+      revenue: 0,
+      orderCount: 0,
+    });
+  }
+
+  const repBuckets = new Map<string, RepRevenueStat>();
+  const repMonthSales = new Map<string, { revenue: number; orderCount: number }>();
+  const newStoresByRepMonth = new Map<string, Set<string>>();
+  const newVmiStoresByRepMonth = new Map<string, Set<string>>();
+  const nonVmiReordersByRepMonth = new Map<string, Set<string>>();
+
+  for (const order of rangeOrders) {
+    const monthKey = toMonthKey(order.createdDate);
+    if (!monthKey) continue;
+    const repName = formatNabisSalesRep(order.salesRep);
+    const matchedStore = orderMatchingKeys(order).map((key) => storesByKey.get(key)).find(Boolean) ?? null;
+    const storeKey = orderStoreKey(order, matchedStore);
+    const monthBucket = monthlyBuckets.get(monthKey);
+    if (monthBucket) {
+      monthBucket.revenue += order.total;
+      monthBucket.orderCount += 1;
+    }
+
+    const repBucket = repBuckets.get(repName) ?? { name: repName, revenue: 0, orderCount: 0 };
+    repBucket.revenue += order.total;
+    repBucket.orderCount += 1;
+    repBuckets.set(repName, repBucket);
+
+    const territoryRepLabels = matchedStore ? repLabelsForStore(matchedStore) : [repName];
+
+    for (const territoryRepLabel of territoryRepLabels) {
+      const repMonthKey = `${territoryRepLabel}::${monthKey}`;
+      const currentRepMonth = repMonthSales.get(repMonthKey) ?? { revenue: 0, orderCount: 0 };
+      currentRepMonth.revenue += order.total;
+      currentRepMonth.orderCount += 1;
+      repMonthSales.set(repMonthKey, currentRepMonth);
+
+      const firstMonth = storeKey ? firstPaidOrderMonthByStore.get(storeKey) : null;
+      if (storeKey && firstMonth === monthKey) {
+        const current = newStoresByRepMonth.get(repMonthKey) ?? new Set<string>();
+        current.add(storeKey);
+        newStoresByRepMonth.set(repMonthKey, current);
+        if (matchedStore?.isPreferredPartner) {
+          const currentVmi = newVmiStoresByRepMonth.get(repMonthKey) ?? new Set<string>();
+          currentVmi.add(storeKey);
+          newVmiStoresByRepMonth.set(repMonthKey, currentVmi);
+        }
+      }
+
+      if (storeKey && firstMonth && firstMonth < monthKey && matchedStore && !matchedStore.isPreferredPartner) {
+        const current = nonVmiReordersByRepMonth.get(repMonthKey) ?? new Set<string>();
+        current.add(storeKey);
+        nonVmiReordersByRepMonth.set(repMonthKey, current);
+      }
+    }
+  }
+
+  const customerStoresByRep = new Map<string, Set<string>>();
+  const vmiStoresByRep = new Map<string, Set<string>>();
+  const nonVmiStoresByRep = new Map<string, Set<string>>();
+  const sampledLeadStoresByRep = new Map<string, Set<string>>();
+
+  for (const store of input.territoryStores) {
+    const storeKey = territoryStoreKey(store);
+    const labels = repLabelsForStore(store);
+    const customer = isCustomerStore(store);
+    const preferred = Boolean(store.isPreferredPartner);
+    const hasSampleDelivery = Boolean(store.lastSampleDeliveryDate);
+    const hasPaidOrder = firstPaidOrderMonthByStore.has(storeKey);
+
+    for (const label of labels) {
+      if (customer) {
+        const customerSet = customerStoresByRep.get(label) ?? new Set<string>();
+        customerSet.add(storeKey);
+        customerStoresByRep.set(label, customerSet);
+
+        const target = preferred ? vmiStoresByRep : nonVmiStoresByRep;
+        const current = target.get(label) ?? new Set<string>();
+        current.add(storeKey);
+        target.set(label, current);
+      }
+
+      if (!customer && hasSampleDelivery && !hasPaidOrder) {
+        const sampledSet = sampledLeadStoresByRep.get(label) ?? new Set<string>();
+        sampledSet.add(storeKey);
+        sampledLeadStoresByRep.set(label, sampledSet);
+      }
+    }
+  }
+
+  const repNames = new Set<string>();
+  for (const order of rangeOrders) repNames.add(formatNabisSalesRep(order.salesRep));
+  for (const store of input.territoryStores) {
+    for (const label of repLabelsForStore(store)) repNames.add(label);
+  }
+
+  const repMonthlyMetrics: RepMonthlyMetric[] = [];
+  for (const monthKey of months) {
+    for (const repName of [...repNames].sort((a, b) => a.localeCompare(b))) {
+      const repMonthKey = `${repName}::${monthKey}`;
+      const sales = repMonthSales.get(repMonthKey) ?? { revenue: 0, orderCount: 0 };
+      const nonVmiStoreCount = nonVmiStoresByRep.get(repName)?.size ?? 0;
+      const nonVmiReorderCount = nonVmiReordersByRepMonth.get(repMonthKey)?.size ?? 0;
+
+      repMonthlyMetrics.push({
+        repName,
+        monthKey,
+        monthLabel: monthLabel(monthKey),
+        salesInTerritory: Number(sales.revenue.toFixed(2)),
+        orderCount: sales.orderCount,
+        customerStoreCount: customerStoresByRep.get(repName)?.size ?? 0,
+        newStoreCount: newStoresByRepMonth.get(repMonthKey)?.size ?? 0,
+        vmiStoreCount: vmiStoresByRep.get(repName)?.size ?? 0,
+        newVmiStoreCount: newVmiStoresByRepMonth.get(repMonthKey)?.size ?? 0,
+        nonVmiStoreCount,
+        nonVmiReorderCount,
+        reorderPercent: nonVmiStoreCount > 0 ? Number(((nonVmiReorderCount / nonVmiStoreCount) * 100).toFixed(2)) : null,
+        nonClosedSampledStoreCount: sampledLeadStoresByRep.get(repName)?.size ?? 0,
+        dataNotes: [HISTORICAL_VMI_NOTE],
+      });
+    }
+  }
+
+  const totalRevenue = rangeOrders.reduce((sum, order) => sum + order.total, 0);
+
+  return {
+    totalRevenue: Number(totalRevenue.toFixed(2)),
+    totalOrders: rangeOrders.length,
+    activeSalesReps: repBuckets.size,
+    monthlyTrend: [...monthlyBuckets.values()].map((row) => ({
+      ...row,
+      revenue: Number(row.revenue.toFixed(2)),
+    })),
+    repStats: [...repBuckets.values()]
+      .map((row) => ({ ...row, revenue: Number(row.revenue.toFixed(2)) }))
+      .sort((left, right) => right.revenue - left.revenue || left.name.localeCompare(right.name)),
+    repMonthlyMetrics,
+    dataNotes: input.territoryStores.length > 0 ? [HISTORICAL_VMI_NOTE] : ['Territory status cache is unavailable, so VMI/customer/sample store counts are not available.'],
+  };
+}

--- a/lib/dashboard/nabis-client.ts
+++ b/lib/dashboard/nabis-client.ts
@@ -1,5 +1,7 @@
 import type { DashboardDateRange, ProcessedNabisOrder, SerializedNabisOrder } from '@/lib/dashboard/nabis-types';
 
+export type DashboardRangePreset = 'current-month' | 'ytd' | 'trailing-12' | 'custom';
+
 export function formatCurrency(amount: number) {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -16,10 +18,33 @@ export function formatDateInputValue(date: Date) {
 }
 
 export function getDefaultDateRange(): DashboardDateRange {
-  const now = new Date();
+  return getPresetDateRange('current-month');
+}
+
+export function getPresetDateRange(preset: Exclude<DashboardRangePreset, 'custom'>, now = new Date()): DashboardDateRange {
+  const today = formatDateInputValue(now);
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+
+  if (preset === 'ytd') {
+    return {
+      start: `${now.getFullYear()}-01-01`,
+      end: today,
+    };
+  }
+
+  if (preset === 'trailing-12') {
+    const start = new Date(now);
+    start.setMonth(start.getMonth() - 11);
+    start.setDate(1);
+    return {
+      start: formatDateInputValue(start),
+      end: today,
+    };
+  }
+
   return {
-    start: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`,
-    end: formatDateInputValue(now),
+    start: currentMonth,
+    end: today,
   };
 }
 

--- a/lib/dashboard/nabis-server.ts
+++ b/lib/dashboard/nabis-server.ts
@@ -1,11 +1,21 @@
 import 'server-only';
 
 import { prisma } from '@/lib/db/prisma';
+import {
+  buildCacheCoverage,
+  formatNabisSalesRep,
+  summarizeNabisDashboardAnalytics,
+  type AnalyticsOrder,
+  type AnalyticsTerritoryStore,
+} from '@/lib/dashboard/nabis-analytics';
 import { getNabisSyncFreshness, syncNabisOrders } from '@/lib/server/nabis-sync';
+import { readNotionCacheSnapshot } from '@/lib/server/notion-cache-store';
 import { excludedInternalTransferRetailers } from '@/lib/nabis/internal-transfers';
 import type { NabisDashboardMetadata, NabisDashboardResponse, SerializedNabisOrder } from '@/lib/dashboard/nabis-types';
+import type { TerritoryStorePin } from '@/lib/territory/types';
 
 const CANCELED_STATUSES = new Set(['CANCELED', 'CANCELLED', 'VOID', 'VOIDED', 'REJECTED', 'REFUNDED']);
+const TERRITORY_SNAPSHOT_KEY = 'territory-stores-v3';
 
 export function isIsoDate(value: string) {
   return /^\d{4}-\d{2}-\d{2}$/.test(value);
@@ -58,6 +68,95 @@ function staleWarning(syncLagSeconds: number | null) {
   return null;
 }
 
+function isCanceledStatus(status: string | null | undefined) {
+  return CANCELED_STATUSES.has(String(status || '').toUpperCase());
+}
+
+function isValidDashboardOrder(row: { status: string | null; isInternalTransfer: boolean; orderTotal: unknown }) {
+  const total = row.orderTotal ? Number(row.orderTotal) : 0;
+  return !row.isInternalTransfer && !isCanceledStatus(row.status) && total > 0;
+}
+
+function serializeOrder(row: {
+  id: string;
+  externalOrderId: string;
+  orderNumber: string | null;
+  licensedLocationId: string | null;
+  licensedLocationName: string | null;
+  orderCreatedDate: Date | null;
+  status: string | null;
+  isInternalTransfer: boolean;
+  orderTotal: unknown;
+  salesRep: string | null;
+  account: { id: string; name: string } | null;
+}): SerializedNabisOrder {
+  return {
+    id: row.id,
+    orderNumber: row.orderNumber ?? row.externalOrderId,
+    createdDate: toDateKey(row.orderCreatedDate ?? new Date()),
+    status: row.status ?? 'UNKNOWN',
+    customerName: row.licensedLocationName ?? 'Unknown Retailer',
+    total: row.orderTotal ? Number(row.orderTotal) : 0,
+    salesRep: formatNabisSalesRep(row.salesRep),
+    monthKey: toDateKey(row.orderCreatedDate ?? new Date()).slice(0, 7),
+    isCanceled: isCanceledStatus(row.status),
+    licensedLocationId: row.licensedLocationId ?? null,
+    matchedAccountId: row.account?.id ?? null,
+    matchedAccountName: row.account?.name ?? null,
+  };
+}
+
+function toAnalyticsOrder(order: SerializedNabisOrder, input?: { isInternalTransfer?: boolean }): AnalyticsOrder {
+  return {
+    id: order.id,
+    orderNumber: order.orderNumber,
+    createdDate: order.createdDate,
+    status: order.status,
+    customerName: order.customerName,
+    total: order.total,
+    salesRep: order.salesRep,
+    licensedLocationId: order.licensedLocationId,
+    matchedAccountId: order.matchedAccountId,
+    matchedAccountName: order.matchedAccountName,
+    isInternalTransfer: input?.isInternalTransfer ?? false,
+  };
+}
+
+function normalizeCachedTerritoryStores(payload: unknown): TerritoryStorePin[] {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload.filter((row): row is TerritoryStorePin => {
+    return Boolean(row && typeof row === 'object' && typeof (row as { id?: unknown }).id === 'string' && typeof (row as { name?: unknown }).name === 'string');
+  });
+}
+
+function toAnalyticsTerritoryStore(store: TerritoryStorePin): AnalyticsTerritoryStore {
+  return {
+    id: store.id,
+    name: store.name,
+    statusKey: store.statusKey,
+    repNames: Array.isArray(store.repNames) ? store.repNames : [],
+    licenseNumber: store.licenseNumber ?? null,
+    isPreferredPartner: store.isPreferredPartner ?? false,
+    lastSampleOrderDate: store.lastSampleOrderDate ?? null,
+    lastSampleDeliveryDate: store.lastSampleDeliveryDate ?? null,
+  };
+}
+
+async function loadCachedTerritoryStores() {
+  const snapshot = await readNotionCacheSnapshot<TerritoryStorePin[]>(TERRITORY_SNAPSHOT_KEY);
+  const stores = normalizeCachedTerritoryStores(snapshot?.payload);
+
+  return {
+    stores: stores.map(toAnalyticsTerritoryStore),
+    syncedAt: snapshot?.syncedAt ?? null,
+    recordsRead: snapshot?.recordsRead ?? stores.length,
+    available: stores.length > 0,
+  };
+}
+
 export async function getDashboardPayload(input: {
   orgId: string;
   start: string;
@@ -69,19 +168,22 @@ export async function getDashboardPayload(input: {
     await syncNabisOrders(input.orgId, input.actor);
   }
 
+  const orderWhere = {
+    orgId: input.orgId,
+    orderCreatedDate: {
+      lte: endOfDayUtc(input.end),
+    },
+    NOT: excludedInternalTransferRetailers.map((value) => ({
+      licensedLocationName: {
+        equals: value,
+        mode: 'insensitive' as const,
+      },
+    })),
+  };
+
   const rows = await prisma.nabisOrder.findMany({
     where: {
-      orgId: input.orgId,
-      orderCreatedDate: {
-        gte: startOfDayUtc(input.start),
-        lte: endOfDayUtc(input.end),
-      },
-      NOT: excludedInternalTransferRetailers.map((value) => ({
-        licensedLocationName: {
-          equals: value,
-          mode: 'insensitive' as const,
-        },
-      })),
+      ...orderWhere,
     },
     select: {
       id: true,
@@ -104,31 +206,71 @@ export async function getDashboardPayload(input: {
     orderBy: [{ orderCreatedDate: 'desc' }, { externalOrderId: 'desc' }],
   });
 
-  const canceledOrders = rows.filter((row) => CANCELED_STATUSES.has(String(row.status || '').toUpperCase())).length;
-  const internalTransferOrders = rows.filter((row) => row.isInternalTransfer).length;
+  const rangeRows = rows.filter((row) => {
+    const dateKey = row.orderCreatedDate ? toDateKey(row.orderCreatedDate) : null;
+    return Boolean(dateKey && dateKey >= input.start && dateKey <= input.end);
+  });
+  const canceledOrders = rangeRows.filter((row) => isCanceledStatus(row.status)).length;
+  const internalTransferOrders = rangeRows.filter((row) => row.isInternalTransfer).length;
 
-  const orders: SerializedNabisOrder[] = rows
-    .filter((row) => !row.isInternalTransfer && !CANCELED_STATUSES.has(String(row.status || '').toUpperCase()))
-    .map((row) => ({
-      id: row.id,
-      orderNumber: row.orderNumber ?? row.externalOrderId,
-      createdDate: toDateKey(row.orderCreatedDate ?? new Date()),
-      status: row.status ?? 'UNKNOWN',
-      customerName: row.licensedLocationName ?? 'Unknown Retailer',
-      total: row.orderTotal ? Number(row.orderTotal) : 0,
-      salesRep: row.salesRep ?? 'Unassigned',
-      monthKey: toDateKey(row.orderCreatedDate ?? new Date()).slice(0, 7),
-      isCanceled: false,
-      licensedLocationId: row.licensedLocationId ?? null,
-      matchedAccountId: row.account?.id ?? null,
-      matchedAccountName: row.account?.name ?? null,
-    }));
+  const allSerializedOrders = rows.map(serializeOrder);
+  const orders = rangeRows.filter(isValidDashboardOrder).map(serializeOrder);
 
-  const freshness = await getNabisSyncFreshness(input.orgId);
+  const [freshness, territorySnapshot, coverageAggregate, cachedOrderCount, cachedLineItemCount, rangeLineItems] = await Promise.all([
+    getNabisSyncFreshness(input.orgId),
+    loadCachedTerritoryStores(),
+    prisma.nabisOrder.aggregate({
+      where: {
+        orgId: input.orgId,
+      },
+      _min: {
+        orderCreatedDate: true,
+      },
+      _max: {
+        orderCreatedDate: true,
+      },
+    }),
+    prisma.nabisOrder.count({
+      where: {
+        orgId: input.orgId,
+      },
+    }),
+    prisma.nabisOrderLine.count({
+      where: {
+        orgId: input.orgId,
+      },
+    }),
+    prisma.nabisOrderLine.count({
+      where: {
+        orgId: input.orgId,
+        nabisOrder: {
+          orderCreatedDate: {
+            gte: startOfDayUtc(input.start),
+            lte: endOfDayUtc(input.end),
+          },
+        },
+      },
+    }),
+  ]);
+
   const syncLag = secondsSince(freshness.lastOrderSyncAt);
+  const cacheCoverage = buildCacheCoverage({
+    requestedRange: { start: input.start, end: input.end },
+    earliestOrderCreatedAt: coverageAggregate._min.orderCreatedDate?.toISOString() ?? null,
+    latestOrderCreatedAt: coverageAggregate._max.orderCreatedDate?.toISOString() ?? null,
+    cachedOrderCount,
+    cachedLineItemCount,
+  });
+
+  const analytics = summarizeNabisDashboardAnalytics({
+    orders: allSerializedOrders.map((order) => toAnalyticsOrder(order)),
+    territoryStores: territorySnapshot.stores,
+    range: { start: input.start, end: input.end },
+  });
 
   return {
     orders,
+    analytics,
     metadata: {
       fetchedAt: freshness.lastOrderSyncAt ?? new Date().toISOString(),
       dataSource: 'local-postgres',
@@ -139,17 +281,23 @@ export async function getDashboardPayload(input: {
       uniqueOrders: orders.length,
       canceledOrders,
       internalTransferOrders,
-      lineItems: rows.length,
-      totalCount: rows.length,
+      lineItems: rangeLineItems,
+      totalCount: rangeRows.length,
       totalPages: 1,
       pagesScanned: 0,
-      partialScan: false,
+      partialScan: !cacheCoverage.fullyCovered,
       cacheHit: false,
       lastOrderSyncAt: freshness.lastOrderSyncAt,
       lastRetailerSyncAt: freshness.lastRetailerSyncAt,
       lastReconciliationAt: freshness.lastReconciliationAt,
       syncLagSeconds: syncLag,
       staleWarning: staleWarning(syncLag),
+      cacheCoverage,
+      territorySnapshot: {
+        syncedAt: territorySnapshot.syncedAt,
+        recordsRead: territorySnapshot.recordsRead,
+        available: territorySnapshot.available,
+      },
     } satisfies NabisDashboardMetadata,
   } satisfies NabisDashboardResponse;
 }

--- a/lib/dashboard/nabis-types.ts
+++ b/lib/dashboard/nabis-types.ts
@@ -1,3 +1,5 @@
+import type { CacheCoverage, NabisDashboardAnalytics } from '@/lib/dashboard/nabis-analytics';
+
 export interface NabisDashboardMetadata {
   fetchedAt: string;
   dataSource: 'local-postgres';
@@ -19,6 +21,12 @@ export interface NabisDashboardMetadata {
   lastReconciliationAt: string | null;
   syncLagSeconds: number | null;
   staleWarning: string | null;
+  cacheCoverage: CacheCoverage;
+  territorySnapshot: {
+    syncedAt: string | null;
+    recordsRead: number;
+    available: boolean;
+  };
 }
 
 export interface SerializedNabisOrder {
@@ -43,6 +51,7 @@ export interface ProcessedNabisOrder extends Omit<SerializedNabisOrder, 'created
 export interface NabisDashboardResponse {
   orders: SerializedNabisOrder[];
   metadata: NabisDashboardMetadata;
+  analytics: NabisDashboardAnalytics;
 }
 
 export interface DashboardDateRange {


### PR DESCRIPTION
## Summary
- Rebuilds the Nabis sales dashboard around cached Postgres orders by default; live Nabis sync only runs when the user explicitly clicks `Sync Now` with permission.
- Adds interactive range presets for Current Month, YTD, Trailing 12, and custom dates, with selected-range revenue, monthly revenue trend, rep revenue, order drilldowns, CSV export, and PDF export all using the same loaded range.
- Adds cache coverage/freshness UI plus a rep/month metrics table for Sales in Territory, Customers/Overdue stores, New Stores, VMI, New VMI, Non-VMI, Non-VMI Reorders, Reorder %, and sampled leads.

## Scope / Owned Paths
- `app/api/dashboard/**`
- `components/dashboard/**`
- `lib/dashboard/**`
- `SESSION.md`

## Open PR Overlap Check
- Checked open PRs before implementation; no active PR had overlapping owned path globs.
- This remains scoped to issue #45 and does not redo transfer cleanup.

## Data Model / Behavior Notes
- Rep Metrics by Month is intentionally limited to Ben, Donovan, Eric, Bryce J, Roxy, Matt M, and Unassigned; older/off-list reps are rolled into Unassigned for this table.
- Dashboard reads cached Nabis Postgres data by default instead of forcing a live sync.
- Proven cache coverage displayed in UI: `2025-07-02T22:26:28.786Z` through `2026-05-07T20:23:36.527Z`.
- VMI means Preferred Partner in the UI/table.
- Store status metrics use the cached territory snapshot. Historical VMI status changes are not currently cached, so New VMI is a current-status proxy and is labeled as such in the UI.
- Rep/month `Sales` is territory-based when an order can be matched to a cached territory store; the separate rep revenue chart remains Nabis sales-rep based.

## Read-Only Production Proof
- Pulled production env to a temporary file, ran read-only checks, and deleted the temp env files.
- Cached orders: `1,579`
- Cached order lines: `27,701`
- Historical checkpoint: `SUCCESS`
- Local browser/API proof against read-only prod DB in demo mode:
  - Current Month `2026-05-01` to `2026-05-07`: `46` paid orders, `$119,220.60`, cache fully covered.
  - YTD `2026-01-01` to `2026-05-07`: `625` paid orders, `$1,507,815.46`, cache fully covered.
  - YTD rep/month table verified in browser with no reorder percentages over 100% after territory-rep matching fix.

## PDF Reconciliation Notes
- The attached Sales NY Rep Metrics PDF is treated as a manual reconciliation reference, not source of truth.
- May dashboard total through cached orders on `2026-05-07` is `$119,220.60` vs the PDF May total of `$84,550`; likely cutoff/sheet logic needs reconciliation.
- March/April dashboard numbers are now exposed by range and export so we can compare them directly without assuming the sheet is authoritative.

## Validation
- `npm test` -> 7 files / 53 tests passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run build` -> passed
- Browser proof with Playwright against `http://127.0.0.1:3010/dashboard`:
  - Current Month loaded cached dashboard, range controls, cache banners, export/PDF buttons, rep/month table, and order detail drilldown.
  - YTD button interaction loaded `2026-01-01` to `2026-05-07`, monthly trend, rep revenue, cache coverage, and rep/month metrics.

## Remaining Risk
- Final pushed commit CI and Vercel preview checks are green after limiting rep metric rows.
- Historical VMI transitions are not available until that state is cached historically.
- Any final reconciliation to the manual PDF should be handled as a follow-up data audit, not by weakening the cache-backed dashboard logic.