### PR TITLE
fix: use promo-adjusted Nabis order totals

### DIFF
--- a/.agents/skills/distill-issue/SKILL.md
+++ b/.agents/skills/distill-issue/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: distill-issue
+description: Drafts a GitHub issue from a brief description using the project's development-slice template (Problem, Intended Outcome, Non-Goals, Acceptance Criteria, Test Expectations, Architecture Impact, Blockers Or Dependencies). Use whenever a slice is going to be worked on but no issue exists yet, before code, per the AGENTS.md proof gate.
+---
+
+# distill-issue
+
+Turns a brief description of a slice into a properly-structured GitHub issue and files it via `gh`. Returns the URL the agent can paste as the proof-gate linked-issue artifact.
+
+## When to use
+
+- The agent is about to start non-trivial work and there is no GitHub issue yet.
+- A user pastes a chat description of what they want done; the agent runs this skill to capture it as an issue before editing code.
+- A reviewer asks "what issue does this PR close?" and the answer is "I haven't filed one" — file it now.
+
+## When _not_ to use
+
+- For one-line typo fixes, formatting tweaks, or doc-only edits where the PR title and body are sufficient.
+- When the user has already linked an issue.
+- When the work is exploratory and not yet a coherent slice — distill into a brief plan first, then come back here.
+
+## How to invoke
+
+The skill includes a renderer that produces the issue body Markdown. The agent fills in each field, renders, and creates the issue with `gh`.
+
+```bash
+cat <<'EOF' | npx tsx .agents/skills/distill-issue/scripts/render-issue-body.ts
+{
+  "title": "feat(ui): add PDF export of the report card",
+  "labels": ["type:ui", "priority:medium", "red-green-refactor"],
+  "problem": "<one short paragraph>",
+  "intendedOutcome": "<what should be true when this is done>",
+  "nonGoals": ["<bulleted non-goal>", "..."],
+  "acceptanceCriteria": ["<task-list item>", "..."],
+  "testExpectations": "<what tests will be added or updated>",
+  "architectureImpact": "<which boundaries / docs are touched>",
+  "blockers": "None."
+}
+EOF
+```
+
+The renderer prints the issue body to stdout. The agent then files the issue:
+
+```bash
+gh issue create \
+  --repo brycejohnson1417/Picc-web-app \
+  --title "<title>" \
+  --label "<comma-separated-labels>" \
+  --milestone "<milestone-name-if-any>" \
+  --body "$(cat <body-from-renderer>)"
+```
+
+`gh issue create` returns the URL on stdout. Paste that URL into chat as the AGENTS.md linked-issue artifact.
+
+## Field guidance
+
+| Field                | What to write                                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `title`              | Conventional Commits style: `<type>(<scope>): <imperative summary>`. Same shape as the eventual PR title.                        |
+| `labels`             | At least a `type:*` and a `priority:*` label. Add `red-green-refactor` if the slice has behavior that needs failing tests first. |
+| `problem`            | One short paragraph. What is broken or missing today, framed as user-facing impact when possible.                                |
+| `intendedOutcome`    | What is true when the slice is done. Concrete, observable.                                                                       |
+| `nonGoals`           | Bulleted list of things the agent might be tempted to bundle in but should not.                                                  |
+| `acceptanceCriteria` | Task-list items the reviewer will check off. Each should be testable.                                                            |
+| `testExpectations`   | What tests are added/updated. Reference file paths when known.                                                                   |
+| `architectureImpact` | Which directories, ports, schemas, or planning docs this touches. Cross-link to `docs/planning/` or `docs/full-stack-improvement-roadmap.md` if relevant. |
+| `blockers`           | Other issues or decisions this depends on. `None.` is fine.                                                                      |
+
+## Output
+
+The renderer emits the body of the issue. It does not invoke `gh` itself — the agent runs `gh issue create` after seeing the body, so the human can review the draft before it lands on GitHub.
+
+## See also
+
+- [AGENTS.md](../../../AGENTS.md) — the proof gate that consumes this skill's output (`linked issue` artifact).
+- [docs/full-stack-improvement-roadmap.md](../../../docs/full-stack-improvement-roadmap.md) — planning context for architecture-impact notes.
+- [docs/skills.md](../../../docs/skills.md) — skill authoring conventions (frontmatter, naming).

--- a/.agents/skills/distill-issue/scripts/render-issue-body.ts
+++ b/.agents/skills/distill-issue/scripts/render-issue-body.ts
@@ -1,0 +1,149 @@
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type IssueDraft = {
+  readonly title: string;
+  readonly labels: readonly string[];
+  readonly milestone?: string;
+  readonly problem: string;
+  readonly intendedOutcome: string;
+  readonly nonGoals: readonly string[];
+  readonly acceptanceCriteria: readonly string[];
+  readonly testExpectations: string;
+  readonly architectureImpact: string;
+  readonly blockers: string;
+};
+
+export function renderIssueBody(draft: IssueDraft): string {
+  const sections: string[] = [
+    `## Problem`,
+    "",
+    draft.problem.trim(),
+    "",
+    `## Intended Outcome`,
+    "",
+    draft.intendedOutcome.trim(),
+    "",
+    `## Non-Goals`,
+    "",
+    renderBulletList(draft.nonGoals),
+    "",
+    `## Acceptance Criteria`,
+    "",
+    renderTaskList(draft.acceptanceCriteria),
+    "",
+    `## Test Expectations`,
+    "",
+    draft.testExpectations.trim(),
+    "",
+    `## Architecture Impact`,
+    "",
+    draft.architectureImpact.trim(),
+    "",
+    `## Blockers Or Dependencies`,
+    "",
+    draft.blockers.trim() === "" ? "_None_" : draft.blockers.trim(),
+    "",
+  ];
+
+  return sections.join("\n");
+}
+
+function renderBulletList(items: readonly string[]): string {
+  if (items.length === 0) {
+    return "_None_";
+  }
+  return items.map((item) => `- ${item.trim()}`).join("\n");
+}
+
+function renderTaskList(items: readonly string[]): string {
+  if (items.length === 0) {
+    return "- [ ] _no acceptance criteria yet — fill in before this issue can be picked up_";
+  }
+  return items.map((item) => `- [ ] ${item.trim()}`).join("\n");
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+async function main(): Promise<void> {
+  const stdin = await readStdin();
+  if (stdin.trim() === "") {
+    process.stderr.write(
+      "Usage: pipe a JSON IssueDraft to this script's stdin to render an issue body to stdout.\n",
+    );
+    process.exit(2);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdin);
+  } catch (error) {
+    process.stderr.write(
+      `Invalid JSON on stdin: ${(error as Error).message}\n`,
+    );
+    process.exit(2);
+  }
+  if (!isIssueDraft(parsed)) {
+    process.stderr.write(
+      "Stdin JSON does not match IssueDraft shape (title, labels[], problem, intendedOutcome, nonGoals[], acceptanceCriteria[], testExpectations, architectureImpact, blockers).\n",
+    );
+    process.exit(2);
+  }
+  process.stdout.write(renderIssueBody(parsed));
+  process.stdout.write("\n");
+}
+
+function isIssueDraft(value: unknown): value is IssueDraft {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  const stringFields = [
+    "title",
+    "problem",
+    "intendedOutcome",
+    "testExpectations",
+    "architectureImpact",
+    "blockers",
+  ] as const;
+  for (const field of stringFields) {
+    if (typeof obj[field] !== "string") {
+      return false;
+    }
+  }
+  if (!isStringArray(obj.labels)) {
+    return false;
+  }
+  if (!isStringArray(obj.nonGoals)) {
+    return false;
+  }
+  if (!isStringArray(obj.acceptanceCriteria)) {
+    return false;
+  }
+  return true;
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exit(1);
+  });
+}

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: preflight
+description: Audits a fresh clone of this repo for fork-day setup gaps before any code work begins. Verifies gh auth, git remote, branch protection, Vercel project link, lefthook install, Node and package-manager versions against package.json engines, presence of CI workflow files, and optional Claude Code red-green PreToolUse hook wiring when present. Use at the start of every session on an unfamiliar clone, or whenever the AGENTS.md proof gate asks for the preflight artifact.
+---
+
+# preflight
+
+Audits whether a freshly-cloned (or freshly-forked) checkout of this repo is set up for agent-driven development. Each check returns `pass`, `fail`, or `skip` with a remediation hint when it fails. The output goes straight into the chat as the preflight artifact for the AGENTS.md proof gate.
+
+## When to use
+
+- The first time you open this repo on a new machine, in a new container, or after a fork.
+- At the start of any session that's about to land non-trivial code, when you're not certain the workspace is fully set up.
+- Whenever a hook unexpectedly doesn't fire (preflight will tell you whether `.claude/settings.json` and `lefthook` are installed).
+
+## What it checks
+
+| Check                      | What it verifies                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------ |
+| CI workflow files          | `.github/workflows/` exists and contains at least one `.yml`                                           |
+| Claude Code red-green hook | `.claude/settings.json` parses and declares `hooks.PreToolUse` when the checkout provides the file      |
+| lefthook git hooks         | `.git/hooks/pre-commit` exists and looks like a lefthook-managed hook when the repo declares lefthook   |
+| git remote origin          | `git remote get-url origin` returns a URL                                                              |
+| Node version               | current `node` version satisfies `engines.node` from `package.json`                                    |
+| pnpm version               | current `pnpm --version` satisfies `engines.pnpm` when the repo declares one                           |
+| Vercel project link        | `.vercel/project.json` is present (skipped if absent — only relevant when this repo deploys to Vercel) |
+| gh auth status             | `gh auth status` exits 0 (skipped when `PREFLIGHT_SKIP_NETWORK=1`)                                     |
+| main branch protection     | `gh api repos/<owner>/<repo>/branches/main/protection` returns 200 (skipped when no network)           |
+
+## How to run it
+
+From the repo root:
+
+```bash
+npx tsx .agents/skills/preflight/scripts/preflight.ts
+```
+
+Or against a different target directory:
+
+```bash
+npx tsx .agents/skills/preflight/scripts/preflight.ts --target /path/to/clone
+```
+
+Environment variables:
+
+| Variable                   | Effect                                                                    |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `PREFLIGHT_SKIP_NETWORK=1` | Skip the `gh auth` and branch-protection checks (useful in CI or offline) |
+| `PREFLIGHT_NODE_VERSION`   | Override the detected Node version (used by tests)                        |
+| `PREFLIGHT_PNPM_VERSION`   | Override the detected pnpm version (used by tests)                        |
+
+## Output
+
+A Markdown table of `(name, status, detail)` followed by a remediation block listing only the failed checks and what to do about them. The script exits `0` when every check passes or skips, and `1` when at least one check fails.
+
+Paste the entire stdout block into chat as the preflight artifact. The remediation block is the only thing you need to act on.
+
+## When a check fails
+
+The remediation hint tells you the next step. Common cases:
+
+- **Claude Code red-green hook**: if `.claude/settings.json` exists but fails, fix the hook JSON. If the file is absent, the check skips because this repo does not require Claude settings in every clone.
+- **lefthook git hooks**: run the repo's package-manager equivalent of `lefthook install` once if lefthook is configured. If the repo does not declare lefthook, the check skips.
+- **Node/package-manager version**: fix your runtime; use Node 20 or 22 for this repo. Only manage pnpm when `package.json` declares `engines.pnpm`.
+- **gh auth status**: `gh auth login` once.
+- **main branch protection**: only triggers if you have admin access; configure on GitHub.
+- **Vercel project link**: `vercel link` if this repo deploys to Vercel; otherwise the check stays in `skip`.
+
+## See also
+
+- [docs/setup.md](../../../docs/setup.md) — long-form fork-day verification with copy-pasteable commands.
+- [docs/agent-compat.md](../../../docs/agent-compat.md) — cross-agent layout that the Claude hook check expects.
+- [AGENTS.md](../../../AGENTS.md) — the proof gate that consumes this skill's output.

--- a/.agents/skills/preflight/scripts/preflight.ts
+++ b/.agents/skills/preflight/scripts/preflight.ts
@@ -1,0 +1,554 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type CheckStatus = "pass" | "fail" | "skip";
+
+export type CheckResult = {
+  readonly name: string;
+  readonly status: CheckStatus;
+  readonly detail?: string;
+  readonly remediation?: string;
+};
+
+export type RunChecksOptions = {
+  readonly projectDir: string;
+  readonly currentNodeVersion?: string;
+  readonly currentPnpmVersion?: string;
+  readonly skipNetworkChecks?: boolean;
+};
+
+type CheckRunner = (options: RunChecksOptions) => CheckResult;
+
+const CHECKS: readonly CheckRunner[] = [
+  checkCiWorkflows,
+  checkClaudeRedGreenHook,
+  checkLefthookInstalled,
+  checkGitRemote,
+  checkNodeVersion,
+  checkPnpmVersion,
+  checkVercelLink,
+  checkGhAuth,
+  checkBranchProtection,
+];
+
+export function runChecks(options: RunChecksOptions): readonly CheckResult[] {
+  return CHECKS.map((check) => check(options));
+}
+
+function checkCiWorkflows(options: RunChecksOptions): CheckResult {
+  const dir = join(options.projectDir, ".github/workflows");
+  if (!existsSync(dir)) {
+    return {
+      name: "CI workflow files",
+      status: "fail",
+      remediation:
+        "Add a workflow under `.github/workflows/` so quality gate and preview deploy run on every PR.",
+    };
+  }
+  const yamlFiles = readdirSync(dir).filter(
+    (name) => name.endsWith(".yml") || name.endsWith(".yaml"),
+  );
+  if (yamlFiles.length === 0) {
+    return {
+      name: "CI workflow files",
+      status: "fail",
+      detail: ".github/workflows/ exists but contains no .yml files",
+      remediation:
+        "Add at least one workflow file under `.github/workflows/` (e.g., `ci.yml`).",
+    };
+  }
+  return {
+    name: "CI workflow files",
+    status: "pass",
+    detail: `${yamlFiles.length} workflow file(s)`,
+  };
+}
+
+function checkClaudeRedGreenHook(options: RunChecksOptions): CheckResult {
+  const settingsPath = join(options.projectDir, ".claude/settings.json");
+  if (!existsSync(settingsPath)) {
+    return {
+      name: "Claude Code red-green hook",
+      status: "skip",
+      detail: ".claude/settings.json is not present in this checkout",
+      remediation:
+        "If this checkout uses Claude Code hooks, add `.claude/settings.json` with a PreToolUse hook invoking `scripts/red-green-gate.ts`.",
+    };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+  } catch (error) {
+    return {
+      name: "Claude Code red-green hook",
+      status: "fail",
+      detail: `failed to parse .claude/settings.json: ${(error as Error).message}`,
+    };
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !hasPreToolUseHook(parsed)
+  ) {
+    return {
+      name: "Claude Code red-green hook",
+      status: "fail",
+      detail: ".claude/settings.json is missing a PreToolUse hook",
+      remediation:
+        "Add `hooks.PreToolUse` matching `Edit|Write|MultiEdit` to `.claude/settings.json`. See docs/agent-compat.md.",
+    };
+  }
+  return {
+    name: "Claude Code red-green hook",
+    status: "pass",
+    detail: ".claude/settings.json declares a PreToolUse hook",
+  };
+}
+
+function hasPreToolUseHook(value: object): boolean {
+  if (!("hooks" in value)) {
+    return false;
+  }
+  const hooks = (value as { readonly hooks?: unknown }).hooks;
+  if (typeof hooks !== "object" || hooks === null) {
+    return false;
+  }
+  if (!("PreToolUse" in hooks)) {
+    return false;
+  }
+  const preToolUse = (hooks as { readonly PreToolUse?: unknown }).PreToolUse;
+  return Array.isArray(preToolUse) && preToolUse.length > 0;
+}
+
+function checkLefthookInstalled(options: RunChecksOptions): CheckResult {
+  if (!repoDeclaresLefthook(options.projectDir)) {
+    return {
+      name: "lefthook git hooks",
+      status: "skip",
+      detail: "repo does not declare lefthook configuration",
+    };
+  }
+  const hooksDirResult = spawnSync(
+    "git",
+    ["-C", options.projectDir, "rev-parse", "--git-path", "hooks"],
+    { encoding: "utf8" },
+  );
+  if (hooksDirResult.error !== undefined || hooksDirResult.status !== 0) {
+    return {
+      name: "lefthook git hooks",
+      status: "fail",
+      detail: "could not resolve git hooks directory",
+      remediation: "Ensure the project is a git checkout.",
+    };
+  }
+  const rawHooksDir = hooksDirResult.stdout.trim();
+  const hooksDir = isAbsolute(rawHooksDir)
+    ? rawHooksDir
+    : join(options.projectDir, rawHooksDir);
+  const hookPath = join(hooksDir, "pre-commit");
+  if (!existsSync(hookPath)) {
+    return {
+      name: "lefthook git hooks",
+      status: "fail",
+      remediation:
+        "Run the repo's package-manager equivalent of `lefthook install` to install the pre-commit and commit-msg hooks.",
+    };
+  }
+  const content = readFileSync(hookPath, "utf8");
+  if (!/lefthook/i.test(content)) {
+    return {
+      name: "lefthook git hooks",
+      status: "fail",
+      detail:
+        ".git/hooks/pre-commit exists but does not look like a lefthook hook",
+      remediation:
+        "Run the repo's package-manager equivalent of `lefthook install` to overwrite with the lefthook-managed hook.",
+    };
+  }
+  return {
+    name: "lefthook git hooks",
+    status: "pass",
+  };
+}
+
+function repoDeclaresLefthook(projectDir: string): boolean {
+  if (
+    existsSync(join(projectDir, "lefthook.yml")) ||
+    existsSync(join(projectDir, "lefthook.yaml"))
+  ) {
+    return true;
+  }
+  const packageJsonPath = join(projectDir, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return false;
+  }
+  return readFileSync(packageJsonPath, "utf8").includes("lefthook");
+}
+
+function checkGitRemote(options: RunChecksOptions): CheckResult {
+  const result = spawnSync(
+    "git",
+    ["-C", options.projectDir, "remote", "get-url", "origin"],
+    {
+      encoding: "utf8",
+    },
+  );
+  if (result.error !== undefined || result.status !== 0) {
+    return {
+      name: "git remote origin",
+      status: "fail",
+      detail: result.stderr?.trim() ?? "git remote get-url origin failed",
+      remediation:
+        "Add a remote with `git remote add origin <url>` pointing at the GitHub repo.",
+    };
+  }
+  return {
+    name: "git remote origin",
+    status: "pass",
+    detail: result.stdout.trim(),
+  };
+}
+
+function checkNodeVersion(options: RunChecksOptions): CheckResult {
+  const engines = readEngines(options.projectDir);
+  if (engines === undefined) {
+    return {
+      name: "Node version vs engines.node",
+      status: "fail",
+      remediation:
+        "Add a `package.json` at the project root with an `engines.node` constraint.",
+    };
+  }
+  const required = engines.node;
+  if (required === undefined) {
+    return {
+      name: "Node version vs engines.node",
+      status: "skip",
+      detail: "package.json has no engines.node",
+    };
+  }
+  const current = (options.currentNodeVersion ?? process.version).replace(
+    /^v/,
+    "",
+  );
+  if (versionMatches(current, required)) {
+    return {
+      name: "Node version vs engines.node",
+      status: "pass",
+      detail: `${current} satisfies ${required}`,
+    };
+  }
+  return {
+    name: "Node version vs engines.node",
+    status: "fail",
+    detail: `${current} does not satisfy ${required}`,
+    remediation: `Switch Node to ${required} (e.g., \`nvm use\`).`,
+  };
+}
+
+function checkPnpmVersion(options: RunChecksOptions): CheckResult {
+  const engines = readEngines(options.projectDir);
+  if (engines?.pnpm === undefined) {
+    return {
+      name: "pnpm version vs engines.pnpm",
+      status: "skip",
+      detail: "package.json has no engines.pnpm",
+    };
+  }
+  const required = engines.pnpm;
+  const current = options.currentPnpmVersion ?? readPnpmVersion();
+  if (current === undefined) {
+    return {
+      name: "pnpm version vs engines.pnpm",
+      status: "fail",
+      detail: "could not determine pnpm version",
+      remediation: "Install pnpm and ensure it is on PATH.",
+    };
+  }
+  if (versionMatches(current, required)) {
+    return {
+      name: "pnpm version vs engines.pnpm",
+      status: "pass",
+      detail: `${current} satisfies ${required}`,
+    };
+  }
+  return {
+    name: "pnpm version vs engines.pnpm",
+    status: "fail",
+    detail: `${current} does not satisfy ${required}`,
+    remediation: `Install pnpm ${required} (e.g., \`corepack enable\` then \`corepack prepare pnpm@${required} --activate\`).`,
+  };
+}
+
+function checkVercelLink(options: RunChecksOptions): CheckResult {
+  const projectFile = join(options.projectDir, ".vercel/project.json");
+  if (existsSync(projectFile)) {
+    return {
+      name: "Vercel project link",
+      status: "pass",
+      detail: ".vercel/project.json present",
+    };
+  }
+  return {
+    name: "Vercel project link",
+    status: "skip",
+    detail:
+      ".vercel/project.json missing (run `vercel link` if this repo deploys to Vercel)",
+  };
+}
+
+function checkGhAuth(options: RunChecksOptions): CheckResult {
+  if (options.skipNetworkChecks === true) {
+    return {
+      name: "gh auth status",
+      status: "skip",
+      detail: "skipped (PREFLIGHT_SKIP_NETWORK=1)",
+    };
+  }
+  const result = spawnSync("gh", ["auth", "status"], { encoding: "utf8" });
+  if (result.error !== undefined) {
+    return {
+      name: "gh auth status",
+      status: "fail",
+      detail: "gh CLI not installed or not on PATH",
+      remediation: "Install GitHub CLI: https://cli.github.com/",
+    };
+  }
+  if (result.status !== 0) {
+    return {
+      name: "gh auth status",
+      status: "fail",
+      detail: result.stderr?.trim() ?? "gh auth status returned non-zero",
+      remediation: "Run `gh auth login`.",
+    };
+  }
+  return {
+    name: "gh auth status",
+    status: "pass",
+  };
+}
+
+function checkBranchProtection(options: RunChecksOptions): CheckResult {
+  if (options.skipNetworkChecks === true) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "skipped (PREFLIGHT_SKIP_NETWORK=1)",
+    };
+  }
+  const remoteResult = spawnSync(
+    "git",
+    ["-C", options.projectDir, "remote", "get-url", "origin"],
+    { encoding: "utf8" },
+  );
+  if (remoteResult.status !== 0) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "no origin remote",
+    };
+  }
+  const slug = parseGitHubSlug(remoteResult.stdout.trim());
+  if (slug === undefined) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "origin is not a GitHub remote",
+    };
+  }
+  const protection = spawnSync(
+    "gh",
+    ["api", `repos/${slug}/branches/main/protection`],
+    { encoding: "utf8" },
+  );
+  if (protection.error !== undefined) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "gh CLI not installed",
+    };
+  }
+  if (protection.status !== 0) {
+    return {
+      name: "main branch protection",
+      status: "fail",
+      detail:
+        "no branch protection configured on main (or no permission to read it)",
+      remediation:
+        "Configure branch protection on `main` to require PR review and CI checks.",
+    };
+  }
+  return {
+    name: "main branch protection",
+    status: "pass",
+  };
+}
+
+function readEngines(projectDir: string):
+  | {
+      readonly node?: string;
+      readonly pnpm?: string;
+    }
+  | undefined {
+  const packageJsonPath = join(projectDir, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    if (typeof parsed === "object" && parsed !== null && "engines" in parsed) {
+      const engines = (parsed as { readonly engines: unknown }).engines;
+      if (typeof engines === "object" && engines !== null) {
+        const obj = engines as {
+          readonly node?: unknown;
+          readonly pnpm?: unknown;
+        };
+        return {
+          ...(typeof obj.node === "string" && { node: obj.node }),
+          ...(typeof obj.pnpm === "string" && { pnpm: obj.pnpm }),
+        };
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return {};
+}
+
+function readPnpmVersion(): string | undefined {
+  const result = spawnSync("pnpm", ["--version"], { encoding: "utf8" });
+  if (result.error !== undefined || result.status !== 0) {
+    return undefined;
+  }
+  return result.stdout.trim();
+}
+
+function versionMatches(current: string, required: string): boolean {
+  const trimmedRequired = required.trim();
+  if (trimmedRequired.endsWith(".x")) {
+    const major = trimmedRequired.slice(0, -2);
+    const currentMajor = current.split(".")[0] ?? "";
+    return currentMajor === major;
+  }
+  if (/[<>]=?/.test(trimmedRequired)) {
+    return trimmedRequired
+      .split(/\s+/)
+      .filter(Boolean)
+      .every((part) => comparatorMatches(current, part));
+  }
+  return current === trimmedRequired;
+}
+
+function comparatorMatches(current: string, comparator: string): boolean {
+  const match = comparator.match(/^(>=|>|<=|<|=)?\s*(\d+(?:\.\d+){0,2})$/);
+  if (match === null || match[2] === undefined) {
+    return false;
+  }
+  const operator = match[1] ?? "=";
+  const comparison = compareVersions(current, match[2]);
+  switch (operator) {
+    case ">":
+      return comparison > 0;
+    case ">=":
+      return comparison >= 0;
+    case "<":
+      return comparison < 0;
+    case "<=":
+      return comparison <= 0;
+    case "=":
+      return comparison === 0;
+    default:
+      return false;
+  }
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    const diff = leftParts[index]! - rightParts[index]!;
+    if (diff !== 0) {
+      return diff > 0 ? 1 : -1;
+    }
+  }
+  return 0;
+}
+
+function parseVersion(value: string): [number, number, number] {
+  const [major = "0", minor = "0", patch = "0"] = value.replace(/^v/, "").split(".");
+  return [major, minor, patch].map((part) => Number.parseInt(part, 10) || 0) as [number, number, number];
+}
+
+function parseGitHubSlug(remoteUrl: string): string | undefined {
+  const trimmed = remoteUrl.trim();
+  const httpsMatch = trimmed.match(
+    /github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?\/?$/,
+  );
+  if (httpsMatch !== null && httpsMatch[1] !== undefined) {
+    return httpsMatch[1];
+  }
+  return undefined;
+}
+
+function renderMarkdownTable(results: readonly CheckResult[]): string {
+  const lines: string[] = ["| name | status | detail |", "| --- | --- | --- |"];
+  for (const result of results) {
+    const detail = result.detail ?? "";
+    const status = `\`${result.status}\``;
+    lines.push(
+      `| ${escapePipe(result.name)} | ${status} | ${escapePipe(detail)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function escapePipe(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+async function main(): Promise<void> {
+  const targetIdx = process.argv.indexOf("--target");
+  const projectDir =
+    targetIdx >= 0 && process.argv[targetIdx + 1] !== undefined
+      ? process.argv[targetIdx + 1]!
+      : process.cwd();
+  const skipNetwork = process.env.PREFLIGHT_SKIP_NETWORK === "1";
+  const overrideNode = process.env.PREFLIGHT_NODE_VERSION;
+  const overridePnpm = process.env.PREFLIGHT_PNPM_VERSION;
+
+  const results = runChecks({
+    projectDir,
+    skipNetworkChecks: skipNetwork,
+    ...(overrideNode !== undefined && { currentNodeVersion: overrideNode }),
+    ...(overridePnpm !== undefined && { currentPnpmVersion: overridePnpm }),
+  });
+
+  process.stdout.write(`${renderMarkdownTable(results)}\n`);
+
+  const failed = results.filter((r) => r.status === "fail");
+  if (failed.length > 0) {
+    process.stdout.write(
+      `\n${failed.length} check(s) failed. See remediation hints above.\n`,
+    );
+    for (const f of failed) {
+      if (f.remediation !== undefined) {
+        process.stdout.write(`- ${f.name}: ${f.remediation}\n`);
+      }
+    }
+    process.exit(1);
+  }
+  process.stdout.write("\nAll preflight checks passed (or skipped).\n");
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exit(1);
+  });
+}

--- a/.agents/skills/start-slice/SKILL.md
+++ b/.agents/skills/start-slice/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: start-slice
+description: Bootstraps a fresh slice on top of main once an issue exists. Refreshes main, creates a `worktrees/<issue#>-<slug>` worktree, runs `npm ci`, and runs `/preflight` so the AGENTS.md proof artifacts (branch, preflight) drop into chat without manual ceremony. Use right after `/distill-issue` returns an issue URL, or right after picking up an existing issue to begin work.
+---
+
+# start-slice
+
+Walks the agent through the three boilerplate steps at the start of every slice: refresh main, branch into a worktree, run preflight. This produces the branch and preflight artifacts required by AGENTS.md.
+
+## When to use
+
+- Right after `/distill-issue` returns an issue URL.
+- When picking up an existing issue (e.g., grabbing a `priority:high` from the Workshop Refinement milestone).
+- Whenever the agent is about to write code but has not yet branched off main.
+
+## When _not_ to use
+
+- When you're already in a feature branch and just need to update a PR — `git pull --rebase` is the right tool then.
+- For hotfixes that branch from a release tag instead of `main`.
+- For exploratory spikes that won't ship; just `git checkout -b` somewhere and don't worry about worktrees.
+
+## How to invoke
+
+The skill ships a script that plans and executes the steps. Always start with `--dry-run` so the agent can paste the plan into chat for the user to sanity-check before anything runs.
+
+```bash
+npx tsx .agents/skills/start-slice/scripts/start-slice.ts \
+  --issue 143 \
+  --slug workflow-skills \
+  --dry-run
+```
+
+The script refuses to proceed if:
+
+- The current branch is anything other than `main`.
+- The working tree has uncommitted changes.
+- The slug is not lowercase-hyphenated (per the same naming rules as skill names).
+- The issue number is not a positive integer.
+
+When the dry-run output looks right, re-run without `--dry-run`:
+
+```bash
+npx tsx .agents/skills/start-slice/scripts/start-slice.ts \
+  --issue 143 \
+  --slug workflow-skills
+```
+
+The script then:
+
+1. `git fetch origin main`
+2. `git worktree add ../worktrees/<issue#>-<slug> -b <issue#>-<slug> origin/main`
+3. `npm ci` inside the new worktree
+4. `PREFLIGHT_SKIP_NETWORK=1 npx tsx .agents/skills/preflight/scripts/preflight.ts`
+
+After it exits, the agent is in (or should `cd` into) the new worktree and writes the failing test first, per AGENTS.md.
+
+## What "slug" should be
+
+The slug is the human-readable name appended to the issue number. Use lowercase letters, digits, and hyphens, no leading or trailing hyphen, no consecutive hyphens. Match the eventual PR's noun, e.g.:
+
+- Issue 143 → `--slug workflow-skills`
+- Issue 142 → `--slug preflight-skill`
+- Issue 139 → `--slug cross-agent-compat`
+
+Branches end up named `<issue#>-<slug>`, e.g., `143-workflow-skills`. Worktrees end up at `worktrees/<issue#>-<slug>` relative to the repo root.
+
+## Why a worktree, not a branch in-place
+
+- Multiple slices can be in flight simultaneously without `git checkout` thrashing.
+- The Claude Code session that originally landed in `demo/` does not need to switch directories — the new worktree gets its own checkout.
+- Stacked PRs can branch from a sibling worktree without disturbing the main checkout.
+
+The trade-off: each worktree gets its own `node_modules/`, so `npm ci` runs fresh. That's acceptable for keeping slices isolated.
+
+## See also
+
+- [AGENTS.md](../../../AGENTS.md) — the proof gate that consumes branch and preflight artifacts.
+- [`distill-issue`](../distill-issue/SKILL.md) — usually the previous step; produces the issue URL that becomes `--issue`.
+- [`preflight`](../preflight/SKILL.md) — invoked at the end of this skill.
+- [docs/skills.md](../../../docs/skills.md) — skill authoring conventions.

--- a/.agents/skills/start-slice/scripts/start-slice.ts
+++ b/.agents/skills/start-slice/scripts/start-slice.ts
@@ -1,0 +1,204 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type SliceArgs = {
+  readonly issueNumber: number;
+  readonly slug: string;
+};
+
+export type SliceParseResult =
+  | { readonly ok: true; readonly args: SliceArgs }
+  | { readonly ok: false; readonly error: string };
+
+export type SlicePlanInput = {
+  readonly issueNumber: number;
+  readonly slug: string;
+  readonly projectDir: string;
+  readonly currentBranch: string;
+  readonly isWorkingTreeDirty: boolean;
+};
+
+export type SlicePlan =
+  | { readonly canProceed: false; readonly reason: string }
+  | {
+      readonly canProceed: true;
+      readonly worktreePath: string;
+      readonly branchName: string;
+      readonly steps: readonly string[];
+    };
+
+const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+export function parseSliceArgs(argv: readonly string[]): SliceParseResult {
+  const issueIdx = argv.indexOf("--issue");
+  if (issueIdx === -1 || argv[issueIdx + 1] === undefined) {
+    return { ok: false, error: "missing --issue <number>" };
+  }
+  const slugIdx = argv.indexOf("--slug");
+  if (slugIdx === -1 || argv[slugIdx + 1] === undefined) {
+    return { ok: false, error: "missing --slug <kebab-case>" };
+  }
+  const issueRaw = argv[issueIdx + 1]!;
+  const issueNumber = Number.parseInt(issueRaw, 10);
+  if (
+    !Number.isInteger(issueNumber) ||
+    issueNumber <= 0 ||
+    `${issueNumber}` !== issueRaw
+  ) {
+    return {
+      ok: false,
+      error: `invalid --issue value ${JSON.stringify(issueRaw)}; expected a positive integer`,
+    };
+  }
+  const slug = argv[slugIdx + 1]!;
+  if (!SLUG_REGEX.test(slug)) {
+    return {
+      ok: false,
+      error: `invalid --slug value ${JSON.stringify(slug)}; must be lowercase letters, digits, and hyphens, with no leading or trailing hyphen`,
+    };
+  }
+  return { ok: true, args: { issueNumber, slug } };
+}
+
+export function planSlice(input: SlicePlanInput): SlicePlan {
+  if (input.isWorkingTreeDirty) {
+    return {
+      canProceed: false,
+      reason:
+        "working tree has uncommitted changes; commit or stash them before starting a new slice",
+    };
+  }
+  if (input.currentBranch !== "main") {
+    return {
+      canProceed: false,
+      reason: `current branch is ${input.currentBranch}, not main; switch to main and re-run so the new worktree branches from a clean base`,
+    };
+  }
+  const branchName = `${input.issueNumber}-${input.slug}`;
+  const worktreePath = join(input.projectDir, "..", "worktrees", branchName);
+  const steps: readonly string[] = [
+    "git fetch origin main",
+    `git worktree add "${worktreePath}" -b "${branchName}" origin/main`,
+    `cd "${worktreePath}"`,
+    "npm ci",
+    "PREFLIGHT_SKIP_NETWORK=1 npx tsx .agents/skills/preflight/scripts/preflight.ts",
+    "# Now write the failing test FIRST per AGENTS.md proof gate",
+  ];
+  return { canProceed: true, worktreePath, branchName, steps };
+}
+
+function detectCurrentBranch(projectDir: string): string {
+  const result = spawnSync(
+    "git",
+    ["-C", projectDir, "rev-parse", "--abbrev-ref", "HEAD"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to read current branch: ${result.stderr?.trim() ?? "unknown error"}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function detectWorkingTreeDirty(projectDir: string): boolean {
+  const result = spawnSync("git", ["-C", projectDir, "status", "--porcelain"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to read git status: ${result.stderr?.trim() ?? "unknown error"}`,
+    );
+  }
+  return result.stdout.trim().length > 0;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes("--dry-run");
+  const filtered = argv.filter((arg) => arg !== "--dry-run");
+
+  const parsed = parseSliceArgs(filtered);
+  if (!parsed.ok) {
+    process.stderr.write(`${parsed.error}\n`);
+    process.stderr.write(
+      "Usage: node start-slice.ts --issue <number> --slug <kebab-case> [--dry-run]\n",
+    );
+    process.exit(2);
+  }
+
+  const projectDir = process.env.START_SLICE_PROJECT_DIR ?? process.cwd();
+  if (!existsSync(join(projectDir, ".git"))) {
+    process.stderr.write(`${projectDir} is not a git checkout\n`);
+    process.exit(2);
+  }
+
+  const currentBranch = detectCurrentBranch(projectDir);
+  const isWorkingTreeDirty = detectWorkingTreeDirty(projectDir);
+
+  const plan = planSlice({
+    issueNumber: parsed.args.issueNumber,
+    slug: parsed.args.slug,
+    projectDir,
+    currentBranch,
+    isWorkingTreeDirty,
+  });
+
+  if (!plan.canProceed) {
+    process.stderr.write(`Refusing to start slice: ${plan.reason}\n`);
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    process.stdout.write(
+      `Plan for slice ${plan.branchName} at ${plan.worktreePath}:\n\n`,
+    );
+    for (const step of plan.steps) {
+      process.stdout.write(`  ${step}\n`);
+    }
+    process.stdout.write(
+      "\nNo changes made (dry run). Re-run without --dry-run to execute.\n",
+    );
+    return;
+  }
+
+  process.stdout.write(`Starting slice ${plan.branchName}...\n`);
+  let cwd = projectDir;
+  for (const step of plan.steps) {
+    if (step.startsWith("#")) {
+      process.stdout.write(`${step}\n`);
+      continue;
+    }
+    if (step.startsWith("cd ")) {
+      cwd = plan.worktreePath;
+      process.stdout.write(`${step}\n`);
+      continue;
+    }
+    process.stdout.write(`+ ${step}\n`);
+    const result = spawnSync(step, {
+      shell: true,
+      stdio: "inherit",
+      cwd,
+    });
+    if (result.status !== 0) {
+      process.stderr.write(`Step failed (exit ${result.status}): ${step}\n`);
+      process.exit(result.status ?? 1);
+    }
+  }
+  process.stdout.write(
+    `\nWorktree ready at ${plan.worktreePath}.\nNext: write the failing test FIRST per AGENTS.md proof gate.\n`,
+  );
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exit(1);
+  });
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Before PR:
 Fast lane / approval lane:
 
 - Fast-lane PRs may be merged by an agent when scoped, labeled, green, and protected by branch rules. Examples: frontend polish, copy/UI improvements, scoped bug fixes, tests, docs, templates, and non-destructive backend fixes.
+- Tested fast-lane changes should deploy forward without waiting on the user as a bottleneck. Once validation passes, the PR is mergeable, and the change does not fall into the approval lane, the agent may merge and promote/deploy to production, then verify production and report the result.
 - Approval-lane PRs must pause for explicit user approval before merge only when the action is hard to undo or can mutate sensitive production state. Examples: production data writes/backfills, schema migrations, auth/RLS/access-control changes, secrets/env vars, payment logic, destructive deletes, and broad rewrites that replace major architecture rather than surgically fixing it.
 - Approval mechanism: post a PR comment exactly in this form: `@bryce approval requested: <one-sentence reason>`. Do not merge until the user replies `approved` on that PR/comment.
 - Large diff rule: line count and changed-file count are self-review signals, not automatic approval gates. If a PR is large, touches many files, or crosses important boundaries, explain why the scope is still coherent and what extra validation was run.

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -6,10 +6,30 @@ import {
   getRetryDelayMs,
   nabisOrderLineFingerprint,
   pageIsOlderThanCutoff,
+  parseNabisOrderForCache,
   parseNabisOrderLineForCache,
 } from '@/lib/server/nabis-sync';
 
 describe('Nabis sync line cache parsing', () => {
+  it('stores promo-adjusted order totals for NY V2 orders with discounts', () => {
+    const order = parseNabisOrderForCache({
+      id: 'af9c9739-82d6-42fd-81e9-bb2e44fde193',
+      order: '924483',
+      retailer: 'The Emerald - Brooklyn',
+      orderAction: 'DELIVERY_TO_RETAILER',
+      status: 'SCHEDULED',
+      createdTimestamp: '2026-04-27T14:02:00.000Z',
+      orderTotal: '3056.50',
+      creditMemo: 98.54,
+      orderDiscount: '479.00',
+      lineItemDiscount: '0.00',
+      siteLicenseNumber: 'OCM-CAURD-24-000057-D1',
+      retailerId: '6593a111-5c6e-4dcf-861d-3c1333aed04e',
+    });
+
+    expect(order?.orderTotal).toBe(2478.96);
+  });
+
   it('extracts order line detail needed for local PPP savings calculations', () => {
     const line = parseNabisOrderLineForCache({
       id: 'order-id-1',
@@ -34,6 +54,36 @@ describe('Nabis sync line cache parsing', () => {
       itemCategory: 'Pre-roll',
       itemClass: 'Cannabis',
     });
+  });
+
+  it('uses line item discount when Nabis does not provide an after-discount line subtotal', () => {
+    const line = parseNabisOrderLineForCache({
+      id: 'order-id-2',
+      order: '924483',
+      skuCode: 'SOM-1G',
+      units: '10',
+      lineItemSubtotal: '80.00',
+      lineItemDiscount: '20.00',
+      skuPricePerUnit: '8.00',
+      itemClass: 'Cannabis',
+    });
+
+    expect(line?.unitPrice).toBe(6);
+  });
+
+  it('preserves zero-dollar unit price for fully discounted line items', () => {
+    const line = parseNabisOrderLineForCache({
+      id: 'order-id-3',
+      order: '924484',
+      skuCode: 'PROMO-1G',
+      units: '4',
+      lineItemSubtotal: '40.00',
+      lineItemDiscount: '40.00',
+      skuPricePerUnit: '10.00',
+      itemClass: 'Cannabis',
+    });
+
+    expect(line?.unitPrice).toBe(0);
   });
 });
 

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -58,6 +58,8 @@ type NabisOrderApiRow = {
   orderSubtotal?: string | number | null;
   wholesaleValue?: string | number | null;
   creditMemo?: string | number | null;
+  orderDiscount?: string | number | null;
+  lineItemDiscount?: string | number | null;
   lineItemSubtotalAfterDiscount?: string | number | null;
   lineItemSubtotal?: string | number | null;
   orderAction?: string | null;
@@ -390,17 +392,18 @@ function getNetSales(row: NabisOrderApiRow) {
   const orderSubtotal = parseCurrency(row.orderSubtotal);
   const wholesaleValue = parseCurrency(row.wholesaleValue);
   const creditMemo = parseCurrency(row.creditMemo);
+  const orderDiscount = parseCurrency(row.orderDiscount);
 
   if (orderTotal > 0) {
-    return Math.max(0, orderTotal - creditMemo);
+    return Math.max(0, orderTotal - creditMemo - orderDiscount);
   }
 
   if (orderSubtotal > 0) {
-    return Math.max(0, orderSubtotal - creditMemo);
+    return Math.max(0, orderSubtotal - creditMemo - orderDiscount);
   }
 
   if (wholesaleValue > 0) {
-    return Math.max(0, wholesaleValue - creditMemo);
+    return Math.max(0, wholesaleValue - creditMemo - orderDiscount);
   }
 
   return Math.max(0, parseCurrency(row.lineItemSubtotalAfterDiscount || row.lineItemSubtotal));
@@ -434,7 +437,7 @@ function parseRetailerRow(row: NabisRetailerApiRow): ParsedRetailer | null {
   };
 }
 
-function parseOrderRow(row: NabisOrderApiRow): ParsedOrder | null {
+export function parseNabisOrderForCache(row: NabisOrderApiRow): ParsedOrder | null {
   const externalOrderId = compactString(row.id ?? row.order);
   if (!externalOrderId) {
     return null;
@@ -470,9 +473,16 @@ export function parseNabisOrderLineForCache(row: NabisOrderApiRow): ParsedOrderL
   const externalOrderId = compactString(row.id ?? row.order);
   const productName = compactString(row.skuName ?? row.skuDisplayName ?? row.productName ?? row.lineItemProductName ?? row.skuCode ?? row.unitDescription);
   const quantity = parseNumber(row.units ?? row.quantity ?? row.lineItemQuantity);
-  const subtotal = parseCurrency(row.lineItemSubtotalAfterDiscount ?? row.lineItemSubtotal);
+  const rawSubtotalAfterDiscount = row.lineItemSubtotalAfterDiscount;
+  const hasExplicitSubtotal =
+    (rawSubtotalAfterDiscount !== null && rawSubtotalAfterDiscount !== undefined && rawSubtotalAfterDiscount !== '') ||
+    (row.lineItemSubtotal !== null && row.lineItemSubtotal !== undefined && row.lineItemSubtotal !== '');
+  const subtotal =
+    rawSubtotalAfterDiscount !== null && rawSubtotalAfterDiscount !== undefined && rawSubtotalAfterDiscount !== ''
+      ? parseCurrency(rawSubtotalAfterDiscount)
+      : Math.max(0, parseCurrency(row.lineItemSubtotal) - parseCurrency(row.lineItemDiscount));
   const fallbackUnitPrice = parseNumber(row.skuPricePerUnit ?? row.lineItemPricePerUnitAfterDiscount ?? row.pricePerUnit ?? row.unitPrice ?? row.lineItemPricePerUnit);
-  const unitPrice = quantity && quantity > 0 && subtotal > 0 ? subtotal / quantity : fallbackUnitPrice;
+  const unitPrice = quantity && quantity > 0 && hasExplicitSubtotal ? subtotal / quantity : fallbackUnitPrice;
 
   if (!externalOrderId || !productName || !quantity || quantity <= 0 || unitPrice == null || unitPrice < 0) {
     return null;
@@ -834,7 +844,7 @@ async function loadOrdersFromNabis(
     const payload = await fetchNabisPage<NabisOrderApiRow>('/v2/ny/order', page);
     const pageRows = payload.data ?? [];
     const rowsToParse = options?.historicalBackfill ? filterOrderRowsOnOrAfterCutoff(pageRows, cutoff) : pageRows;
-    const parsedRows = rowsToParse.map(parseOrderRow).filter((row): row is ParsedOrder => Boolean(row));
+    const parsedRows = rowsToParse.map(parseNabisOrderForCache).filter((row): row is ParsedOrder => Boolean(row));
     rows.push(...parsedRows);
     pagesScanned += 1;
     recordsRead += pageRows.length;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -446,6 +446,113 @@ async function main() {
     },
   });
 
+  const nabisConnection = await prisma.integrationConnection.create({
+    data: {
+      orgId: org.id,
+      provider: 'NABIS',
+      name: 'Nabis NY V2 API',
+      config: { market: 'NY', mode: 'local-seed' },
+      enabled: true,
+      status: 'SUCCESS',
+      lastSyncedAt: new Date(),
+    },
+  });
+
+  const nabisOrders = [
+    {
+      externalOrderId: 'NY924483',
+      orderNumber: 'NY924483',
+      account: accounts[2],
+      licensedLocationId: 'LIC-NY-924483',
+      licensedLocationName: 'The Emerald - Brooklyn',
+      orderCreatedDate: new Date('2026-05-08T15:30:00.000Z'),
+      status: 'DELIVERED',
+      orderTotal: '2478.96',
+      salesRep: 'Bryce Johnson',
+      lines: [
+        { productName: 'PICC AIO Hybrid 1g', quantity: '120', unitPrice: '12.50', itemCategory: 'Vape' },
+        { productName: 'PICC Gummies 10pk', quantity: '80', unitPrice: '8.12', itemCategory: 'Edible' },
+        { productName: 'PICC Flower Eighth', quantity: '20', unitPrice: '16.52', itemCategory: 'Flower' },
+      ],
+    },
+    {
+      externalOrderId: 'NY924501',
+      orderNumber: 'NY924501',
+      account: accounts[1],
+      licensedLocationId: 'LIC-NY-924501',
+      licensedLocationName: accounts[1].name,
+      orderCreatedDate: new Date('2026-05-07T18:15:00.000Z'),
+      status: 'DELIVERED',
+      orderTotal: '1840.25',
+      salesRep: 'Benjamin Rosenthal',
+      lines: [
+        { productName: 'PICC Mini Preroll 10pk', quantity: '100', unitPrice: '10.75', itemCategory: 'Preroll' },
+        { productName: 'PICC Live Resin AIO', quantity: '45', unitPrice: '17.00', itemCategory: 'Vape' },
+      ],
+    },
+    {
+      externalOrderId: 'NY924522',
+      orderNumber: 'NY924522',
+      account: accounts[6],
+      licensedLocationId: 'LIC-NY-924522',
+      licensedLocationName: accounts[6].name,
+      orderCreatedDate: new Date('2026-05-05T14:45:00.000Z'),
+      status: 'DELIVERED',
+      orderTotal: '3265.40',
+      salesRep: 'Bryce Johnson',
+      lines: [
+        { productName: 'PICC Flower Quarter', quantity: '70', unitPrice: '23.00', itemCategory: 'Flower' },
+        { productName: 'PICC Solventless Rosin', quantity: '60', unitPrice: '27.59', itemCategory: 'Concentrate' },
+      ],
+    },
+    {
+      externalOrderId: 'NY924566',
+      orderNumber: 'NY924566',
+      account: accounts[0],
+      licensedLocationId: 'LIC-NY-924566',
+      licensedLocationName: accounts[0].name,
+      orderCreatedDate: new Date('2026-05-02T16:20:00.000Z'),
+      status: 'DELIVERED',
+      orderTotal: '1295.00',
+      salesRep: 'Avry Aviles',
+      lines: [
+        { productName: 'PICC Gummies 10pk', quantity: '120', unitPrice: '7.25', itemCategory: 'Edible' },
+        { productName: 'PICC Infused Preroll', quantity: '50', unitPrice: '8.50', itemCategory: 'Preroll' },
+      ],
+    },
+  ];
+
+  for (const order of nabisOrders) {
+    const created = await prisma.nabisOrder.create({
+      data: {
+        orgId: org.id,
+        accountId: order.account.id,
+        externalOrderId: order.externalOrderId,
+        orderNumber: order.orderNumber,
+        licensedLocationId: order.licensedLocationId,
+        licensedLocationName: order.licensedLocationName,
+        orderCreatedDate: order.orderCreatedDate,
+        status: order.status,
+        orderTotal: order.orderTotal,
+        paymentStatus: 'PAID',
+        deliveryDate: order.orderCreatedDate,
+        salesRep: order.salesRep,
+      },
+    });
+
+    await prisma.nabisOrderLine.createMany({
+      data: order.lines.map((line) => ({
+        orgId: org.id,
+        nabisOrderId: created.id,
+        externalOrderId: order.externalOrderId,
+        productName: line.productName,
+        quantity: line.quantity,
+        unitPrice: line.unitPrice,
+        itemCategory: line.itemCategory,
+      })),
+    });
+  }
+
   await prisma.syncCheckpoint.create({
     data: {
       orgId: org.id,
@@ -456,6 +563,40 @@ async function main() {
       checksum: 'seed-checksum',
       metadata: { rows: 863 },
     },
+  });
+
+  const syncMetadata = { lastSuccessfulSyncAt: new Date().toISOString(), source: 'local-seed' };
+
+  await prisma.syncCheckpoint.createMany({
+    data: [
+      {
+        orgId: org.id,
+        integrationId: nabisConnection.id,
+        module: 'orders',
+        status: 'SUCCESS',
+        cursor: 'seed-orders-cursor',
+        checksum: 'seed-orders-checksum',
+        metadata: syncMetadata,
+      },
+      {
+        orgId: org.id,
+        integrationId: nabisConnection.id,
+        module: 'retailers',
+        status: 'SUCCESS',
+        cursor: 'seed-retailers-cursor',
+        checksum: 'seed-retailers-checksum',
+        metadata: syncMetadata,
+      },
+      {
+        orgId: org.id,
+        integrationId: nabisConnection.id,
+        module: 'orders_reconcile',
+        status: 'SUCCESS',
+        cursor: 'seed-reconcile-cursor',
+        checksum: 'seed-reconcile-checksum',
+        metadata: syncMetadata,
+      },
+    ],
   });
 
   console.log('Seed complete');


### PR DESCRIPTION
Closes #58

## Why
NY V2 Nabis order data now exposes discount fields that need to be included in the sales dashboard cache path. Without them, dashboard revenue overstates promo-discounted orders such as NY924483.

## What changed
- Subtract `orderDiscount` when storing cached order totals from the Nabis order feed.
- Use `lineItemDiscount` to derive after-discount line item unit price when Nabis omits `lineItemSubtotalAfterDiscount`.
- Add regression coverage for the NY924483 promo-adjusted total and line item discount fallback.
- Add local Nabis seed rows so `/dashboard` can be verified in-browser against local Postgres without Nabis/production access.
- Clean repo agent workflow docs and local `.agents` skills to match npm and the current repo path/remote.
- Update the repo deploy rule so tested fast-lane changes can merge/deploy without waiting on Bryce, while keeping explicit approval for production data writes, schema, auth, secrets, destructive changes, payments, and broad rewrites.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run db:local:setup`
- Browser verified `http://localhost:3011/dashboard` renders 4 seeded Nabis orders, NY924483 at `$2,478.96`, and total revenue `$8,879.61`.

## Not changed
- No production DB write or backfill was run.
- No schema migration.
- No live Nabis sync was triggered.

## Remaining risk
Existing production cached order rows need the normal Nabis sync/reconciliation path to refresh after deploy.