### PR TITLE
fix: prune stale Nabis retailer cache rows

### DIFF
--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -8,6 +8,7 @@ import {
   pageIsOlderThanCutoff,
   parseNabisOrderForCache,
   parseNabisOrderLineForCache,
+  staleNabisRetailerIdsToPrune,
 } from '@/lib/server/nabis-sync';
 
 describe('Nabis sync line cache parsing', () => {
@@ -132,6 +133,21 @@ describe('Nabis sync lease coordination', () => {
       activeHolderId: 'stale-holder',
       activeModule: 'orders_reconcile',
     });
+  });
+});
+
+describe('Nabis retailer cache pruning', () => {
+  it('removes cached retailer rows that no longer appear in the current Nabis retailer feed', () => {
+    expect(
+      staleNabisRetailerIdsToPrune(
+        ['retailer-current', 'brand-stale', ' RETAILER-CASE '],
+        ['retailer-current', 'retailer-case'],
+      ),
+    ).toEqual(['brand-stale']);
+  });
+
+  it('does not prune anything when the current retailer feed is empty or unparsable', () => {
+    expect(staleNabisRetailerIdsToPrune(['retailer-current', 'brand-stale'], [])).toEqual([]);
   });
 });
 

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -437,6 +437,20 @@ function parseRetailerRow(row: NabisRetailerApiRow): ParsedRetailer | null {
   };
 }
 
+export function staleNabisRetailerIdsToPrune(existingLicensedLocationIds: readonly string[], currentLicensedLocationIds: readonly string[]) {
+  const currentIds = new Set(
+    currentLicensedLocationIds.map((licensedLocationId) => normalizeIdentity(licensedLocationId)).filter((value): value is string => Boolean(value)),
+  );
+  if (currentIds.size === 0) {
+    return [];
+  }
+
+  return existingLicensedLocationIds.filter((licensedLocationId) => {
+    const normalized = normalizeIdentity(licensedLocationId);
+    return Boolean(normalized && !currentIds.has(normalized));
+  });
+}
+
 export function parseNabisOrderForCache(row: NabisOrderApiRow): ParsedOrder | null {
   const externalOrderId = compactString(row.id ?? row.order);
   if (!externalOrderId) {
@@ -711,6 +725,7 @@ async function withNabisSyncLease<T>(
 
 async function loadRetailersFromNabis() {
   const rows: ParsedRetailer[] = [];
+  const feedLicensedLocationIds = new Set<string>();
   let page = 0;
 
   while (page < MAX_RETAILER_PAGES) {
@@ -719,17 +734,27 @@ async function loadRetailersFromNabis() {
     }
 
     const payload = await fetchNabisPage<NabisRetailerApiRow>('/v2/ny/retailer', page);
-    const pageRows = (payload.data ?? []).map(parseRetailerRow).filter((row): row is ParsedRetailer => Boolean(row));
+    const rawRows = payload.data ?? [];
+    for (const rawRow of rawRows) {
+      const rawLicensedLocationId = compactString(rawRow.licensedLocationId ?? rawRow.retailerId ?? rawRow.id);
+      if (rawLicensedLocationId) {
+        feedLicensedLocationIds.add(rawLicensedLocationId);
+      }
+    }
+    const pageRows = rawRows.map(parseRetailerRow).filter((row): row is ParsedRetailer => Boolean(row));
     rows.push(...pageRows);
 
-    if (!pageRows.length || payload.nextPage == null || payload.nextPage <= page) {
+    if (!rawRows.length || payload.nextPage == null || payload.nextPage <= page) {
       break;
     }
 
     page = payload.nextPage;
   }
 
-  return rows;
+  return {
+    rows,
+    feedLicensedLocationIds: [...feedLicensedLocationIds],
+  };
 }
 
 export function pageIsOlderThanCutoff(rows: NabisOrderApiRow[], cutoff: Date) {
@@ -1408,7 +1433,30 @@ async function syncNabisRetailersCore(orgId: string, integrationId: string, acto
   const orderBackedStores = new Set(existingOrderIds.map((row) => row.licensedLocationId).filter((value): value is string => Boolean(value)));
 
   return withSyncRun({ orgId, integrationId, module: 'retailers', actor }, async () => {
-    const retailers = await loadRetailersFromNabis();
+    const loadedRetailers = await loadRetailersFromNabis();
+    const retailers = loadedRetailers.rows;
+    const existingRetailers = await prisma.nabisRetailer.findMany({
+      where: { orgId },
+      select: { licensedLocationId: true },
+    });
+    const staleLicensedLocationIds = staleNabisRetailerIdsToPrune(
+      existingRetailers.map((retailer) => retailer.licensedLocationId),
+      loadedRetailers.feedLicensedLocationIds,
+    );
+    const prunedRetailers =
+      staleLicensedLocationIds.length > 0
+        ? (
+            await prisma.nabisRetailer.deleteMany({
+              where: {
+                orgId,
+                licensedLocationId: {
+                  in: staleLicensedLocationIds,
+                },
+              },
+            })
+          ).count
+        : 0;
+
     await prisma.nabisRetailer.deleteMany({
       where: {
         orgId,
@@ -1480,11 +1528,13 @@ async function syncNabisRetailersCore(orgId: string, integrationId: string, acto
       result: {
         retailers: retailers.length,
         upserted,
+        pruned: prunedRetailers,
       },
       recordsIn: retailers.length,
       recordsUpserted: upserted,
       metadata: {
         retailers: retailers.length,
+        prunedRetailers,
         crmMirrored: options?.syncCrm === true,
       },
     };


### PR DESCRIPTION
Closes #60.

## Why
Production had 775 cached Nabis retailers after sync, but a live read-only probe of the current NY `/v2/ny/retailer` endpoint returned 701 rows. The public NY retailer docs still show the legacy CA-compatibility response fields, but the current endpoint now excludes many brand/processor rows that were left behind in our local cache because retailer sync only upserted and never pruned rows removed from Nabis.

Docs checked:
- https://developers.nabis.com/v2/docs/endpoints/ny-retailer-controller-get-ny-retailers/
- https://developers.nabis.com/v2/blog/

## What changed
- Added stale `NabisRetailer` cache pruning inside the Nabis sync boundary.
- Pruning is keyed by current live `licensedLocationId` values from Nabis.
- If the current feed parses empty, pruning is disabled so an API outage cannot wipe the cache.
- Added unit tests for stale brand/non-retailer row pruning and the empty-feed guard.

## What did not change
- No schema changes.
- No Notion CRM mirroring.
- No app account deletion. This only prunes `NabisRetailer` cache rows.
- No order revenue math changes from PR #59.

## Validation
- `npm test -- lib/server/nabis-sync.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Production follow-up after merge
After deploy, rerun production retailer sync with `syncCrm: false` and verify `NabisRetailer` count matches the current NY retailer feed instead of the stale 775 cache count.