### PR TITLE
Fix Nabis dashboard active-sync feedback

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,26 +1,36 @@
-# Session: Issue #45 Nabis Sales Dashboard
+# Session: Issue #64 Nabis Active Sync Feedback
 
 ## Scope
 
-- Rebuild the Nabis sales dashboard around cached Postgres analytics by default.
-- Support current month, YTD, trailing 12 months, and custom date ranges.
-- Show selected-range revenue, historical monthly revenue, sales by rep, and rep/month metrics.
-- Keep selected-range drilldowns, CSV export, and PDF export useful.
-- Show cache coverage, freshness, and partial-cache states clearly.
-- Use the Sales NY Rep Metrics PDF as a reconciliation reference only.
+- Fix the Nabis dashboard feedback shown when a manual refresh collides with an active Nabis sync lease.
+- Keep saved dashboard data visible and explain that the active sync is still running.
+- Make the Settings Nabis sync panel treat HTTP 409 lease refusals as active-sync status instead of generic failures.
+- Separate operational warnings/errors from informational VMI snapshot notes in the dashboard status strip.
 
 ## Out Of Scope
 
-- Redoing transfer cleanup.
-- Production writes, schema changes, destructive operations, or Notion/Nabis writes.
-- Treating the PDF sheet as authoritative.
-- Moving the full rep metrics workflow to Home.
+- Production data writes, schema changes, destructive operations, or Notion writes.
+- Changing Nabis order, line-item, retailer, or promo total sync semantics.
+- Reworking the dashboard analytics or sales metric calculations.
+- Rebuilding the sync architecture.
 
 ## Constraints
 
-- Worktree: `/Users/brycejohnson/Code/worktrees/45-nabis-sales-dashboard`
-- Branch: `codex/45-nabis-sales-dashboard`
-- Issue: `https://github.com/brycejohnson1417/Picc-web-app/issues/45`
-- Draft PR: `https://github.com/brycejohnson1417/Picc-web-app/pull/55`
-- Keep UI components thin and put analytics logic in `lib/dashboard`.
-- Cached Nabis coverage starts at the proven earliest order unless current cache evidence shows otherwise.
+- Worktree: `/Users/brycejohnson/Code/PICC-Web-App`
+- Branch: `codex/64-nabis-active-sync-feedback`
+- Issue: `https://github.com/brycejohnson1417/Picc-web-app/issues/64`
+- Owned path globs:
+  - `app/api/dashboard/route.ts`
+  - `app/api/sync/run/route.ts`
+  - `components/dashboard/nabis-sales-dashboard.tsx`
+  - `components/settings/nabis-sync-admin-panel.tsx`
+  - `lib/server/nabis-sync.ts`
+  - focused tests for the touched modules
+- Checked open PRs: none open at session start.
+
+## Validation Plan
+
+- Add or update focused tests for Nabis sync lease refusal message handling.
+- Run the focused test first.
+- Run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
+- Browser-verify the affected feedback path locally when auth/dev setup allows; otherwise document the blocker and rely on unit/API coverage for this surgical path.

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -28,7 +28,7 @@ import { SalesTrendChart } from '@/components/dashboard/sales-trend-chart';
 
 const REP_COLORS = ['#1d4ed8', '#2563eb', '#0f766e', '#0284c7', '#7c3aed', '#db2777', '#f97316', '#eab308', '#16a34a', '#475569'];
 const DASHBOARD_SNAPSHOT_TTL_MS = 1000 * 60 * 5;
-const DASHBOARD_SNAPSHOT_KEY_PREFIX = 'picc:nabis-dashboard:v4';
+const DASHBOARD_SNAPSHOT_KEY_PREFIX = 'picc:nabis-dashboard:v5';
 
 type DashboardSnapshot = {
   fetchedAt: number;
@@ -505,11 +505,15 @@ export function NabisSalesDashboard() {
                   .filter(Boolean)
                   .join(' · ')}
               />
-              <InfoCard
-                label="Cache Coverage"
-                value={metadata.cacheCoverage.fullyCovered ? 'Fully covered' : 'Partial cache'}
-                note={`${metadata.cacheCoverage.cachedOrderCount.toLocaleString()} cached orders · ${metadata.cacheCoverage.cachedLineItemCount.toLocaleString()} cached lines`}
-              />
+              {metadata.cacheCoverage ? (
+                <InfoCard
+                  label="Cache Coverage"
+                  value={metadata.cacheCoverage.fullyCovered ? 'Fully covered' : 'Partial cache'}
+                  note={`${metadata.cacheCoverage.cachedOrderCount.toLocaleString()} cached orders · ${metadata.cacheCoverage.cachedLineItemCount.toLocaleString()} cached lines`}
+                />
+              ) : (
+                <InfoCard label="Cache Coverage" value="Refreshing metadata" note="Reload the dashboard to update local cache details." />
+              )}
             </div>
           ) : null}
 
@@ -785,11 +789,12 @@ function InfoCard({ label, value, note }: { label: string; value: string; note?:
 
 function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | null; metadata: NabisDashboardMetadata | null; hasOrders: boolean }) {
   const items: Array<{ label: string; value: string; tone: 'warning' | 'info' | 'ok' }> = [];
-  const details: string[] = [];
+  const warnings: string[] = [];
+  const notes: string[] = [];
 
   if (error) {
     items.push({ label: 'Dashboard', value: metadata ? 'Showing saved data' : 'Load issue', tone: 'warning' });
-    details.push(error);
+    warnings.push(error);
   }
 
   if (metadata?.cacheCoverage) {
@@ -801,25 +806,25 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
     });
 
     if (!coverage.fullyCovered || coverage.status === 'empty') {
-      details.push(coverage.message);
+      warnings.push(coverage.message);
     }
   }
 
   if (metadata?.staleWarning) {
     items.push({ label: 'Sync', value: 'Needs attention', tone: 'info' });
-    details.push(metadata.staleWarning);
+    warnings.push(metadata.staleWarning);
   }
 
   if (metadata?.territorySnapshot.available === false) {
     items.push({ label: 'Store status', value: 'Unavailable', tone: 'warning' });
-    details.push('Customer, VMI, and sampled-lead metrics are hidden until the territory cache is restored.');
+    warnings.push('Customer, VMI, and sampled-lead metrics are hidden until the territory cache is restored.');
   } else if (metadata?.territorySnapshot.available && metadata.territorySnapshot.syncedAt) {
     items.push({ label: 'Store status', value: formatTimestamp(metadata.territorySnapshot.syncedAt), tone: 'info' });
-    details.push('VMI is based on the current territory snapshot; historical VMI status changes are not cached.');
+    notes.push('VMI uses the current territory snapshot. Historical VMI status changes are not cached.');
   }
 
   if (metadata?.cacheCoverage.status === 'empty' && !hasOrders) {
-    details.push('This dashboard reads saved Postgres data first; manual refresh only checks Nabis when you explicitly request it.');
+    notes.push('This dashboard reads saved Postgres data first; manual refresh only checks Nabis when you explicitly request it.');
   }
 
   if (items.length === 0) {
@@ -833,7 +838,20 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
           <StatusPill key={`${item.label}:${item.value}`} item={item} />
         ))}
       </div>
-      {details.length > 0 ? <p className="mt-2 leading-5 text-[#68717e]">{Array.from(new Set(details)).join(' ')}</p> : null}
+      {warnings.length > 0 ? (
+        <div className="mt-2 space-y-1 leading-5 text-[#8a4a12]">
+          {Array.from(new Set(warnings)).map((detail) => (
+            <p key={detail}>{detail}</p>
+          ))}
+        </div>
+      ) : null}
+      {notes.length > 0 ? (
+        <div className="mt-2 space-y-1 leading-5 text-[#68717e]">
+          {Array.from(new Set(notes)).map((detail) => (
+            <p key={detail}>{detail}</p>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -823,7 +823,7 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
     notes.push('VMI uses the current territory snapshot. Historical VMI status changes are not cached.');
   }
 
-  if (metadata?.cacheCoverage.status === 'empty' && !hasOrders) {
+  if (metadata?.cacheCoverage?.status === 'empty' && !hasOrders) {
     notes.push('This dashboard reads saved Postgres data first; manual refresh only checks Nabis when you explicitly request it.');
   }
 

--- a/components/settings/nabis-sync-admin-panel.tsx
+++ b/components/settings/nabis-sync-admin-panel.tsx
@@ -118,6 +118,7 @@ export function NabisSyncAdminPanel() {
   const [refreshing, setRefreshing] = useState(false);
   const [runningModule, setRunningModule] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [activeSyncNotice, setActiveSyncNotice] = useState<string | null>(null);
 
   const modules = useMemo(() => {
     const source = status?.modules ?? [];
@@ -125,6 +126,10 @@ export function NabisSyncAdminPanel() {
       .map((module) => source.find((entry) => entry.module === module))
       .filter((entry): entry is SyncModule => Boolean(entry));
   }, [status?.modules]);
+  const activeLease = useMemo(() => modules.find((module) => module.module === 'nabis_global_sync_lease' && module.status === 'RUNNING'), [modules]);
+  const syncControlsLocked = status ? !status.controls.recentOrders.enabled && !status.controls.retailers.enabled && !status.controls.historicalBackfill.enabled : false;
+  const activeLeaseStatus =
+    activeLease && syncControlsLocked ? `${shortModuleLabel(activeLease.activeModule ?? 'nabis sync')} is running. Controls unlock when this sync releases its lease.` : null;
 
   const loadStatus = useCallback(async (mode: 'initial' | 'refresh' = 'refresh') => {
     if (mode === 'initial') {
@@ -133,6 +138,7 @@ export function NabisSyncAdminPanel() {
       setRefreshing(true);
     }
     setError(null);
+    setActiveSyncNotice(null);
     try {
       const response = await fetch('/api/sync/status', { cache: 'no-store' });
       const payload = await response.json().catch(() => ({}));
@@ -155,6 +161,7 @@ export function NabisSyncAdminPanel() {
   async function runSync(module: string, label: string) {
     setRunningModule(module);
     setError(null);
+    setActiveSyncNotice(null);
     try {
       const response = await fetch('/api/sync/run', {
         method: 'POST',
@@ -163,6 +170,13 @@ export function NabisSyncAdminPanel() {
       });
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
+        const message = payload?.error ?? `${label} failed`;
+        if (response.status === 409) {
+          await loadStatus('refresh');
+          setActiveSyncNotice(message);
+          toast.info(message);
+          return;
+        }
         throw new Error(payload?.error ?? `${label} failed`);
       }
       toast.success(`${label} started and completed.`);
@@ -198,6 +212,16 @@ export function NabisSyncAdminPanel() {
       {error ? (
         <div className="rounded-2xl border border-[#f1b8a8] bg-[#fff5f1] px-4 py-3 text-sm text-[#a23b22]">
           {error}
+        </div>
+      ) : null}
+      {activeSyncNotice ? (
+        <div className="rounded-2xl border border-[#b7d4ff] bg-[#f1f7ff] px-4 py-3 text-sm text-[#24518d]">
+          {activeSyncNotice}
+        </div>
+      ) : null}
+      {!activeSyncNotice && activeLeaseStatus ? (
+        <div className="rounded-2xl border border-[#b7d4ff] bg-[#f1f7ff] px-4 py-3 text-sm text-[#24518d]">
+          {activeLeaseStatus}
         </div>
       ) : null}
 

--- a/lib/server/nabis-sync-status.ts
+++ b/lib/server/nabis-sync-status.ts
@@ -160,6 +160,10 @@ export async function getNabisAdminSyncStatus(orgId: string) {
   });
 
   const latestErrorRun = (integration?.syncRuns ?? []).find((run) => run.status === IntegrationSyncStatus.ERROR || run.error);
+  const globalLease = modules.find((module) => module.module === 'nabis_global_sync_lease');
+  const globalLeaseExpiresAt = globalLease?.leaseExpiresAt ? new Date(globalLease.leaseExpiresAt) : null;
+  const globalLeaseHasFutureExpiry = globalLeaseExpiresAt ? !Number.isNaN(globalLeaseExpiresAt.getTime()) && globalLeaseExpiresAt.getTime() > Date.now() : true;
+  const activeGlobalLease = globalLease?.status === IntegrationSyncStatus.RUNNING && globalLeaseHasFutureExpiry;
 
   return {
     integration: integration
@@ -205,17 +209,17 @@ export async function getNabisAdminSyncStatus(orgId: string) {
     })),
     controls: {
       recentOrders: {
-        enabled: true,
+        enabled: !activeGlobalLease,
         module: 'nabis-orders',
         label: 'Refresh Recent Orders',
       },
       retailers: {
-        enabled: true,
+        enabled: !activeGlobalLease,
         module: 'nabis-retailers',
         label: 'Run Retailer Sync',
       },
       historicalBackfill: {
-        enabled: true,
+        enabled: !activeGlobalLease,
         module: 'nabis-historical-backfill',
         label: 'Run Historical Backfill',
         description: 'Runs the next bounded historical batch from 2025-01-01 with the global sync lease, rate-limit pacing, and resumable progress.',

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -3,6 +3,7 @@ import { IntegrationSyncStatus } from '@prisma/client';
 import {
   evaluateNabisSyncLease,
   filterOrderRowsOnOrAfterCutoff,
+  formatNabisSyncLeaseConflictMessage,
   getRetryDelayMs,
   nabisOrderLineFingerprint,
   pageIsOlderThanCutoff,
@@ -110,6 +111,21 @@ describe('Nabis sync lease coordination', () => {
       activeHolderId: 'first-holder',
       activeModule: 'orders',
     });
+  });
+
+  it('formats active lease conflicts as an in-progress sync instead of a moving retry timestamp', () => {
+    const message = formatNabisSyncLeaseConflictMessage({
+      canAcquire: false,
+      reason: 'held',
+      activeHolderId: 'first-holder',
+      activeModule: 'orders',
+      activeRefreshedAt: '2026-05-11T23:35:02.059Z',
+      activeExpiresAt: '2026-05-11T23:36:02.059Z',
+    });
+
+    expect(message).toBe('Nabis order sync is already running. Showing saved data while it finishes; refresh status in a minute.');
+    expect(message).not.toContain('try again after');
+    expect(message).not.toContain('2026-05-11T23:36:02.059Z');
   });
 
   it('stale-recovery lets a new holder acquire an expired lease', () => {

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -185,15 +185,24 @@ type NabisLeaseDecision = {
   activeExpiresAt: string | null;
 };
 
+function syncModuleActionLabel(module: string | null) {
+  if (module === 'orders') return 'order sync';
+  if (module === 'retailers') return 'retailer sync';
+  if (module === 'orders_reconcile') return 'historical reconciliation';
+  if (module === 'orders_historical_backfill') return 'historical backfill';
+  return 'sync';
+}
+
+export function formatNabisSyncLeaseConflictMessage(decision: NabisLeaseDecision) {
+  const syncLabel = syncModuleActionLabel(decision.activeModule);
+  return `Nabis ${syncLabel} is already running. Showing saved data while it finishes; refresh status in a minute.`;
+}
+
 export class NabisSyncLeaseError extends Error {
   readonly statusCode = 409;
 
   constructor(public readonly decision: NabisLeaseDecision) {
-    super(
-      `Nabis sync already running${decision.activeModule ? ` for ${decision.activeModule}` : ''}; try again after ${
-        decision.activeExpiresAt ?? 'the active sync finishes'
-      }`,
-    );
+    super(formatNabisSyncLeaseConflictMessage(decision));
     this.name = 'NabisSyncLeaseError';
   }
 }


### PR DESCRIPTION
## Summary
- changes active Nabis lease conflicts from a generic failure into an in-progress sync message
- separates dashboard operational warnings from informational VMI/current-territory notes
- disables Settings sync controls while a live global Nabis lease is active
- bumps the dashboard session snapshot key and guards missing `cacheCoverage` so stale local browser snapshots cannot crash the dashboard

Closes #64

## Scope
- In scope: Nabis dashboard refresh feedback, sync admin panel conflict handling, lease refusal copy, stale local dashboard snapshot guard, focused tests
- Out of scope: Nabis data writes, schema changes, Notion writes, metric calculation changes, sync architecture rewrites

## Owned Path Globs
- `components/dashboard/nabis-sales-dashboard.tsx`
- `components/settings/nabis-sync-admin-panel.tsx`
- `lib/server/nabis-sync.ts`
- `lib/server/nabis-sync-status.ts`
- `lib/server/nabis-sync.test.ts`
- `SESSION.md`

## Parallel Safety
- Checked open PRs: none open when claimed.
- Label: `parallel:ok` because no other active PR owned these paths.

## Validation
- [x] `npm test -- lib/server/nabis-sync.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] Browser verification at `http://127.0.0.1:3010/dashboard`: dashboard rendered, no framework overlay after server restart, `Trailing 12` interaction updated the selected range

## Production Proof
- Read-only production check showed the user-reported sync completed successfully at `2026-05-11T23:35:19Z`; no production writes in this PR.

## Remaining Risk
- The exact active-lease UI state is covered by the lease-conflict unit test and status handling code, not by a live production write/re-run.