### PR TITLE
Enable scheduled Nabis retailer CRM mirroring

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -7,6 +7,7 @@
 - Enable the scheduled Nabis cron to mirror newly discovered retailers into the Dispensary Master List CRM.
 - Make manual dashboard refresh run retailer + order sync with CRM mirroring so new Nabis retailers are added to the app cache and Dispensary Master List.
 - Add an explicit admin UI control for manual retailer/all sync CRM mirroring.
+- Keep CRM mirroring create-only: match existing CRM pages by `Licensed Location ID`, link local accounts to existing pages, and do not patch existing CRM properties.
 - Keep the existing Nabis lease and order sync behavior intact.
 
 ## Out Of Scope

--- a/SESSION.md
+++ b/SESSION.md
@@ -5,6 +5,7 @@
 
 ## Scope
 - Enable the scheduled Nabis cron to mirror newly discovered retailers into the Dispensary Master List CRM.
+- Make manual dashboard refresh run retailer + order sync with CRM mirroring so new Nabis retailers are added to the app cache and Dispensary Master List.
 - Add an explicit admin UI control for manual retailer/all sync CRM mirroring.
 - Keep the existing Nabis lease and order sync behavior intact.
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,36 +1,27 @@
-# Session: Issue #64 Nabis Active Sync Feedback
+# Session: Issue #66 Nabis Scheduled CRM Mirroring
+
+## Issue
+- https://github.com/brycejohnson1417/Picc-web-app/issues/66
 
 ## Scope
-
-- Fix the Nabis dashboard feedback shown when a manual refresh collides with an active Nabis sync lease.
-- Keep saved dashboard data visible and explain that the active sync is still running.
-- Make the Settings Nabis sync panel treat HTTP 409 lease refusals as active-sync status instead of generic failures.
-- Separate operational warnings/errors from informational VMI snapshot notes in the dashboard status strip.
+- Enable the scheduled Nabis cron to mirror newly discovered retailers into the Dispensary Master List CRM.
+- Add an explicit admin UI control for manual retailer/all sync CRM mirroring.
+- Keep the existing Nabis lease and order sync behavior intact.
 
 ## Out Of Scope
-
-- Production data writes, schema changes, destructive operations, or Notion writes.
-- Changing Nabis order, line-item, retailer, or promo total sync semantics.
-- Reworking the dashboard analytics or sales metric calculations.
-- Rebuilding the sync architecture.
+- No schema migration.
+- No Nabis write API usage.
+- No review-required Notion overwrites from the CSV preview.
+- No duplicate page archiving.
+- No order sync semantic changes.
+- No Google Maps fix in this branch; tracked separately in issue #67.
 
 ## Constraints
-
-- Worktree: `/Users/brycejohnson/Code/PICC-Web-App`
-- Branch: `codex/64-nabis-active-sync-feedback`
-- Issue: `https://github.com/brycejohnson1417/Picc-web-app/issues/64`
-- Owned path globs:
-  - `app/api/dashboard/route.ts`
-  - `app/api/sync/run/route.ts`
-  - `components/dashboard/nabis-sales-dashboard.tsx`
-  - `components/settings/nabis-sync-admin-panel.tsx`
-  - `lib/server/nabis-sync.ts`
-  - focused tests for the touched modules
-- Checked open PRs: none open at session start.
+- Approval-lane before merge because scheduled production Notion writes are enabled.
+- Do not print secrets or run production cron manually without explicit approval.
+- Keep the change surgical and revertable.
 
 ## Validation Plan
-
-- Add or update focused tests for Nabis sync lease refusal message handling.
-- Run the focused test first.
-- Run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
-- Browser-verify the affected feedback path locally when auth/dev setup allows; otherwise document the blocker and rely on unit/API coverage for this surgical path.
+- RED test first for Nabis sync option selection.
+- Focused unit test after implementation.
+- Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` before completion.

--- a/app/api/cron/nabis-sync/route.ts
+++ b/app/api/cron/nabis-sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getSharedWorkspaceId } from '@/lib/auth/access-policy';
+import { nabisCronSyncOptions } from '@/lib/server/nabis-sync-options';
 import { NabisSyncLeaseError, syncNabisRetailersAndOrders } from '@/lib/server/nabis-sync';
 
 export const dynamic = 'force-dynamic';
@@ -26,9 +27,7 @@ export async function GET(request: Request) {
     {
       email: 'vercel-cron@piccplatform.com',
     },
-    {
-      syncCrm: false,
-    },
+    nabisCronSyncOptions(),
   ).then(
     (value) => ({ ok: true as const, value }),
     (error: unknown) => ({ ok: false as const, error }),

--- a/app/api/sync/run/route.ts
+++ b/app/api/sync/run/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { guard } from '@/lib/auth/api-guard';
 import { prisma } from '@/lib/db/prisma';
+import { nabisManualSyncOptions } from '@/lib/server/nabis-sync-options';
 import { NabisSyncLeaseError, syncNabisOrders, syncNabisRetailersAndOrders, syncNabisRetailersWithOptions } from '@/lib/server/nabis-sync';
 
 export async function POST(req: Request) {
@@ -9,6 +10,7 @@ export async function POST(req: Request) {
 
   const body = await req.json().catch(() => ({}));
   const syncModule = body.module || 'all';
+  const crmOptions = nabisManualSyncOptions(syncModule, body);
   const actor = {
     clerkUserId: ctx.userId,
     email: ctx.email,
@@ -24,12 +26,12 @@ export async function POST(req: Request) {
         });
       }
       if (syncModule === 'nabis-orders') {
-        return syncNabisRetailersAndOrders(ctx.orgId, actor, { reconciliation: false, syncCrm: false });
+        return syncNabisRetailersAndOrders(ctx.orgId, actor, { reconciliation: false, syncCrm: crmOptions.syncCrm });
       }
       if (syncModule === 'nabis-retailers') {
-        return syncNabisRetailersWithOptions(ctx.orgId, actor, { syncCrm: false });
+        return syncNabisRetailersWithOptions(ctx.orgId, actor, crmOptions);
       }
-      return syncNabisRetailersAndOrders(ctx.orgId, actor, { reconciliation: body.reconciliation === true, syncCrm: false });
+      return syncNabisRetailersAndOrders(ctx.orgId, actor, { reconciliation: body.reconciliation === true, syncCrm: crmOptions.syncCrm });
     };
 
     const result = await run().catch((error: unknown) => {

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -463,7 +463,7 @@ export function NabisSalesDashboard() {
                   className="inline-flex items-center justify-center rounded-xl border border-[#d3d9e2] bg-white px-4 py-2.5 text-sm font-semibold text-[#243040] shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                  Sync Now
+                  Sync Orders + Retailers
                 </button>
               </div>
 
@@ -824,7 +824,7 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
   }
 
   if (metadata?.cacheCoverage?.status === 'empty' && !hasOrders) {
-    notes.push('This dashboard reads saved Postgres data first; manual refresh only checks Nabis when you explicitly request it.');
+    notes.push('This dashboard reads saved Postgres data first; manual refresh syncs Nabis orders, local retailer records, and missing CRM retailer pages.');
   }
 
   if (items.length === 0) {

--- a/components/settings/nabis-sync-admin-panel.tsx
+++ b/components/settings/nabis-sync-admin-panel.tsx
@@ -119,6 +119,7 @@ export function NabisSyncAdminPanel() {
   const [runningModule, setRunningModule] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeSyncNotice, setActiveSyncNotice] = useState<string | null>(null);
+  const [mirrorRetailersToCrm, setMirrorRetailersToCrm] = useState(false);
 
   const modules = useMemo(() => {
     const source = status?.modules ?? [];
@@ -162,11 +163,12 @@ export function NabisSyncAdminPanel() {
     setRunningModule(module);
     setError(null);
     setActiveSyncNotice(null);
+    const syncCrm = module === 'nabis-retailers' && mirrorRetailersToCrm;
     try {
       const response = await fetch('/api/sync/run', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ module }),
+        body: JSON.stringify({ module, syncCrm }),
       });
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
@@ -280,6 +282,21 @@ export function NabisSyncAdminPanel() {
             ))}
           </div>
 
+          <label className="flex items-start gap-3 rounded-2xl border border-[#d6dae2] bg-[#f7f9fc] px-4 py-4">
+            <input
+              type="checkbox"
+              checked={mirrorRetailersToCrm}
+              onChange={(event) => setMirrorRetailersToCrm(event.currentTarget.checked)}
+              className="mt-1 h-4 w-4 rounded border-[#aeb6c4] text-[#1d5eea] accent-[#1d5eea]"
+            />
+            <span>
+              <span className="block text-[15px] font-semibold text-[#1d1f23]">Mirror new Nabis retailers to CRM during manual retailer sync</span>
+              <span className="mt-1 block text-sm text-[#5c6674]">
+                Daily cron already creates missing Dispensary Master List pages from Nabis. Turn this on only when manually running retailer sync and you want the same CRM mirroring.
+              </span>
+            </span>
+          </label>
+
           <div className="grid gap-3 xl:grid-cols-3">
             <SyncActionButton
               icon={<RefreshCw className="h-4 w-4" />}
@@ -292,7 +309,7 @@ export function NabisSyncAdminPanel() {
             <SyncActionButton
               icon={<Store className="h-4 w-4" />}
               title={status.controls.retailers.label}
-              description="Refreshes local Nabis retailer records without CRM mirroring."
+              description={mirrorRetailersToCrm ? 'Refreshes local retailer records and creates missing CRM pages from Nabis.' : 'Refreshes local Nabis retailer records without CRM mirroring.'}
               disabled={!status.controls.retailers.enabled || Boolean(runningModule)}
               loading={runningModule === status.controls.retailers.module}
               onClick={() => void runSync(status.controls.retailers.module, status.controls.retailers.label)}

--- a/lib/dashboard/nabis-server.ts
+++ b/lib/dashboard/nabis-server.ts
@@ -8,7 +8,8 @@ import {
   type AnalyticsOrder,
   type AnalyticsTerritoryStore,
 } from '@/lib/dashboard/nabis-analytics';
-import { getNabisSyncFreshness, syncNabisOrders } from '@/lib/server/nabis-sync';
+import { getNabisSyncFreshness, syncNabisRetailersAndOrders } from '@/lib/server/nabis-sync';
+import { nabisDashboardRefreshSyncOptions } from '@/lib/server/nabis-sync-options';
 import { readNotionCacheSnapshot } from '@/lib/server/notion-cache-store';
 import { excludedInternalTransferRetailers } from '@/lib/nabis/internal-transfers';
 import type { NabisDashboardMetadata, NabisDashboardResponse, SerializedNabisOrder } from '@/lib/dashboard/nabis-types';
@@ -165,7 +166,7 @@ export async function getDashboardPayload(input: {
   actor?: { clerkUserId?: string | null; email?: string | null };
 }) {
   if (input.forceRefresh) {
-    await syncNabisOrders(input.orgId, input.actor);
+    await syncNabisRetailersAndOrders(input.orgId, input.actor, nabisDashboardRefreshSyncOptions());
   }
 
   const orderWhere = {

--- a/lib/server/nabis-sync-options.test.ts
+++ b/lib/server/nabis-sync-options.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { nabisCronSyncOptions, nabisManualSyncOptions } from '@/lib/server/nabis-sync-options';
+import { nabisCronSyncOptions, nabisDashboardRefreshSyncOptions, nabisManualSyncOptions } from '@/lib/server/nabis-sync-options';
 
 describe('Nabis sync CRM mirroring options', () => {
   it('enables CRM mirroring for scheduled cron retailer syncs', () => {
     expect(nabisCronSyncOptions()).toEqual({ syncCrm: true });
+  });
+
+  it('enables CRM mirroring when the dashboard manually refreshes Nabis data', () => {
+    expect(nabisDashboardRefreshSyncOptions()).toEqual({ reconciliation: false, syncCrm: true });
   });
 
   it('keeps manual admin syncs local-only unless CRM mirroring is explicitly requested', () => {

--- a/lib/server/nabis-sync-options.test.ts
+++ b/lib/server/nabis-sync-options.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { nabisCronSyncOptions, nabisManualSyncOptions } from '@/lib/server/nabis-sync-options';
+
+describe('Nabis sync CRM mirroring options', () => {
+  it('enables CRM mirroring for scheduled cron retailer syncs', () => {
+    expect(nabisCronSyncOptions()).toEqual({ syncCrm: true });
+  });
+
+  it('keeps manual admin syncs local-only unless CRM mirroring is explicitly requested', () => {
+    expect(nabisManualSyncOptions('nabis-retailers', {})).toEqual({ syncCrm: false });
+    expect(nabisManualSyncOptions('nabis-retailers', { syncCrm: true })).toEqual({ syncCrm: true });
+    expect(nabisManualSyncOptions('nabis-orders', { syncCrm: true })).toEqual({ syncCrm: false });
+    expect(nabisManualSyncOptions('nabis-historical-backfill', { syncCrm: true })).toEqual({ syncCrm: false });
+  });
+});

--- a/lib/server/nabis-sync-options.ts
+++ b/lib/server/nabis-sync-options.ts
@@ -1,0 +1,19 @@
+export type NabisSyncCrmOptions = {
+  syncCrm: boolean;
+};
+
+type ManualSyncRequest = {
+  syncCrm?: unknown;
+};
+
+const CRM_MIRRORABLE_MANUAL_MODULES = new Set(['all', 'nabis', 'nabis-retailers']);
+
+export function nabisCronSyncOptions(): NabisSyncCrmOptions {
+  return { syncCrm: true };
+}
+
+export function nabisManualSyncOptions(syncModule: string, body: ManualSyncRequest): NabisSyncCrmOptions {
+  return {
+    syncCrm: CRM_MIRRORABLE_MANUAL_MODULES.has(syncModule) && body.syncCrm === true,
+  };
+}

--- a/lib/server/nabis-sync-options.ts
+++ b/lib/server/nabis-sync-options.ts
@@ -12,6 +12,10 @@ export function nabisCronSyncOptions(): NabisSyncCrmOptions {
   return { syncCrm: true };
 }
 
+export function nabisDashboardRefreshSyncOptions(): NabisSyncCrmOptions & { reconciliation: false } {
+  return { reconciliation: false, syncCrm: true };
+}
+
 export function nabisManualSyncOptions(syncModule: string, body: ManualSyncRequest): NabisSyncCrmOptions {
   return {
     syncCrm: CRM_MIRRORABLE_MANUAL_MODULES.has(syncModule) && body.syncCrm === true,

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -5,7 +5,7 @@ import { IntegrationProvider, IntegrationSyncStatus, Prisma } from '@prisma/clie
 import { prisma } from '@/lib/db/prisma';
 import { ensureAccountIdentityMappings, resolveCanonicalAccountByIdentifiers } from '@/lib/server/account-identity';
 import { appendAuditEvent } from '@/lib/server/audit-log';
-import { upsertDispensaryCrmPageFromRetailer } from '@/lib/server/notion-crm-sync';
+import { ensureDispensaryCrmPageFromRetailer } from '@/lib/server/notion-crm-sync';
 import { ensureActivePolicySnapshot } from '@/lib/server/policy-snapshots';
 import { excludedInternalTransferRetailers, isExcludedInternalTransferRetailerName } from '@/lib/nabis/internal-transfers';
 
@@ -1199,7 +1199,7 @@ async function upsertLocalAccountFromRetailer(
   const shouldSyncCrm = options?.syncCrm === true;
 
   if (shouldSyncCrm && (changed || !account.notionPageId)) {
-    const notion = await upsertDispensaryCrmPageFromRetailer({
+    const notion = await ensureDispensaryCrmPageFromRetailer({
       licensedLocationId: retailer.licensedLocationId,
       nabisRetailerId: retailer.externalRetailerId,
       licenseNumber: retailer.licenseNumber,
@@ -1224,7 +1224,7 @@ async function upsertLocalAccountFromRetailer(
 
     await appendAuditEvent({
       orgId,
-      action: notion.created ? 'CRM_ACCOUNT_CREATED_FROM_NABIS' : 'CRM_ACCOUNT_UPDATED_FROM_NABIS',
+      action: notion.created ? 'CRM_ACCOUNT_CREATED_FROM_NABIS' : 'CRM_ACCOUNT_LINKED_FROM_NABIS',
       entityType: 'Account',
       entityId: account.id,
       actorClerkUserId: actor?.clerkUserId ?? null,

--- a/lib/server/notion-crm-sync.test.ts
+++ b/lib/server/notion-crm-sync.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureDispensaryCrmPageFromRetailer } from '@/lib/server/notion-crm-sync';
+
+const originalEnv = process.env;
+
+function jsonResponse(payload: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+}
+
+function retailerInput() {
+  return {
+    licensedLocationId: 'nabis-licensed-location-1',
+    nabisRetailerId: 'retailer-1',
+    licenseNumber: 'OCM-CAURD-24-000001-D1',
+    name: 'Nabis Store',
+    doingBusinessAs: 'Nabis DBA',
+    address1: '1 Main St',
+    city: 'Brooklyn',
+    state: 'NY',
+    zipcode: '11201',
+    hasOrders: true,
+  };
+}
+
+describe('Notion CRM retailer mirroring', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = {
+      ...originalEnv,
+      NOTION_API_KEY: 'test-notion-key',
+      NOTION_MASTER_LIST_DATABASE_ID: 'master-list-db',
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('does not update an existing CRM page matched by Licensed Location ID', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/databases/master-list-db/query')) {
+        return jsonResponse({ results: [{ id: 'existing-page-id' }] });
+      }
+      throw new Error(`Unexpected Notion request: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await ensureDispensaryCrmPageFromRetailer(retailerInput());
+
+    expect(result).toEqual({
+      pageId: 'existing-page-id',
+      created: false,
+      updated: false,
+      skippedExisting: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+      filter: {
+        property: 'Licensed Location ID',
+        rich_text: {
+          equals: 'nabis-licensed-location-1',
+        },
+      },
+    });
+  });
+
+  it('creates a CRM page only when no Licensed Location ID match exists', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ results: [] }))
+      .mockImplementationOnce((url: string, init: RequestInit) => {
+        expect(url).toBe('https://api.notion.com/v1/pages');
+        expect(init.method).toBe('POST');
+        return jsonResponse({ id: 'created-page-id' });
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await ensureDispensaryCrmPageFromRetailer(retailerInput());
+
+    expect(result).toEqual({
+      pageId: 'created-page-id',
+      created: true,
+      updated: false,
+      skippedExisting: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/server/notion-crm-sync.ts
+++ b/lib/server/notion-crm-sync.ts
@@ -138,7 +138,7 @@ function buildRetailerProperties(input: CrmRetailerSyncInput, options?: { includ
   return properties;
 }
 
-export async function upsertDispensaryCrmPageFromRetailer(input: CrmRetailerSyncInput) {
+export async function ensureDispensaryCrmPageFromRetailer(input: CrmRetailerSyncInput) {
   const existing =
     (input.notionPageId
       ? ({
@@ -161,19 +161,14 @@ export async function upsertDispensaryCrmPageFromRetailer(input: CrmRetailerSync
       pageId: created.id,
       created: true,
       updated: false,
+      skippedExisting: false,
     };
   }
-
-  await notionRequest<NotionPage>(`/pages/${existing.id}`, {
-    method: 'PATCH',
-    body: JSON.stringify({
-      properties: buildRetailerProperties(input),
-    }),
-  });
 
   return {
     pageId: existing.id,
     created: false,
-    updated: true,
+    updated: false,
+    skippedExisting: true,
   };
 }


### PR DESCRIPTION
## Why
Fixes #66.

The daily Nabis cron and the dashboard manual refresh were not mirroring newly discovered Nabis retailers into the Dispensary Master List CRM. That meant new Nabis stores could exist in the API/order feed while still requiring manual CSV-based CRM creation before appearing cleanly across Notion and PICC-Web-App.

## What changed
- Scheduled `/api/cron/nabis-sync` uses the existing CRM mirroring path with `syncCrm: true`.
- Dashboard manual refresh now runs the combined retailer + order sync with CRM mirroring, not order-only refresh.
- The dashboard button now reads `Sync Orders + Retailers`, and the status copy explains the manual refresh behavior.
- Manual Settings sync remains local-only by default unless the explicit CRM mirroring checkbox is enabled.
- CRM mirroring is create-only: it queries Notion by `Licensed Location ID`, creates a Dispensary Master List page only when no matching CRM page exists, and does not PATCH existing CRM pages.
- Local app accounts can still link to an existing CRM page when the Licensed Location ID already exists in Notion.
- Added focused option-selection tests plus Notion CRM create-only tests.
- Updated `SESSION.md` for the current issue scope.

## What did not change
- No schema migration.
- No Nabis write API calls.
- No order sync semantic changes beyond dashboard refresh composing the existing retailer step first.
- No review-required CSV/Notion overwrites.
- No duplicate page archiving.
- No updates to existing Notion CRM pages during Nabis API mirroring.
- No Google Maps changes; tracked in #67.

## Validation
- `npx vitest run lib/server/nabis-sync-options.test.ts` passed.
- `npx vitest run lib/server/nabis-sync-options.test.ts lib/server/notion-crm-sync.test.ts` passed.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm test` passed: 10 files, 67 tests.
- `npm run build` passed.

## Browser proof
- Verified locally at `http://127.0.0.1:3010/dashboard?codexRefresh=1` that the dashboard shows `Sync Orders + Retailers` and the status copy says manual refresh syncs Nabis orders, local retailer records, and missing CRM retailer pages.
- Screenshot captured through Playwright: `/Users/brycejohnson/Code/picc-issue-66-dashboard-sync-retailers.png`.
- I did not click the sync button locally because that can invoke live external sync/write behavior through local env.

## Approval lane
This enables scheduled and dashboard-triggered create-only Notion CRM writes from Nabis API retailer sync. The user approved this conditionally in the Codex thread: only add retailers that are in Nabis via API, are not already in CRM, and match by Licensed Location ID.
