### PR TITLE
Allow Nabis cron through middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,7 +17,7 @@ const isProtectedRoute = createRouteMatcher([
   '/api/(.*)',
 ]);
 const isApiRoute = createRouteMatcher(['/api/(.*)']);
-const isCronSyncRoute = createRouteMatcher(['/api/cron/notion-sync']);
+const isCronSyncRoute = createRouteMatcher(['/api/cron/notion-sync', '/api/cron/nabis-sync']);
 const isPublicWebhookRoute = createRouteMatcher(['/api/webhooks/notion']);
 const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
 const secretKey = process.env.CLERK_SECRET_KEY ?? '';


### PR DESCRIPTION
## Why
Fixes #69.

Production smoke after #68 showed `/api/cron/nabis-sync` was returning the protected-route 404 before reaching its route handler. The route already has its own `CRON_SECRET` / `x-vercel-cron` guard, but middleware only exempted `/api/cron/notion-sync`.

## What changed
- Added `/api/cron/nabis-sync` to the middleware cron allowlist.

## What did not change
- No Notion write behavior changed.
- No production cron execution.
- No changes to normal protected app/API auth.

## Validation
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm test` passed: 10 files, 67 tests.
- `npm run build` passed.

## Production verification plan
After merge/deploy, verify unauthenticated `GET /api/cron/nabis-sync` returns route-level `401 Unauthorized` instead of protected-route 404. Do not call with cron credentials and do not execute the cron manually.
