### PR TITLE
Make Nabis dashboard manual refresh non-blocking

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,29 +1,29 @@
-# Session: Issue #66 Nabis Scheduled CRM Mirroring
+# Session: Issue #71 Nabis Dashboard Background Sync
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/66
+- https://github.com/brycejohnson1417/Picc-web-app/issues/71
 
 ## Scope
-- Enable the scheduled Nabis cron to mirror newly discovered retailers into the Dispensary Master List CRM.
-- Make manual dashboard refresh run retailer + order sync with CRM mirroring so new Nabis retailers are added to the app cache and Dispensary Master List.
-- Add an explicit admin UI control for manual retailer/all sync CRM mirroring.
-- Keep CRM mirroring create-only: match existing CRM pages by `Licensed Location ID`, link local accounts to existing pages, and do not patch existing CRM properties.
-- Keep the existing Nabis lease and order sync behavior intact.
+- Make Nabis dashboard manual refresh start the retailer + order sync in the background instead of blocking the browser response.
+- Return saved local Postgres dashboard data immediately after the user clicks manual refresh.
+- Show a clear dashboard status that the sync was started in the background.
+- Preserve the create-only CRM mirroring rule: match existing CRM pages by `Licensed Location ID`, link local accounts to existing pages, and do not patch existing CRM properties.
+- Keep daily cron behavior protected and unchanged.
 
 ## Out Of Scope
 - No schema migration.
 - No Nabis write API usage.
-- No review-required Notion overwrites from the CSV preview.
-- No duplicate page archiving.
-- No order sync semantic changes.
+- No production data backfill.
+- No manual production cron execution.
+- No change to order parsing, retailer matching, or Notion property mapping.
 - No Google Maps fix in this branch; tracked separately in issue #67.
 
 ## Constraints
-- Approval-lane before merge because scheduled production Notion writes are enabled.
-- Do not print secrets or run production cron manually without explicit approval.
+- This is a fast-lane surgical UX/runtime fix; it does not add a new production write surface beyond the already-approved sync path.
+- Do not print secrets or run production cron manually.
 - Keep the change surgical and revertable.
 
 ## Validation Plan
-- RED test first for Nabis sync option selection.
-- Focused unit test after implementation.
+- RED test first for dashboard refresh metadata where practical.
+- Focused unit/unit-route test after implementation if the existing harness supports it.
 - Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` before completion.

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,16 +1,21 @@
-import { NextResponse } from 'next/server';
+import { after, NextResponse } from 'next/server';
 import { guard } from '@/lib/auth/api-guard';
+import { withBackgroundManualRefreshStarted } from '@/lib/dashboard/nabis-refresh';
 import { resolveNabisDashboardOrgId } from '@/lib/dashboard/nabis-org';
 import { ensureDateRange, getDashboardPayload } from '@/lib/dashboard/nabis-server';
+import type { NabisDashboardResponse } from '@/lib/dashboard/nabis-types';
 import { getUserRole } from '@/lib/rbac/guards';
+import { NabisSyncLeaseError, syncNabisRetailersAndOrders } from '@/lib/server/nabis-sync';
+import { nabisDashboardRefreshSyncOptions } from '@/lib/server/nabis-sync-options';
 
 export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
 
 const DASHBOARD_RESPONSE_CACHE_TTL_MS = 1000 * 60;
 
 type DashboardCacheEntry = {
   expiresAt: number;
-  payload: Awaited<ReturnType<typeof getDashboardPayload>>;
+  payload: NabisDashboardResponse;
 };
 
 const dashboardResponseCache = new Map<string, DashboardCacheEntry>();
@@ -57,6 +62,7 @@ export async function GET(request: Request) {
     const forceRefresh = searchParams.get('refresh') === '1';
     const dataOrgId = resolveNabisDashboardOrgId();
     const key = cacheKey(dataOrgId, start, end);
+    let manualRefreshStartedAt: string | null = null;
 
     if (forceRefresh) {
       const role = await getUserRole(ctx.orgId, ctx.userId);
@@ -69,6 +75,28 @@ export async function GET(request: Request) {
           },
         );
       }
+
+      manualRefreshStartedAt = new Date().toISOString();
+      const actor = {
+        clerkUserId: ctx.userId,
+        email: ctx.email,
+      };
+
+      after(async () => {
+        try {
+          await syncNabisRetailersAndOrders(dataOrgId, actor, nabisDashboardRefreshSyncOptions());
+        } catch (error) {
+          if (error instanceof NabisSyncLeaseError) {
+            console.info('[picc-nabis-dashboard-refresh]', {
+              status: 'already-running',
+              active: error.decision,
+            });
+            return;
+          }
+
+          console.error('[picc-nabis-dashboard-refresh]', error);
+        }
+      });
     }
 
     if (!forceRefresh) {
@@ -82,21 +110,23 @@ export async function GET(request: Request) {
       orgId: dataOrgId,
       start,
       end,
-      forceRefresh,
+      forceRefresh: false,
       actor: {
         clerkUserId: ctx.userId,
         email: ctx.email,
       },
     });
+    const responsePayload =
+      forceRefresh && manualRefreshStartedAt ? withBackgroundManualRefreshStarted(payload, manualRefreshStartedAt) : payload;
 
     if (!forceRefresh) {
       dashboardResponseCache.set(key, {
         expiresAt: Date.now() + DASHBOARD_RESPONSE_CACHE_TTL_MS,
-        payload,
+        payload: responsePayload,
       });
     }
 
-    return NextResponse.json(payload, { headers: responseHeaders(forceRefresh) });
+    return NextResponse.json(responsePayload, { headers: responseHeaders(forceRefresh) });
   } catch (error) {
     const statusCode = Number((error as Error & { statusCode?: number })?.statusCode || 500);
     const publicMessage =

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -463,7 +463,7 @@ export function NabisSalesDashboard() {
                   className="inline-flex items-center justify-center rounded-xl border border-[#d3d9e2] bg-white px-4 py-2.5 text-sm font-semibold text-[#243040] shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                  Sync Orders + Retailers
+                  Start Sync
                 </button>
               </div>
 
@@ -815,6 +815,11 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
     warnings.push(metadata.staleWarning);
   }
 
+  if (metadata?.manualRefresh?.status === 'background-started') {
+    items.push({ label: 'Manual sync', value: `Started ${formatTimestamp(metadata.manualRefresh.startedAt)}`, tone: 'info' });
+    notes.push('Nabis orders, local retailer records, and missing CRM retailer pages are syncing in the background. Saved dashboard data stays visible while it finishes.');
+  }
+
   if (metadata?.territorySnapshot.available === false) {
     items.push({ label: 'Store status', value: 'Unavailable', tone: 'warning' });
     warnings.push('Customer, VMI, and sampled-lead metrics are hidden until the territory cache is restored.');
@@ -824,7 +829,7 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
   }
 
   if (metadata?.cacheCoverage?.status === 'empty' && !hasOrders) {
-    notes.push('This dashboard reads saved Postgres data first; manual refresh syncs Nabis orders, local retailer records, and missing CRM retailer pages.');
+    notes.push('This dashboard reads saved Postgres data first; manual refresh starts a background sync for Nabis orders, local retailer records, and missing CRM retailer pages.');
   }
 
   if (items.length === 0) {

--- a/lib/dashboard/nabis-refresh.test.ts
+++ b/lib/dashboard/nabis-refresh.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { withBackgroundManualRefreshStarted } from '@/lib/dashboard/nabis-refresh';
+import type { NabisDashboardResponse } from '@/lib/dashboard/nabis-types';
+
+function dashboardPayload(): NabisDashboardResponse {
+  return {
+    orders: [],
+    analytics: {
+      totalRevenue: 0,
+      totalOrders: 0,
+      activeSalesReps: 0,
+      monthlyTrend: [],
+      repStats: [],
+      repMonthlyMetrics: [],
+      dataNotes: [],
+    },
+    metadata: {
+      fetchedAt: '2026-05-21T14:00:00.000Z',
+      dataSource: 'local-postgres',
+      range: {
+        startCreatedAt: '2026-05-01',
+        endCreatedAt: '2026-05-21',
+      },
+      uniqueOrders: 0,
+      canceledOrders: 0,
+      internalTransferOrders: 0,
+      lineItems: 0,
+      totalCount: 0,
+      totalPages: 1,
+      pagesScanned: 0,
+      partialScan: false,
+      cacheHit: false,
+      lastOrderSyncAt: null,
+      lastRetailerSyncAt: null,
+      lastReconciliationAt: null,
+      syncLagSeconds: null,
+      staleWarning: null,
+      cacheCoverage: {
+        status: 'empty',
+        fullyCovered: false,
+        requestedStart: '2026-05-01',
+        requestedEnd: '2026-05-21',
+        message: 'No cached Nabis orders are available yet.',
+        earliestOrderCreatedAt: null,
+        latestOrderCreatedAt: null,
+        cachedOrderCount: 0,
+        cachedLineItemCount: 0,
+      },
+      territorySnapshot: {
+        syncedAt: null,
+        recordsRead: 0,
+        available: false,
+      },
+    },
+  };
+}
+
+describe('withBackgroundManualRefreshStarted', () => {
+  it('marks a dashboard response when manual refresh starts in the background', () => {
+    const payload = dashboardPayload();
+
+    const result = withBackgroundManualRefreshStarted(payload, '2026-05-21T14:35:00.000Z');
+
+    expect(result.metadata.manualRefresh).toEqual({
+      status: 'background-started',
+      startedAt: '2026-05-21T14:35:00.000Z',
+    });
+    expect(result.orders).toBe(payload.orders);
+    expect(result.analytics).toBe(payload.analytics);
+  });
+});

--- a/lib/dashboard/nabis-refresh.ts
+++ b/lib/dashboard/nabis-refresh.ts
@@ -1,0 +1,14 @@
+import type { NabisDashboardResponse } from '@/lib/dashboard/nabis-types';
+
+export function withBackgroundManualRefreshStarted(payload: NabisDashboardResponse, startedAt: string): NabisDashboardResponse {
+  return {
+    ...payload,
+    metadata: {
+      ...payload.metadata,
+      manualRefresh: {
+        status: 'background-started',
+        startedAt,
+      },
+    },
+  };
+}

--- a/lib/dashboard/nabis-server.ts
+++ b/lib/dashboard/nabis-server.ts
@@ -8,8 +8,7 @@ import {
   type AnalyticsOrder,
   type AnalyticsTerritoryStore,
 } from '@/lib/dashboard/nabis-analytics';
-import { getNabisSyncFreshness, syncNabisRetailersAndOrders } from '@/lib/server/nabis-sync';
-import { nabisDashboardRefreshSyncOptions } from '@/lib/server/nabis-sync-options';
+import { getNabisSyncFreshness } from '@/lib/server/nabis-sync';
 import { readNotionCacheSnapshot } from '@/lib/server/notion-cache-store';
 import { excludedInternalTransferRetailers } from '@/lib/nabis/internal-transfers';
 import type { NabisDashboardMetadata, NabisDashboardResponse, SerializedNabisOrder } from '@/lib/dashboard/nabis-types';
@@ -165,10 +164,6 @@ export async function getDashboardPayload(input: {
   forceRefresh?: boolean;
   actor?: { clerkUserId?: string | null; email?: string | null };
 }) {
-  if (input.forceRefresh) {
-    await syncNabisRetailersAndOrders(input.orgId, input.actor, nabisDashboardRefreshSyncOptions());
-  }
-
   const orderWhere = {
     orgId: input.orgId,
     orderCreatedDate: {

--- a/lib/dashboard/nabis-types.ts
+++ b/lib/dashboard/nabis-types.ts
@@ -3,6 +3,10 @@ import type { CacheCoverage, NabisDashboardAnalytics } from '@/lib/dashboard/nab
 export interface NabisDashboardMetadata {
   fetchedAt: string;
   dataSource: 'local-postgres';
+  manualRefresh?: {
+    status: 'background-started';
+    startedAt: string;
+  } | null;
   range: {
     startCreatedAt: string;
     endCreatedAt: string;


### PR DESCRIPTION
## Summary
- Makes Nabis dashboard manual refresh non-blocking: `/api/dashboard?refresh=1` schedules the approved retailer+order sync with `after()` and immediately returns saved Postgres dashboard data.
- Adds response metadata and dashboard UI copy so users see that Nabis orders, local retailer records, and missing CRM pages are syncing in the background.
- Keeps daily cron behavior, global sync lease behavior, and create-only Licensed Location ID CRM matching unchanged.

## Root Cause Evidence
- Production read-only sync status showed the May 21 manual run succeeded but took about 118 seconds: retailers 14:33:07-14:33:55 UTC, then orders 14:33:55-14:35:06 UTC.
- No post-#70 daily cron run had occurred yet because the current schedule is `0 5 * * *` UTC and #70 deployed at 07:15 UTC on May 21. The next scheduled run is May 22 at 05:00 UTC.

## Scope
- Owned path globs: `app/api/dashboard/route.ts`, `lib/dashboard/nabis-*`, `components/dashboard/nabis-sales-dashboard.tsx`, `SESSION.md`.
- Out of scope: schema changes, production data backfills, manual production cron execution, Nabis/Notion mapping changes.

## Active PR Check
- Checked open PRs with `gh pr list`; none were open, so no owned path overlap.

## Validation
- `npx vitest run lib/dashboard/nabis-refresh.test.ts lib/server/nabis-sync-options.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- Local Playwright check with `/api/dashboard` mocked: clicked `Start Sync`, observed the background-sync status, and saved `/Users/brycejohnson/Code/picc-issue-71-dashboard-background-sync.png`.

Closes #71