### PR TITLE
Show active Nabis sync status on dashboard

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,14 +1,12 @@
-# Session: Issue #71 Nabis Dashboard Background Sync
+# Session: Issue #73 Nabis Dashboard Active Sync Status
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/71
+- https://github.com/brycejohnson1417/Picc-web-app/issues/73
 
 ## Scope
-- Make Nabis dashboard manual refresh start the retailer + order sync in the background instead of blocking the browser response.
-- Return saved local Postgres dashboard data immediately after the user clicks manual refresh.
-- Show a clear dashboard status that the sync was started in the background.
-- Preserve the create-only CRM mirroring rule: match existing CRM pages by `Licensed Location ID`, link local accounts to existing pages, and do not patch existing CRM properties.
-- Keep daily cron behavior protected and unchanged.
+- Show an active/running Nabis sync status on the dashboard when the global Nabis sync lease is active.
+- Suppress stale-order warnings while a background Nabis sync is actively running.
+- Keep the manual refresh "started in background" status visible when the user starts the sync.
 
 ## Out Of Scope
 - No schema migration.
@@ -24,6 +22,5 @@
 - Keep the change surgical and revertable.
 
 ## Validation Plan
-- RED test first for dashboard refresh metadata where practical.
-- Focused unit/unit-route test after implementation if the existing harness supports it.
+- RED test first for active-sync dashboard status behavior.
 - Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` before completion.

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -810,7 +810,10 @@ function DashboardStatusStrip({ error, metadata, hasOrders }: { error: string | 
     }
   }
 
-  if (metadata?.staleWarning) {
+  if (metadata?.activeSync) {
+    items.push({ label: 'Sync', value: 'Running', tone: 'info' });
+    notes.push('Nabis sync is actively running. Saved dashboard data stays visible until the latest run finishes.');
+  } else if (metadata?.staleWarning) {
     items.push({ label: 'Sync', value: 'Needs attention', tone: 'info' });
     warnings.push(metadata.staleWarning);
   }

--- a/lib/dashboard/nabis-refresh.test.ts
+++ b/lib/dashboard/nabis-refresh.test.ts
@@ -17,6 +17,7 @@ function dashboardPayload(): NabisDashboardResponse {
     metadata: {
       fetchedAt: '2026-05-21T14:00:00.000Z',
       dataSource: 'local-postgres',
+      activeSync: null,
       range: {
         startCreatedAt: '2026-05-01',
         endCreatedAt: '2026-05-21',

--- a/lib/dashboard/nabis-server.ts
+++ b/lib/dashboard/nabis-server.ts
@@ -250,6 +250,7 @@ export async function getDashboardPayload(input: {
   ]);
 
   const syncLag = secondsSince(freshness.lastOrderSyncAt);
+  const activeSync = freshness.activeSync;
   const cacheCoverage = buildCacheCoverage({
     requestedRange: { start: input.start, end: input.end },
     earliestOrderCreatedAt: coverageAggregate._min.orderCreatedDate?.toISOString() ?? null,
@@ -287,7 +288,8 @@ export async function getDashboardPayload(input: {
       lastRetailerSyncAt: freshness.lastRetailerSyncAt,
       lastReconciliationAt: freshness.lastReconciliationAt,
       syncLagSeconds: syncLag,
-      staleWarning: staleWarning(syncLag),
+      staleWarning: activeSync ? null : staleWarning(syncLag),
+      activeSync,
       cacheCoverage,
       territorySnapshot: {
         syncedAt: territorySnapshot.syncedAt,

--- a/lib/dashboard/nabis-types.ts
+++ b/lib/dashboard/nabis-types.ts
@@ -3,6 +3,11 @@ import type { CacheCoverage, NabisDashboardAnalytics } from '@/lib/dashboard/nab
 export interface NabisDashboardMetadata {
   fetchedAt: string;
   dataSource: 'local-postgres';
+  activeSync?: {
+    module: string | null;
+    refreshedAt: string | null;
+    expiresAt: string | null;
+  } | null;
   manualRefresh?: {
     status: 'background-started';
     startedAt: string;

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { IntegrationSyncStatus } from '@prisma/client';
 import {
+  activeNabisSyncFromLease,
   evaluateNabisSyncLease,
   filterOrderRowsOnOrAfterCutoff,
   formatNabisSyncLeaseConflictMessage,
@@ -90,6 +91,38 @@ describe('Nabis sync line cache parsing', () => {
 });
 
 describe('Nabis sync lease coordination', () => {
+  it('exposes an active global sync lease for dashboard freshness', () => {
+    const active = activeNabisSyncFromLease({
+      status: IntegrationSyncStatus.RUNNING,
+      metadata: {
+        module: 'retailers_and_orders',
+        refreshedAt: '2026-05-21T14:53:38.850Z',
+        expiresAt: '2026-05-21T14:54:38.850Z',
+      },
+      now: new Date('2026-05-21T14:53:48.000Z'),
+    });
+
+    expect(active).toEqual({
+      module: 'retailers_and_orders',
+      refreshedAt: '2026-05-21T14:53:38.850Z',
+      expiresAt: '2026-05-21T14:54:38.850Z',
+    });
+  });
+
+  it('does not expose an expired global sync lease as active', () => {
+    const active = activeNabisSyncFromLease({
+      status: IntegrationSyncStatus.RUNNING,
+      metadata: {
+        module: 'retailers_and_orders',
+        refreshedAt: '2026-05-21T14:53:38.850Z',
+        expiresAt: '2026-05-21T14:54:38.850Z',
+      },
+      now: new Date('2026-05-21T14:55:00.000Z'),
+    });
+
+    expect(active).toBeNull();
+  });
+
   it('lease-refusal blocks a second active holder before the lease is stale', () => {
     const now = new Date('2026-05-07T18:00:00.000Z');
     const decision = evaluateNabisSyncLease({

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -308,6 +308,31 @@ export function evaluateNabisSyncLease(input: {
   return { canAcquire: false, reason: 'held', activeHolderId, activeModule, activeRefreshedAt, activeExpiresAt };
 }
 
+export function activeNabisSyncFromLease(input: {
+  status?: IntegrationSyncStatus | null;
+  metadata?: unknown;
+  updatedAt?: Date | null;
+  now?: Date;
+}) {
+  if (input.status !== IntegrationSyncStatus.RUNNING) {
+    return null;
+  }
+
+  const metadata = toJsonObject(input.metadata);
+  const refreshedAt = isoFromUnknown(metadata?.refreshedAt) ?? input.updatedAt?.toISOString() ?? null;
+  const expiresAt = isoFromUnknown(metadata?.expiresAt);
+  const expiresAtDate = dateFromUnknown(metadata?.expiresAt);
+  if (expiresAtDate && expiresAtDate.getTime() <= (input.now ?? new Date()).getTime()) {
+    return null;
+  }
+
+  return {
+    module: isoFromUnknown(metadata?.module),
+    refreshedAt,
+    expiresAt,
+  };
+}
+
 function compactString(value: unknown) {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -1894,7 +1919,7 @@ export async function getNabisSyncFreshness(orgId: string) {
       checkpoints: {
         where: {
           module: {
-            in: ['retailers', 'orders', 'orders_reconcile'],
+            in: ['retailers', 'orders', 'orders_reconcile', NABIS_SYNC_LEASE_MODULE],
           },
         },
         select: {
@@ -1912,6 +1937,7 @@ export async function getNabisSyncFreshness(orgId: string) {
   const retailerCheckpoint = byModule.get('retailers');
   const orderCheckpoint = byModule.get('orders');
   const reconcileCheckpoint = byModule.get('orders_reconcile');
+  const leaseCheckpoint = byModule.get(NABIS_SYNC_LEASE_MODULE);
 
   const orderSyncAt =
     ((orderCheckpoint?.metadata as Record<string, unknown> | null)?.lastSuccessfulSyncAt as string | undefined) ??
@@ -1931,5 +1957,10 @@ export async function getNabisSyncFreshness(orgId: string) {
       ((reconcileCheckpoint?.metadata as Record<string, unknown> | null)?.lastSuccessfulSyncAt as string | undefined) ??
       reconcileCheckpoint?.updatedAt.toISOString() ??
       null,
+    activeSync: activeNabisSyncFromLease({
+      status: leaseCheckpoint?.status,
+      metadata: leaseCheckpoint?.metadata,
+      updatedAt: leaseCheckpoint?.updatedAt,
+    }),
   };
 }


### PR DESCRIPTION
## Summary
- Adds active Nabis global lease metadata to dashboard freshness.
- Suppresses stale-order warnings while a Nabis sync is actively running.
- Shows `Sync / Running` on the dashboard during active syncs, while keeping the manual background-started status visible.

## Root Cause Evidence
- Production read-only status at 2026-05-21 14:53 UTC showed the background sync was running: retailers had completed, orders were RUNNING with 27 pages and 13,500 records read, and the global Nabis sync lease was active.
- The UI still showed `Needs attention` because stale warning logic only considered the last completed order sync timestamp.

## Scope
- Owned path globs: `lib/server/nabis-sync.ts`, `lib/dashboard/nabis-*`, `components/dashboard/nabis-sales-dashboard.tsx`, `SESSION.md`.
- Out of scope: schema changes, production data backfills, manual production sync execution, Nabis/Notion mapping changes.

## Active PR Check
- Checked open PRs with `gh pr list`; none were open, so no owned path overlap.

## Validation
- `npx vitest run lib/server/nabis-sync.test.ts lib/dashboard/nabis-refresh.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- Local mocked Playwright check: active sync renders `Running`; `Needs attention` count = 0; stale-warning count = 0. Screenshot: `/Users/brycejohnson/Code/picc-issue-73-active-sync-status.png`.

Closes #73