### PR TITLE
Show selectable territory map search matches

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,29 +1,29 @@
-# Session: Issue #71 Nabis Dashboard Background Sync
+# Session: Issue #75 Territory Map Search Suggestions
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/71
+- https://github.com/brycejohnson1417/Picc-web-app/issues/75
 
 ## Scope
-- Make Nabis dashboard manual refresh start the retailer + order sync in the background instead of blocking the browser response.
-- Return saved local Postgres dashboard data immediately after the user clicks manual refresh.
-- Show a clear dashboard status that the sync was started in the background.
-- Preserve the create-only CRM mirroring rule: match existing CRM pages by `Licensed Location ID`, link local accounts to existing pages, and do not patch existing CRM properties.
-- Keep daily cron behavior protected and unchanged.
+- Make territory map search show selectable store matches while the user types.
+- Stop auto-focusing the first matching store from search text alone.
+- Let explicit suggestion clicks focus/highlight the selected store and open the selected-account card.
+- Preserve the current Google Maps provider, route controls, filter sheet, and mobile-first shell.
 
 ## Out Of Scope
 - No schema migration.
-- No Nabis write API usage.
-- No production data backfill.
-- No manual production cron execution.
-- No change to order parsing, retailer matching, or Notion property mapping.
-- No Google Maps fix in this branch; tracked separately in issue #67.
+- No Notion writes or production data mutation.
+- No auth, Clerk, Vercel, or provider changes.
+- No map provider rewrite.
+- No Nabis dashboard/server sync changes; open PR #74 owns that area.
 
 ## Constraints
-- This is a fast-lane surgical UX/runtime fix; it does not add a new production write surface beyond the already-approved sync path.
-- Do not print secrets or run production cron manually.
+- This is production triage: keep it surgical and revertable.
+- Keep all requested behavior usable directly from the browser UI.
+- Owned path globs: `components/mobile/territory-*`, `lib/territory/map-search-*`, `lib/territory/*.test.ts`, `SESSION.md`.
+- Open PR overlap checked: PR #74 touches Nabis dashboard/server sync files only; no expected path overlap.
 - Keep the change surgical and revertable.
 
 ## Validation Plan
-- RED test first for dashboard refresh metadata where practical.
-- Focused unit/unit-route test after implementation if the existing harness supports it.
-- Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` before completion.
+- RED test first for search suggestion ranking/selection behavior in a focused territory helper.
+- Run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
+- Start the local app and verify `/territory` in a browser with the map search flow.

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -2,6 +2,7 @@
 
 import { Crosshair, Filter, Layers3, RefreshCw, Search } from 'lucide-react';
 import { MobileSearch } from '@/components/mobile/mobile-search';
+import type { TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
 
 interface TerritoryRepLegendEntry {
@@ -22,7 +23,9 @@ interface TerritoryMapOverlayControlsProps {
   mapSearch: string;
   onMapSearchChange: (value: string) => void;
   onClearMapSearch: () => void;
-  highlightedSearchStoreName: string | null;
+  searchSuggestions: TerritoryStorePin[];
+  onSelectSearchSuggestion: (storeId: string) => void;
+  selectedSearchStoreId: string | null;
   hasRoadRouteGeometry: boolean;
   routeModeLabel: string | null;
   pinColorMode: 'status' | 'rep';
@@ -51,7 +54,9 @@ export function TerritoryMapOverlayControls({
   mapSearch,
   onMapSearchChange,
   onClearMapSearch,
-  highlightedSearchStoreName,
+  searchSuggestions,
+  onSelectSearchSuggestion,
+  selectedSearchStoreId,
   hasRoadRouteGeometry,
   routeModeLabel,
   pinColorMode,
@@ -129,9 +134,45 @@ export function TerritoryMapOverlayControls({
               </button>
             </div>
             {mapSearch.trim().length > 0 ? (
-              <p className="mt-2 px-1 text-[12px] text-[#62666f]">
-                {highlightedSearchStoreName ? `Highlighting ${highlightedSearchStoreName}` : 'No dispensaries match this search yet'}
-              </p>
+              <div className="mt-2 overflow-hidden rounded-xl border border-[#e1e3e8] bg-white">
+                {searchSuggestions.length > 0 ? (
+                  <div role="listbox" aria-label="Matching stores" className="max-h-[260px] overflow-y-auto">
+                    {searchSuggestions.map((store) => {
+                      const selected = selectedSearchStoreId === store.id;
+                      return (
+                        <button
+                          key={store.id}
+                          type="button"
+                          role="option"
+                          aria-selected={selected}
+                          onClick={() => onSelectSearchSuggestion(store.id)}
+                          className={cn(
+                            'flex w-full items-center justify-between gap-3 border-b px-3 py-2.5 text-left last:border-b-0 active:bg-[#f3f5f8]',
+                            selected ? 'border-[#cfe2ff] bg-[#f4f8ff]' : 'border-[#eef0f3]',
+                          )}
+                        >
+                          <span className="min-w-0">
+                            <span className="block truncate text-[14px] font-semibold text-[#24272f]">{store.name}</span>
+                            <span className="mt-0.5 block truncate text-[12px] text-[#62666f]">
+                              {[store.city, store.state].filter(Boolean).join(', ') || store.locationLabel || store.locationAddress || 'No location'}
+                            </span>
+                          </span>
+                          <span
+                            className={cn(
+                              'shrink-0 rounded-full px-2 py-1 text-[11px] font-semibold',
+                              selected ? 'bg-[#1d5eea] text-white' : 'bg-[#eef6ff] text-[#1d5eea]',
+                            )}
+                          >
+                            {selected ? 'Selected' : 'Select'}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="px-3 py-2.5 text-[12px] text-[#62666f]">No dispensaries match this search yet.</p>
+                )}
+              </div>
             ) : null}
           </div>
         </div>

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -732,6 +732,8 @@ export function TerritoryMobile() {
             searchSuggestions={mapSearchSuggestions}
             onSelectSearchSuggestion={(storeId) => {
               setFocusedId(storeId);
+              setMapSearch('');
+              setDebouncedMapSearch('');
               setShowMapSearch(false);
               setFocusRequestToken((current) => current + 1);
             }}

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -25,6 +25,7 @@ import { MapRenderBoundary } from '@/components/mobile/map-render-boundary';
 import { createRepColorMap, type PinColorMode } from '@/lib/territory/pin-colors';
 import type { PreferredPartnerFilter } from '@/lib/territory/preferred-partner';
 import type { TerritoryStorePin } from '@/lib/territory/types';
+import { getTerritoryMapSearchSuggestions } from '@/lib/territory/map-search-suggestions';
 import { clearSavedTerritoryFilters, countActiveTerritoryFilters, loadSavedTerritoryFilters, persistSavedTerritoryFilters, type TerritorySavedFiltersPayload } from '@/lib/territory/filter-storage';
 import { useRoutePlan } from '@/lib/territory/route-plan-client';
 
@@ -403,55 +404,10 @@ export function TerritoryMobile() {
     }
   }, [pinColorMode]);
 
-  const highlightedSearchStore = useMemo(() => {
-    const query = debouncedMapSearch.trim().toLowerCase();
-    if (!query) {
-      return null;
-    }
-
-    const scoreStore = (store: TerritoryStorePin) => {
-      const haystacks = [
-        store.name,
-        store.locationAddress ?? '',
-        store.locationLabel ?? '',
-      ]
-        .join(' ')
-        .toLowerCase();
-
-      if (store.name.toLowerCase() === query) return 0;
-      if (store.name.toLowerCase().startsWith(query)) return 1;
-      if (haystacks.includes(query)) return 2;
-      return 3;
-    };
-
-    return [...mapStores].sort((left, right) => {
-      const scoreDiff = scoreStore(left) - scoreStore(right);
-      if (scoreDiff !== 0) return scoreDiff;
-      return left.name.localeCompare(right.name);
-    })[0] ?? null;
-  }, [debouncedMapSearch, mapStores]);
-
-  const lastSearchFocusRef = useRef<string>('');
-
-  useEffect(() => {
-    if (view !== 'map') {
-      return;
-    }
-
-    const highlightedId = highlightedSearchStore?.id ?? '';
-    if (!highlightedId) {
-      lastSearchFocusRef.current = '';
-      return;
-    }
-
-    if (lastSearchFocusRef.current === highlightedId) {
-      return;
-    }
-
-    lastSearchFocusRef.current = highlightedId;
-    setFocusedId(highlightedId);
-    setFocusRequestToken((current) => current + 1);
-  }, [highlightedSearchStore?.id, view]);
+  const mapSearchSuggestions = useMemo(
+    () => getTerritoryMapSearchSuggestions(debouncedMapSearch, mapStores),
+    [debouncedMapSearch, mapStores],
+  );
 
   const selectedOnCard = focusedStore ? routePlan.selectedStopIds.includes(focusedStore.id) : false;
   const activeFiltersCount = countActiveTerritoryFilters({
@@ -736,7 +692,7 @@ export function TerritoryMobile() {
               selectedStopIds={routePlan.selectedStopIds}
               orderedStopIds={routePlan.orderedStopIds}
               focusedStoreId={focusedStore?.id ?? null}
-              highlightedStoreId={highlightedSearchStore?.id ?? null}
+              highlightedStoreId={null}
               currentLocation={currentLocation}
               locationRequestToken={locationRequestToken}
               focusRequestToken={focusRequestToken}
@@ -763,14 +719,23 @@ export function TerritoryMobile() {
             onFinishLasso={finishLasso}
             showMapSearch={showMapSearch}
             mapSearch={mapSearch}
-            onMapSearchChange={setMapSearch}
+            onMapSearchChange={(value) => {
+              setMapSearch(value);
+              setFocusedId(null);
+            }}
             onClearMapSearch={() => {
               setMapSearch('');
               setDebouncedMapSearch('');
               setShowMapSearch(false);
-              lastSearchFocusRef.current = '';
+              setFocusedId(null);
             }}
-            highlightedSearchStoreName={highlightedSearchStore?.name ?? null}
+            searchSuggestions={mapSearchSuggestions}
+            onSelectSearchSuggestion={(storeId) => {
+              setFocusedId(storeId);
+              setShowMapSearch(false);
+              setFocusRequestToken((current) => current + 1);
+            }}
+            selectedSearchStoreId={focusedId}
             hasRoadRouteGeometry={hasRoadRouteGeometry}
             routeModeLabel={
               routePlan.optimizedRoute?.mode === 'transit'

--- a/lib/territory/map-search-suggestions.test.ts
+++ b/lib/territory/map-search-suggestions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { TerritoryStorePin } from '@/lib/territory/types';
+import { getTerritoryMapSearchSuggestions } from '@/lib/territory/map-search-suggestions';
+
+function store(id: string, name: string, city = 'New York'): TerritoryStorePin {
+  return {
+    id,
+    notionPageId: id,
+    name,
+    status: 'Lead - Hot',
+    statusKey: 'lead-hot',
+    statusColor: 'red',
+    pinKind: 'lead',
+    repNames: [],
+    repEmails: [],
+    lat: 40.75,
+    lng: -73.98,
+    locationLabel: city,
+    locationAddress: `${city}, NY`,
+    locationSource: 'google-address-cache',
+    locationPrecision: 'address',
+    isApproximate: false,
+    lastEditedTime: '2026-05-21T00:00:00.000Z',
+    city,
+    state: 'NY',
+    referralSource: null,
+  };
+}
+
+describe('getTerritoryMapSearchSuggestions', () => {
+  it('returns multiple store-name matches instead of collapsing to the first alphabetical match', () => {
+    const suggestions = getTerritoryMapSearchSuggestions('Flynnstoned', [
+      store('astoria', 'Flynnstoned Astoria', 'Astoria'),
+      store('bay-ridge', 'Flynnstoned Bay Ridge', 'Brooklyn'),
+      store('binghamton', 'Flynnstoned Binghamton', 'Binghamton'),
+      store('union-square', 'Union Square Travel Agency', 'New York'),
+    ]);
+
+    expect(suggestions.map((suggestion) => suggestion.id)).toEqual(['astoria', 'bay-ridge', 'binghamton']);
+    expect(suggestions).toHaveLength(3);
+  });
+});

--- a/lib/territory/map-search-suggestions.ts
+++ b/lib/territory/map-search-suggestions.ts
@@ -1,0 +1,54 @@
+import type { TerritoryStorePin } from '@/lib/territory/types';
+
+const DEFAULT_SUGGESTION_LIMIT = 8;
+
+function normalizeSearchText(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function searchableText(store: TerritoryStorePin) {
+  return [
+    store.name,
+    store.locationAddress ?? '',
+    store.locationLabel ?? '',
+    store.city ?? '',
+    store.state ?? '',
+    store.licenseNumber ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+function scoreStoreMatch(store: TerritoryStorePin, query: string) {
+  const name = store.name.toLowerCase();
+  const haystack = searchableText(store);
+
+  if (name === query) return 0;
+  if (name.startsWith(query)) return 1;
+  if (name.includes(query)) return 2;
+  if (haystack.includes(query)) return 3;
+  return null;
+}
+
+export function getTerritoryMapSearchSuggestions(
+  query: string,
+  stores: TerritoryStorePin[],
+  limit = DEFAULT_SUGGESTION_LIMIT,
+) {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  return stores
+    .map((store) => ({ store, score: scoreStoreMatch(store, normalizedQuery) }))
+    .filter((entry): entry is { store: TerritoryStorePin; score: number } => entry.score !== null)
+    .sort((left, right) => {
+      const scoreDiff = left.score - right.score;
+      if (scoreDiff !== 0) return scoreDiff;
+      return left.store.name.localeCompare(right.store.name);
+    })
+    .slice(0, Math.max(1, limit))
+    .map((entry) => entry.store);
+}


### PR DESCRIPTION
Closes #75

## Why
Territory map search currently auto-focuses the first matching store while typing. For shared account names like Flynnstoned, this jumps to Flynnstoned Astoria instead of letting the user choose which Flynnstoned store they meant.

## Scope
- Add selectable territory map search suggestions.
- Stop automatic first-result focus from search text alone.
- Keep explicit suggestion or marker selection as the only focus action.

## Out of scope
- No Notion writes or production data mutation.
- No schema/auth/provider changes.
- No Nabis dashboard/server sync changes; checked open PR #74 and there is no intended path overlap.

## Owned paths
- `components/mobile/territory-*`
- `lib/territory/map-search-*`
- `lib/territory/*.test.ts`
- `SESSION.md`

## Validation plan
- RED: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test -- lib/territory/map-search-suggestions.test.ts` currently fails until implementation lands.
- Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
- Browser verify `/territory` search suggestions after implementation.

## Architecture/plan check
Read `AGENTS.md`, `README.md`, `AI_HANDOFF.md`, `DESIGN-SYSTEM.md`, and current territory components. This remains a surgical UI/search interaction fix inside the current Google Maps territory shell.