### PR TITLE
Reuse Notion tab from territory map

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,26 +1,26 @@
-# Session: Issue #73 Nabis Dashboard Active Sync Status
+# Session: Issue #77 Reuse Notion Tab From Territory Map
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/73
+- https://github.com/brycejohnson1417/Picc-web-app/issues/77
 
 ## Scope
-- Show an active/running Nabis sync status on the dashboard when the global Nabis sync lease is active.
-- Suppress stale-order warnings while a background Nabis sync is actively running.
-- Keep the manual refresh "started in background" status visible when the user starts the sync.
+- Change the territory focused-card "N" shortcut so it opens Notion in a named app tab instead of `_blank`.
+- Preserve the existing Notion destination URL generated from the selected store's Notion page ID.
+- Add a focused regression test for the tab target and opener-clearing behavior.
 
 ## Out Of Scope
-- No schema migration.
-- No Nabis write API usage.
-- No production data backfill.
-- No manual production cron execution.
-- No change to order parsing, retailer matching, or Notion property mapping.
-- No Google Maps fix in this branch; tracked separately in issue #67.
+- No Notion workspace writes or Notion API mutation.
+- No schema migration, auth change, production data write, or Vercel config change.
+- No redesign of the account detail sheet or unrelated Notion archive links.
+- No change to Google Maps routing behavior.
 
 ## Constraints
-- This is a fast-lane surgical UX/runtime fix; it does not add a new production write surface beyond the already-approved sync path.
-- Do not print secrets or run production cron manually.
+- This is a fast-lane surgical frontend behavior fix.
+- Keep Notion behind the existing URL handoff; do not add any external-system writes.
 - Keep the change surgical and revertable.
+- Open PR #76 was checked; it currently changes `SESSION.md` and `lib/territory/map-search-suggestions.test.ts`.
 
 ## Validation Plan
-- RED test first for active-sync dashboard status behavior.
+- RED test first for the Notion CRM tab target helper.
 - Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` before completion.
+- Browser verify `/territory` if the local protected route can be loaded.

--- a/components/mobile/territory-focused-card.tsx
+++ b/components/mobile/territory-focused-card.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 import type { PinColorMode } from '@/lib/territory/pin-colors';
 import { pinColorForStore } from '@/lib/territory/pin-colors';
+import { openNotionCrmTab } from '@/lib/territory/notion-link-target';
 
 interface TerritoryFocusedCardProps {
   store: TerritoryStorePin;
@@ -64,16 +65,15 @@ export function TerritoryFocusedCard({
             <span className="inline-block h-3.5 w-3.5 rounded-full" style={{ backgroundColor: pinColorForStore(store, pinColorMode, repColorMap) }} />
             Message rep
           </button>
-          <a
-            href={notionPageUrl}
-            target="_blank"
-            rel="noreferrer"
+          <button
+            type="button"
+            onClick={() => openNotionCrmTab(notionPageUrl)}
             className="grid place-items-center border-l border-[#30333b] text-[20px] font-semibold text-[#d8dde6]"
             aria-label="Open in Notion"
             title="Open in Notion"
           >
             N
-          </a>
+          </button>
           <button type="button" onClick={() => onToggleRouteStop(store.id)} className="grid place-items-center border-l border-[#30333b]">
             <Plus className={cn('h-6 w-6', selectedOnRoute ? 'text-[#4fb649]' : 'text-[#d8dde6]')} />
           </button>

--- a/lib/territory/notion-link-target.test.ts
+++ b/lib/territory/notion-link-target.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NOTION_CRM_TAB_TARGET, openNotionCrmTab } from '@/lib/territory/notion-link-target';
+
+describe('territory Notion link target', () => {
+  it('reuses the same Notion CRM tab instead of opening a blank tab for each click', () => {
+    expect(NOTION_CRM_TAB_TARGET).toBe('picc-notion-crm');
+    expect(NOTION_CRM_TAB_TARGET).not.toBe('_blank');
+  });
+
+  it('opens Notion in the named tab and clears opener access', () => {
+    const openedWindow = {
+      opener: { location: 'app' },
+      focus: vi.fn(),
+    } as unknown as Window;
+    const openWindow = vi.fn(() => openedWindow);
+
+    const result = openNotionCrmTab('https://www.notion.so/page-id', openWindow);
+
+    expect(result).toBe(openedWindow);
+    expect(openWindow).toHaveBeenCalledWith('https://www.notion.so/page-id', NOTION_CRM_TAB_TARGET);
+    expect(openedWindow.opener).toBeNull();
+    expect(openedWindow.focus).toHaveBeenCalled();
+  });
+});

--- a/lib/territory/notion-link-target.ts
+++ b/lib/territory/notion-link-target.ts
@@ -1,0 +1,16 @@
+export const NOTION_CRM_TAB_TARGET = 'picc-notion-crm';
+
+type OpenWindow = (url?: string | URL, target?: string, features?: string) => Window | null;
+
+export function openNotionCrmTab(notionPageUrl: string, openWindow?: OpenWindow) {
+  const openFn = openWindow ?? globalThis.window?.open?.bind(globalThis.window);
+  if (!openFn) return null;
+
+  const notionWindow = openFn(notionPageUrl, NOTION_CRM_TAB_TARGET);
+  if (notionWindow) {
+    notionWindow.opener = null;
+    notionWindow.focus();
+  }
+
+  return notionWindow;
+}


### PR DESCRIPTION
Closes #77

## Why
The territory map pin card Notion shortcut currently uses `_blank`, so each click creates another Notion tab. Reps need repeated clicks to replace/reuse the existing Notion browser context instead of cluttering the browser.

## Scope
- Update the focused territory map card Notion shortcut target behavior.
- Preserve the current Notion destination URL and visible `N` control.
- Add focused regression coverage for the named-tab and opener-clearing contract.

## Out of scope
- No Notion workspace writes or API mutations.
- No schema/auth/Vercel changes.
- No account-detail-sheet redesign or unrelated Notion archive-link behavior.

## Owned paths
- `components/mobile/territory-focused-card.tsx`
- `lib/territory/notion-link-target.ts`
- `lib/territory/notion-link-target.test.ts`
- `SESSION.md`

## Open PR overlap check
Checked open PR #76. It claims broad `components/mobile/territory-*` ownership but currently changes only `SESSION.md` and `lib/territory/map-search-suggestions.test.ts`; this PR keeps the source change to the focused card and may need a light `SESSION.md` rebase if #76 lands first.

## Validation
- RED: `npm test -- lib/territory/notion-link-target.test.ts` failed before helper implementation because `@/lib/territory/notion-link-target` did not exist.
- PASS: `npm test -- lib/territory/notion-link-target.test.ts`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run typecheck`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run lint`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run build`

## Browser proof
- Local URL: `http://127.0.0.1:3010/territory`
- Flow exercised: territory route loads -> clicked visible map pin -> focused card appears.
- Caveat: the in-app browser kept rendering an old cached client card (`<a target="_blank">`) even after reload/new tab/cache reset, while the local `.next/static` compiled module contains the new `<button>` calling `openNotionCrmTab`. The rendered route also has pre-existing hydration mismatch warnings and a local seed/read-model FK warning.

## Remaining risk
- Production verification should be done after deploy against the fresh production bundle.
- A manually opened arbitrary Notion tab cannot be commandeered by the browser; the fix reuses the named Notion tab/window created by this app shortcut.