### PR TITLE
Color territory map pins by follow-up date

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,26 +1,40 @@
-# Session: Issue #77 Reuse Notion Tab From Territory Map
+# Session: Issue #79 Follow-Up Date Pin Heatmap
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/77
+- https://github.com/brycejohnson1417/Picc-web-app/issues/79
 
 ## Scope
-- Change the territory focused-card "N" shortcut so it opens Notion in a named app tab instead of `_blank`.
-- Preserve the existing Notion destination URL generated from the selected store's Notion page ID.
-- Add a focused regression test for the tab target and opener-clearing behavior.
+- Add a Follow Up Date option to the territory Pin Colors UI.
+- Color territory map pins by follow-up urgency using the provided blue-to-green-to-red heatmap direction.
+- Show days until follow-up inside map pins only in Follow Up Date mode.
+- Keep Preferred Partner bold pin outline in Follow Up Date mode while suppressing the `P` glyph.
 
 ## Out Of Scope
-- No Notion workspace writes or Notion API mutation.
-- No schema migration, auth change, production data write, or Vercel config change.
-- No redesign of the account detail sheet or unrelated Notion archive links.
-- No change to Google Maps routing behavior.
+- No Notion, Neon, Supabase, GHL, Nabis, Vercel, schema, auth, or production data writes.
+- No map provider changes.
+- No unrelated territory search, account-detail, Notion-link, or route-planning behavior changes.
+
+## Owned Paths
+- `lib/territory/pin-colors.ts`
+- `lib/territory/*.test.ts`
+- `components/mobile/store-filter-sheet.tsx`
+- `components/mobile/territory-mobile.tsx`
+- `components/territory/google-territory-map.tsx`
+- `app/api/territory/filter-presets/route.ts`
+- `SESSION.md`
+
+## Open PR Overlap Check
+- Checked open PR #76. It owns broad `components/mobile/territory-*` search-suggestion paths and `SESSION.md`; this slice avoids search behavior.
+- Checked open PR #78. It owns the focused Notion card/link helper and `SESSION.md`; this slice avoids Notion-link behavior.
+- During rebase, `SESSION.md` conflicted with the landed issue #77 session note. This branch keeps the current issue #79 scope note.
 
 ## Constraints
-- This is a fast-lane surgical frontend behavior fix.
-- Keep Notion behind the existing URL handoff; do not add any external-system writes.
-- Keep the change surgical and revertable.
-- Open PR #76 was checked; it currently changes `SESSION.md` and `lib/territory/map-search-suggestions.test.ts`.
+- Production triage style: surgical, additive, one issue per PR.
+- Keep UI components thin; put follow-up date classification/color logic in `lib/territory/pin-colors.ts`.
+- The running browser UI is the source of truth for the feature.
 
 ## Validation Plan
-- RED test first for the Notion CRM tab target helper.
-- Then run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` before completion.
-- Browser verify `/territory` if the local protected route can be loaded.
+- RED test first for follow-up date pin color and label classification.
+- Then implement the helper/UI wiring.
+- Run focused tests, typecheck, lint, full test suite, and build.
+- Browser-verify `/territory`: open filters, select Follow Up Date, apply, and confirm map pins show heatmap colors with day labels.

--- a/app/api/territory/filter-presets/route.ts
+++ b/app/api/territory/filter-presets/route.ts
@@ -9,7 +9,7 @@ const presetSchema = z.object({
   selectedStatuses: z.array(z.string().trim().min(1)).max(25).default([]),
   selectedReps: z.array(z.string().trim().min(1)).max(25).default([]),
   showRouteOnly: z.boolean().default(false),
-  pinColorMode: z.enum(['status', 'rep']).default('status'),
+  pinColorMode: z.enum(['status', 'rep', 'follow-up-date']).default('status'),
 });
 
 export const dynamic = 'force-dynamic';

--- a/components/mobile/store-filter-sheet.tsx
+++ b/components/mobile/store-filter-sheet.tsx
@@ -130,29 +130,39 @@ export function StoreFilterSheet({
         <div className="flex-1 overflow-y-auto px-4 py-4">
           <section className="mb-4 rounded-xl border border-[#c7c9cf] bg-white p-3">
             <h3 className="mb-2 text-[12px] font-semibold uppercase tracking-wide text-[#7b7e87]">Pin Colors</h3>
-            <div className="grid grid-cols-2 gap-2">
-              <button
-                type="button"
-                className={cn(
-                  'rounded-lg border px-3 py-2 text-[13px] font-medium',
-                  pinColorMode === 'status' ? 'border-[#cd3814] bg-[#cd3814] text-white' : 'border-[#c3c5cb] bg-white text-[#4a4c52]',
-                )}
-                onClick={() => onSetPinColorMode('status')}
-              >
-                By Status
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  'rounded-lg border px-3 py-2 text-[13px] font-medium',
-                  pinColorMode === 'rep' ? 'border-[#cd3814] bg-[#cd3814] text-white' : 'border-[#c3c5cb] bg-white text-[#4a4c52]',
-                )}
-                onClick={() => onSetPinColorMode('rep')}
-              >
-                By Rep
-              </button>
+            <div className="grid grid-cols-3 gap-2">
+              {[
+                { mode: 'status' as const, label: 'By Status' },
+                { mode: 'rep' as const, label: 'By Rep' },
+                { mode: 'follow-up-date' as const, label: 'Follow Up Date' },
+              ].map((option) => (
+                <button
+                  key={option.mode}
+                  type="button"
+                  className={cn(
+                    'rounded-lg border px-2 py-2 text-[12px] font-medium sm:text-[13px]',
+                    pinColorMode === option.mode ? 'border-[#cd3814] bg-[#cd3814] text-white' : 'border-[#c3c5cb] bg-white text-[#4a4c52]',
+                  )}
+                  onClick={() => onSetPinColorMode(option.mode)}
+                >
+                  {option.label}
+                </button>
+              ))}
             </div>
-            <p className="mt-2 text-[12px] text-[#72757d]">Filter results are still applied. This only changes pin coloring. Preferred Partner pins keep the PICC marker treatment in both modes.</p>
+            {pinColorMode === 'follow-up-date' ? (
+              <div className="mt-3 overflow-hidden rounded-lg border border-[#c3c5cb] bg-white">
+                <div className="h-2 bg-[linear-gradient(90deg,#0616b7_0%,#a7dcff_32%,#00e63a_50%,#ffcf24_64%,#ff7a00_76%,#d00000_100%)]" />
+                <div className="grid grid-cols-4 gap-1 px-2 py-2 text-[10px] font-semibold uppercase tracking-wide text-[#72757d]">
+                  <span>No Date</span>
+                  <span>Upcoming</span>
+                  <span>Today</span>
+                  <span className="text-right">Overdue</span>
+                </div>
+              </div>
+            ) : null}
+            <p className="mt-2 text-[12px] text-[#72757d]">
+              Filter results are still applied. Follow Up Date mode shows days until follow-up inside pins; Preferred Partner pins keep the bold outline but hide the P.
+            </p>
           </section>
 
           <FilterSection

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -4,6 +4,7 @@ import { Crosshair, Filter, Layers3, RefreshCw, Search } from 'lucide-react';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
+import type { PinColorMode } from '@/lib/territory/pin-colors';
 
 interface TerritoryRepLegendEntry {
   label: string;
@@ -28,7 +29,7 @@ interface TerritoryMapOverlayControlsProps {
   selectedSearchStoreId: string | null;
   hasRoadRouteGeometry: boolean;
   routeModeLabel: string | null;
-  pinColorMode: 'status' | 'rep';
+  pinColorMode: PinColorMode;
   repLegend: TerritoryRepLegendEntry[];
   showRepLegend: boolean;
   onToggleRepLegend: () => void;

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -238,7 +238,7 @@ export function TerritoryMobile() {
         : 'all',
     );
     setShowRouteOnly(Boolean(parsed.showRouteOnly));
-    setPinColorMode(parsed.pinColorMode === 'rep' ? 'rep' : 'status');
+    setPinColorMode(parsed.pinColorMode === 'rep' || parsed.pinColorMode === 'follow-up-date' ? parsed.pinColorMode : 'status');
     setSavedFiltersAt(typeof parsed.savedAt === 'string' ? parsed.savedAt : null);
     toast.success('Loaded saved territory filters');
   }, []);

--- a/components/territory/google-territory-map.tsx
+++ b/components/territory/google-territory-map.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { AdvancedMarker, APIProvider, Map as GoogleMap, Marker, Pin, useMap } from '@vis.gl/react-google-maps';
 import { GoogleTerritoryBoundaries, type TerritoryBoundaryDraft } from '@/components/territory/google-territory-boundaries';
 import { GoogleTerritoryMarkers, GoogleTerritoryMarkersFallback } from '@/components/territory/google-territory-markers';
-import { pinColorForStore, type PinColorMode } from '@/lib/territory/pin-colors';
+import { pinColorForStore, pinGlyphColorForStore, pinGlyphForStore, type PinColorMode } from '@/lib/territory/pin-colors';
 import type { TerritoryBoundary, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
 
@@ -321,8 +321,8 @@ function markerScale({
 
 const fallbackMarkerIconCache = new Map<string, string>();
 
-function fallbackMarkerIcon(fillColor: string, approximate: boolean, preferredPartner: boolean, scale = 1) {
-  const key = `${fillColor}|${approximate ? 'approx' : 'exact'}|${preferredPartner ? 'preferred' : 'standard'}|${scale}`;
+function fallbackMarkerIcon(fillColor: string, approximate: boolean, preferredPartner: boolean, glyph: string, glyphColor: string, scale = 1) {
+  const key = `${fillColor}|${approximate ? 'approx' : 'exact'}|${preferredPartner ? 'preferred' : 'standard'}|${glyph}|${glyphColor}|${scale}`;
   const existing = fallbackMarkerIconCache.get(key);
   if (existing) {
     return existing;
@@ -331,12 +331,14 @@ function fallbackMarkerIcon(fillColor: string, approximate: boolean, preferredPa
   const width = Math.round(30 * scale);
   const height = Math.round(38 * scale);
   const stroke = preferredPartner ? '#111111' : approximate ? '#111827' : '#ffffff';
-  const glyph = preferredPartner
-    ? `<text x="15" y="15.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="8.5" font-weight="700" fill="#ffffff">P</text>`
-    : `<circle cx="15" cy="13" r="4" fill="white" fill-opacity="${approximate ? '0.65' : '0.95'}"/>`;
+  const markerGlyph = glyph
+    ? `<text x="15" y="16" text-anchor="middle" font-family="Arial, sans-serif" font-size="${glyph.length > 2 ? '7.2' : '8.8'}" font-weight="800" fill="${glyphColor}">${glyph}</text>`
+    : approximate
+      ? `<circle cx="15" cy="13" r="4" fill="white" fill-opacity="0.65"/>`
+      : '';
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 30 38">
     <path d="M15 1C8.37258 1 3 6.37258 3 13C3 22 15 37 15 37C15 37 27 22 27 13C27 6.37258 21.6274 1 15 1Z" fill="${fillColor}" stroke="${stroke}" stroke-width="${preferredPartner ? '2.6' : '2'}"/>
-    ${glyph}
+    ${markerGlyph}
   </svg>`;
   const encoded = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
   fallbackMarkerIconCache.set(key, encoded);
@@ -603,9 +605,11 @@ export function GoogleTerritoryMap({
             const selected = selectedSet.has(store.id);
             const approximate = Boolean(store.isApproximate);
             const preferredPartner = Boolean(store.isPreferredPartner);
-            const glyph = preferredPartner ? 'P' : approximate ? '≈' : '';
+            const glyph = pinGlyphForStore(store, pinColorMode);
+            const glyphColor = pinGlyphColorForStore(store, pinColorMode);
             const scale = markerScale({ focused, highlighted, selected, approximate });
             const borderColor = preferredPartner ? '#111111' : approximate ? '#111827' : '#ffffff';
+            const background = pinColorForStore(store, pinColorMode, repColorMap);
 
             if (useAdvancedMarkers) {
               return (
@@ -616,9 +620,9 @@ export function GoogleTerritoryMap({
                     title={store.name}
                 >
                   <Pin
-                    background={pinColorForStore(store, pinColorMode, repColorMap)}
+                    background={background}
                     borderColor={borderColor}
-                    glyphColor="#ffffff"
+                    glyphColor={glyphColor}
                     scale={scale}
                     glyph={glyph}
                   />
@@ -634,7 +638,7 @@ export function GoogleTerritoryMap({
                 title={store.name}
                 opacity={approximate ? 0.78 : 1}
                 icon={{
-                  url: fallbackMarkerIcon(pinColorForStore(store, pinColorMode, repColorMap), approximate, preferredPartner, scale),
+                  url: fallbackMarkerIcon(background, approximate, preferredPartner, glyph, glyphColor, scale),
                 }}
               />
             );

--- a/lib/server/territory-read-model.ts
+++ b/lib/server/territory-read-model.ts
@@ -8,6 +8,7 @@ import {
   preferredPartnerLabel,
   type PreferredPartnerFilter,
 } from '@/lib/territory/preferred-partner';
+import type { PinColorMode } from '@/lib/territory/pin-colors';
 import { normalizeStatus, type TerritoryFilterCount, type TerritoryStorePin } from '@/lib/territory/types';
 
 const CONFIGURED_ORG_ID = process.env.TERRITORY_ORG_ID?.trim() ?? '';
@@ -23,7 +24,7 @@ export interface TerritoryFilterPresetInput {
   selectedStatuses: string[];
   selectedReps: string[];
   showRouteOnly: boolean;
-  pinColorMode: 'status' | 'rep';
+  pinColorMode: PinColorMode;
 }
 
 function asDate(value: string | null | undefined) {

--- a/lib/territory/pin-colors.test.ts
+++ b/lib/territory/pin-colors.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { followUpPinPresentation, pinColorForStore, pinGlyphForStore } from '@/lib/territory/pin-colors';
+import type { TerritoryStorePin } from '@/lib/territory/types';
+
+function buildStore(overrides: Partial<TerritoryStorePin> = {}): TerritoryStorePin {
+  return {
+    id: 'store-1',
+    notionPageId: 'page-1',
+    name: 'Demo Store',
+    status: 'Customer',
+    statusKey: 'customer',
+    statusColor: '#16a34a',
+    statusColorName: 'green',
+    pinKind: 'customer',
+    repNames: ['Donovan Snyder'],
+    repEmails: ['donovan@example.com'],
+    lat: 40.1,
+    lng: -73.9,
+    locationLabel: 'Demo',
+    locationAddress: '123 Main St',
+    locationSource: 'notion-place',
+    locationPrecision: 'exact',
+    isApproximate: false,
+    lastEditedTime: '2026-05-21T15:00:00.000Z',
+    referralSource: null,
+    isPreferredPartner: false,
+    followUpDate: null,
+    ...overrides,
+  };
+}
+
+describe('territory pin colors', () => {
+  const referenceDate = new Date('2026-05-21T16:00:00.000Z');
+
+  it('colors no follow-up date dark blue with a blank label', () => {
+    const store = buildStore({ followUpDate: null });
+
+    expect(followUpPinPresentation(store, referenceDate)).toEqual({
+      color: '#0616b7',
+      daysUntil: null,
+      glyph: '',
+    });
+    expect(pinColorForStore(store, 'follow-up-date', undefined, referenceDate)).toBe('#0616b7');
+    expect(pinGlyphForStore(store, 'follow-up-date', referenceDate)).toBe('');
+  });
+
+  it('colors due-today follow-ups green with 0 inside the pin', () => {
+    const store = buildStore({ followUpDate: '2026-05-21T00:00:00.000Z' });
+
+    expect(followUpPinPresentation(store, referenceDate)).toEqual({
+      color: '#00e63a',
+      daysUntil: 0,
+      glyph: '0',
+    });
+  });
+
+  it('colors upcoming follow-ups light blue with positive labels', () => {
+    const store = buildStore({ followUpDate: '2026-05-24' });
+
+    expect(followUpPinPresentation(store, referenceDate)).toEqual({
+      color: '#a7dcff',
+      daysUntil: 3,
+      glyph: '3',
+    });
+  });
+
+  it('colors overdue follow-ups orange to red with negative labels', () => {
+    const mildlyOverdue = buildStore({ followUpDate: '2026-05-19' });
+    const severelyOverdue = buildStore({ followUpDate: '2026-05-06' });
+
+    expect(followUpPinPresentation(mildlyOverdue, referenceDate)).toEqual({
+      color: '#ff7a00',
+      daysUntil: -2,
+      glyph: '-2',
+    });
+    expect(followUpPinPresentation(severelyOverdue, referenceDate)).toEqual({
+      color: '#d00000',
+      daysUntil: -15,
+      glyph: '-15',
+    });
+  });
+
+  it('suppresses the preferred partner P glyph in follow-up date mode but keeps it in status mode', () => {
+    const store = buildStore({ isPreferredPartner: true, followUpDate: '2026-05-21' });
+
+    expect(pinGlyphForStore(store, 'status', referenceDate)).toBe('P');
+    expect(pinGlyphForStore(store, 'follow-up-date', referenceDate)).toBe('0');
+  });
+});

--- a/lib/territory/pin-colors.ts
+++ b/lib/territory/pin-colors.ts
@@ -1,6 +1,12 @@
 import type { TerritoryStorePin } from '@/lib/territory/types';
 
-export type PinColorMode = 'status' | 'rep';
+export type PinColorMode = 'status' | 'rep' | 'follow-up-date';
+
+export interface TerritoryPinPresentation {
+  color: string;
+  daysUntil: number | null;
+  glyph: string;
+}
 
 const DISTINCT_REP_COLORS = [
   '#7c3aed',
@@ -34,6 +40,13 @@ const FIXED_REP_COLORS: Record<string, string> = {
   eric: '#60a5fa',
   'eric acosta': '#60a5fa',
 };
+
+const FOLLOW_UP_NO_DATE_COLOR = '#0616b7';
+const FOLLOW_UP_UPCOMING_SOON_COLOR = '#a7dcff';
+const FOLLOW_UP_UPCOMING_LATER_COLOR = '#5f7cff';
+const FOLLOW_UP_TODAY_COLOR = '#00e63a';
+const FOLLOW_UP_OVERDUE_RECENT_COLOR = '#ff7a00';
+const FOLLOW_UP_OVERDUE_OLD_COLOR = '#d00000';
 
 function normalizeRepLabel(label: string) {
   return label.trim();
@@ -81,10 +94,86 @@ export function createRepColorMap(labels: string[]) {
   return map;
 }
 
-export function pinColorForStore(store: TerritoryStorePin, mode: PinColorMode, repColorMap?: Map<string, string>) {
+function dateKeyToUtcDay(dateKey: string) {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  if (!year || !month || !day) {
+    return null;
+  }
+  return Date.UTC(year, month - 1, day);
+}
+
+function localDateKey(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function daysUntilFollowUp(followUpDate: string | null | undefined, referenceDate = new Date()) {
+  const dateKey = followUpDate?.slice(0, 10);
+  if (!dateKey) {
+    return null;
+  }
+
+  const followUpDay = dateKeyToUtcDay(dateKey);
+  const referenceDay = dateKeyToUtcDay(localDateKey(referenceDate));
+  if (followUpDay === null || referenceDay === null) {
+    return null;
+  }
+
+  return Math.round((followUpDay - referenceDay) / 86_400_000);
+}
+
+function followUpColorForDays(daysUntil: number | null) {
+  if (daysUntil === null) {
+    return FOLLOW_UP_NO_DATE_COLOR;
+  }
+  if (daysUntil === 0) {
+    return FOLLOW_UP_TODAY_COLOR;
+  }
+  if (daysUntil > 0) {
+    return daysUntil <= 7 ? FOLLOW_UP_UPCOMING_SOON_COLOR : FOLLOW_UP_UPCOMING_LATER_COLOR;
+  }
+  return Math.abs(daysUntil) <= 7 ? FOLLOW_UP_OVERDUE_RECENT_COLOR : FOLLOW_UP_OVERDUE_OLD_COLOR;
+}
+
+export function followUpPinPresentation(store: Pick<TerritoryStorePin, 'followUpDate'>, referenceDate = new Date()): TerritoryPinPresentation {
+  const daysUntil = daysUntilFollowUp(store.followUpDate, referenceDate);
+  return {
+    color: followUpColorForDays(daysUntil),
+    daysUntil,
+    glyph: daysUntil === null ? '' : String(daysUntil),
+  };
+}
+
+export function pinColorForStore(store: TerritoryStorePin, mode: PinColorMode, repColorMap?: Map<string, string>, referenceDate = new Date()) {
+  if (mode === 'follow-up-date') {
+    return followUpPinPresentation(store, referenceDate).color;
+  }
   if (mode === 'rep') {
     const rep = store.repNames.find((name) => name.trim().length > 0) ?? 'Unassigned';
     return repColorMap?.get(rep) ?? repColorForLabel(rep);
   }
   return store.statusColor;
+}
+
+export function pinGlyphForStore(store: TerritoryStorePin, mode: PinColorMode, referenceDate = new Date()) {
+  if (mode === 'follow-up-date') {
+    return followUpPinPresentation(store, referenceDate).glyph;
+  }
+  if (store.isPreferredPartner) {
+    return 'P';
+  }
+  if (store.isApproximate) {
+    return '≈';
+  }
+  return '';
+}
+
+export function pinGlyphColorForStore(store: TerritoryStorePin, mode: PinColorMode, referenceDate = new Date()) {
+  if (mode === 'follow-up-date') {
+    const { daysUntil } = followUpPinPresentation(store, referenceDate);
+    return daysUntil !== null && daysUntil >= 0 ? '#0f172a' : '#ffffff';
+  }
+  return '#ffffff';
 }


### PR DESCRIPTION
Closes #79

## Why
Reps need the territory map to show follow-up urgency directly on the pins, using the requested blue-to-green-to-red heatmap scale and day count labels.

## Scope
- Added a Follow Up Date option to the territory Pin Colors control.
- Added follow-up date pin classification in `lib/territory/pin-colors.ts`: no date dark blue/blank, upcoming blue with positive labels, today green with `0`, overdue orange/red with negative labels.
- Wired map pins so Follow Up Date mode shows day labels inside the pins.
- Preserved Preferred Partner bold pin outlines while suppressing the `P` glyph in Follow Up Date mode.
- Allowed saved filter presets/local saved filters to carry the new pin color mode.

## Out of scope
- No Notion, Neon, Supabase, GHL, Nabis, Vercel, schema, auth, or production data writes.
- No map provider changes.
- No unrelated territory search, account-detail, Notion-link, or route-planning behavior changes.

## Owned paths
- `lib/territory/pin-colors.ts`
- `lib/territory/pin-colors.test.ts`
- `components/mobile/store-filter-sheet.tsx`
- `components/mobile/territory-mobile.tsx`
- `components/mobile/territory-map-overlay-controls.tsx`
- `components/territory/google-territory-map.tsx`
- `app/api/territory/filter-presets/route.ts`
- `lib/server/territory-read-model.ts`
- `SESSION.md`

## Open PR overlap check
Checked open PR #76 and #78. Both touch adjacent territory surfaces and `SESSION.md`; this PR avoids their source behavior and only overlaps on `SESSION.md`.

## Validation
- RED: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test -- lib/territory/pin-colors.test.ts` failed before implementation because the new helper APIs did not exist.
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test -- lib/territory/pin-colors.test.ts`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test -- lib/territory/pin-colors.test.ts lib/territory/preferred-partner.test.ts`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run typecheck`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run lint`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test`
- PASS: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run build`

## Browser proof
- Browser path: Codex in-app Browser.
- Local URL: `http://127.0.0.1:3011/territory` using the existing local env via ignored `.env.local` symlink.
- Flow exercised: `/territory` loads -> Open filters -> select Follow Up Date -> heatmap legend appears -> Apply -> map pins render with blue/orange/red heatmap colors and day labels.
- Mobile check: 390x844 viewport -> Pin Colors three-option control fits; Follow Up Date wraps cleanly without clipping.

## Console notes
- Observed existing Google Maps `google.maps.Marker` deprecation warning.
- Observed an existing local hydration mismatch warning on `/territory` load where the loading shell differs from the hydrated territory shell; the requested interaction still rendered and worked after client regeneration.

## Remaining risk
- Production verification still needs to happen after merge/deploy against `https://piccnewyork.org/territory`.