### PR TITLE
Remove Notion workspace requirement from app access

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,40 +1,39 @@
-# Session: Issue #79 Follow-Up Date Pin Heatmap
+# Session: Issue #83 Remove Notion Auth Gate
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/79
+- https://github.com/brycejohnson1417/Picc-web-app/issues/83
 
 ## Scope
-- Add a Follow Up Date option to the territory Pin Colors UI.
-- Color territory map pins by follow-up urgency using the provided blue-to-green-to-red heatmap direction.
-- Show days until follow-up inside map pins only in Follow Up Date mode.
-- Keep Preferred Partner bold pin outline in Follow Up Date mode while suppressing the `P` glyph.
+- Remove the PICC Notion workspace membership check from app access.
+- Preserve the existing `@piccplatform.com` company email and allowlist gates.
+- Preserve active guest invite and operational invite access.
+- Update sign-in UI copy so it no longer tells team members they need a PICC Notion workspace account.
 
 ## Out Of Scope
-- No Notion, Neon, Supabase, GHL, Nabis, Vercel, schema, auth, or production data writes.
-- No map provider changes.
-- No unrelated territory search, account-detail, Notion-link, or route-planning behavior changes.
+- No Clerk provider changes.
+- No Google-only sign-in changes.
+- No Notion CRM/archive integration changes.
+- No env/secrets, schema changes, production data writes, or production verification claims.
 
 ## Owned Paths
-- `lib/territory/pin-colors.ts`
-- `lib/territory/*.test.ts`
-- `components/mobile/store-filter-sheet.tsx`
-- `components/mobile/territory-mobile.tsx`
-- `components/territory/google-territory-map.tsx`
-- `app/api/territory/filter-presets/route.ts`
+- `lib/auth/access-policy.ts`
+- `lib/auth/access-policy.test.ts`
+- `components/auth/google-only-sign-in-card.tsx`
 - `SESSION.md`
 
 ## Open PR Overlap Check
-- Checked open PR #76. It owns broad `components/mobile/territory-*` search-suggestion paths and `SESSION.md`; this slice avoids search behavior.
-- Checked open PR #78. It owns the focused Notion card/link helper and `SESSION.md`; this slice avoids Notion-link behavior.
-- During rebase, `SESSION.md` conflicted with the landed issue #77 session note. This branch keeps the current issue #79 scope note.
+- Checked open PR #82. It owns docs only (`AGENTS.md`, `AI_HANDOFF.md`) and does not overlap this auth slice.
 
 ## Constraints
-- Production triage style: surgical, additive, one issue per PR.
-- Keep UI components thin; put follow-up date classification/color logic in `lib/territory/pin-colors.ts`.
-- The running browser UI is the source of truth for the feature.
+- Keep Clerk Google-only sign-in.
+- Keep access restricted to allowed `@piccplatform.com` users or active invites.
+- Keep Notion integrations behind server modules for CRM/archive workflows, not app access.
 
 ## Validation Plan
-- RED test first for follow-up date pin color and label classification.
-- Then implement the helper/UI wiring.
-- Run focused tests, typecheck, lint, full test suite, and build.
-- Browser-verify `/territory`: open filters, select Follow Up Date, apply, and confirm map pins show heatmap colors with day labels.
+- Update auth policy tests first to prove allowed company emails no longer require Notion verification.
+- Run `npm test -- lib/auth/access-policy.test.ts`.
+- Run `npm run typecheck`.
+- Run `npm run lint`.
+- Run `npm test`.
+- Run `npm run build`.
+- Browser-check `/sign-in` copy when local Clerk configuration can render the sign-in card.

--- a/components/auth/google-only-sign-in-card.tsx
+++ b/components/auth/google-only-sign-in-card.tsx
@@ -66,7 +66,7 @@ export function GoogleOnlySignInCard() {
         <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primary">piccnewyork.org</p>
         <h1 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Sign in with Google</h1>
         <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
-          Team members must use a <span className="font-semibold">@piccplatform.com</span> Google account that also exists in the PICC Notion workspace. Invited guests can sign in with the exact Google email address that received their read-only invite.
+          Team members must use a <span className="font-semibold">@piccplatform.com</span> Google account. Invited guests can sign in with the exact Google email address that received their invite.
         </p>
       </div>
 

--- a/lib/auth/access-policy.test.ts
+++ b/lib/auth/access-policy.test.ts
@@ -75,21 +75,10 @@ describe('access policy', () => {
     });
   });
 
-  it('rejects allowlisted company emails that are missing from the notion workspace', async () => {
+  it('allows allowlisted company emails without requiring a notion workspace user', async () => {
     process.env.TERRITORY_ALLOWED_EMAILS = '*';
     mockedGetActiveGuestInviteByEmail.mockResolvedValue(null);
     mockedHasNotionWorkspaceUser.mockResolvedValue(false);
-
-    await expect(evaluateUserAccess('rep@piccplatform.com')).resolves.toMatchObject({
-      ok: false,
-      status: 403,
-    });
-  });
-
-  it('allows allowlisted company emails that also exist in notion', async () => {
-    process.env.TERRITORY_ALLOWED_EMAILS = '*';
-    mockedGetActiveGuestInviteByEmail.mockResolvedValue(null);
-    mockedHasNotionWorkspaceUser.mockResolvedValue(true);
 
     await expect(evaluateUserAccess('rep@piccplatform.com')).resolves.toMatchObject({
       ok: true,
@@ -97,6 +86,21 @@ describe('access policy', () => {
       accessType: 'workspace',
       email: 'rep@piccplatform.com',
     });
+    expect(mockedHasNotionWorkspaceUser).not.toHaveBeenCalled();
+  });
+
+  it('does not block allowlisted company emails when notion verification is unavailable', async () => {
+    process.env.TERRITORY_ALLOWED_EMAILS = '*';
+    mockedGetActiveGuestInviteByEmail.mockResolvedValue(null);
+    mockedHasNotionWorkspaceUser.mockRejectedValue(new Error('Notion unavailable'));
+
+    await expect(evaluateUserAccess('rep@piccplatform.com')).resolves.toMatchObject({
+      ok: true,
+      status: 200,
+      accessType: 'workspace',
+      email: 'rep@piccplatform.com',
+    });
+    expect(mockedHasNotionWorkspaceUser).not.toHaveBeenCalled();
   });
 
   it('allows operational invites before company-email checks', async () => {

--- a/lib/auth/access-policy.ts
+++ b/lib/auth/access-policy.ts
@@ -3,7 +3,6 @@ import 'server-only';
 import { isEmailAllowed, parseEmailAllowlist } from '@/lib/auth/email-allowlist';
 import { getActiveGuestInviteByEmail } from '@/lib/auth/guest-invites';
 import { getActiveOperationalInviteByEmail } from '@/lib/auth/operational-invites';
-import { hasNotionWorkspaceUser } from '@/lib/server/notion-workspace-users';
 
 const REQUIRED_EMAIL_DOMAIN = 'piccplatform.com';
 const DEFAULT_ALLOWED_EMAILS = `@${REQUIRED_EMAIL_DOMAIN}`;
@@ -75,24 +74,6 @@ export async function evaluateUserAccess(email: string | null | undefined): Prom
       ok: false,
       status: 403,
       error: 'Your account is not allowlisted for this workspace.',
-    };
-  }
-
-  try {
-    const hasNotionAccount = await hasNotionWorkspaceUser(normalizedEmail);
-    if (!hasNotionAccount) {
-      return {
-        ok: false,
-        status: 403,
-        error: 'Your @piccplatform.com email must also be a Notion workspace account.',
-      };
-    }
-  } catch (error) {
-    console.error('Failed to verify Notion workspace membership:', error);
-    return {
-      ok: false,
-      status: 503,
-      error: 'Notion workspace verification is currently unavailable.',
     };
   }
 


### PR DESCRIPTION
## Summary
- Closes #83
- Removes the PICC Notion workspace account requirement from app access.
- Preserves the existing `@piccplatform.com` domain/allowlist requirement and active guest/operational invite access.
- Updates sign-in copy so the UI reflects the current access rule.

## Scope
- In scope: auth access policy, auth policy tests, sign-in card copy, session scope note.
- Out of scope: Clerk provider changes, Notion CRM/archive behavior, env/secrets, schema changes, production data writes.

## Architecture / Plan Check
- Keeps Clerk Google-only sign-in unchanged.
- Keeps Notion integration behind existing server modules for data workflows.
- Decouples app access from Notion workspace membership so Notion availability cannot block allowed app users.

## Validation
- `npm test -- lib/auth/access-policy.test.ts` passed: 1 file, 8 tests.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm test` passed: 14 files, 78 tests.
- `npm run build` passed.
- Browser check attempted at `http://127.0.0.1:3010/sign-in`; local `DEMO_MODE=true` with no Clerk keys renders the existing Clerk-provider error before the sign-in card, so visual copy proof is blocked by local auth shell configuration. The source copy and build are verified.

## Active PR Overlap
- Checked open PR #82. It owns docs only (`AGENTS.md`, `AI_HANDOFF.md`); no overlap with this PR's owned paths.

## Risk
Auth gate change. Expected behavior is narrower than removing auth: allowed company emails and active invites continue to pass, non-company/non-invited emails continue to fail. No production data, schema, env, or Clerk provider changes are included.
