### PR TITLE
fix: restore territory boundary editing

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,39 +1,41 @@
-# Session: Issue #83 Remove Notion Auth Gate
+# Session: Issue #85 Territory Boundary Editing
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/83
+- https://github.com/brycejohnson1417/Picc-web-app/issues/85
 
 ## Scope
-- Remove the PICC Notion workspace membership check from app access.
-- Preserve the existing `@piccplatform.com` company email and allowlist gates.
-- Preserve active guest invite and operational invite access.
-- Update sign-in UI copy so it no longer tells team members they need a PICC Notion workspace account.
+- Restore territory boundary create/update persistence after the `Territory.geometry` column was removed.
+- Preserve shared boundary visibility through the existing signed-in territory read API.
+- Preserve admin-only mutation access for boundary create/update/delete.
+- Add regression coverage for the removed geometry-column path.
 
 ## Out Of Scope
-- No Clerk provider changes.
-- No Google-only sign-in changes.
-- No Notion CRM/archive integration changes.
-- No env/secrets, schema changes, production data writes, or production verification claims.
+- No map provider changes.
+- No schema migration, production data backfill, or production write operation.
+- No new territory map surface or drawing UX redesign.
+- No Clerk/auth provider changes.
 
 ## Owned Paths
-- `lib/auth/access-policy.ts`
-- `lib/auth/access-policy.test.ts`
-- `components/auth/google-only-sign-in-card.tsx`
+- `lib/server/territory-boundaries.ts`
+- `lib/server/territory-boundaries.test.ts`
+- `app/api/territory/boundaries/**`
+- `components/mobile/**territory**`
 - `SESSION.md`
 
 ## Open PR Overlap Check
-- Checked open PR #82. It owns docs only (`AGENTS.md`, `AI_HANDOFF.md`) and does not overlap this auth slice.
+- Checked open PR #82. It is docs-only project-boundary work and does not overlap this territory slice.
 
 ## Constraints
-- Keep Clerk Google-only sign-in.
-- Keep access restricted to allowed `@piccplatform.com` users or active invites.
-- Keep Notion integrations behind server modules for CRM/archive workflows, not app access.
+- Keep Google Maps as the only map provider.
+- Keep the current mobile-first PWA shell.
+- Keep business logic in server modules and UI components thin.
+- Keep mutations scoped by `orgId`.
 
 ## Validation Plan
-- Update auth policy tests first to prove allowed company emails no longer require Notion verification.
-- Run `npm test -- lib/auth/access-policy.test.ts`.
+- Add a failing Vitest test proving boundary create/update persistence does not reference the removed `geometry` column.
+- Run `npm test -- lib/server/territory-boundaries.test.ts`.
 - Run `npm run typecheck`.
 - Run `npm run lint`.
 - Run `npm test`.
 - Run `npm run build`.
-- Browser-check `/sign-in` copy when local Clerk configuration can render the sign-in card.
+- Start `npm run dev:local` and browser-check `/territory` with the real territory controls reachable.

--- a/lib/server/territory-boundaries.test.ts
+++ b/lib/server/territory-boundaries.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    $executeRaw: vi.fn(),
+    territory: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/db/prisma';
+import { createTerritoryBoundary, updateTerritoryBoundary } from '@/lib/server/territory-boundaries';
+
+const mockedExecuteRaw = vi.mocked(prisma.$executeRaw);
+const mockedFindFirst = vi.mocked(prisma.territory.findFirst as unknown as ReturnType<typeof vi.fn>);
+const mockedUpdateMany = vi.mocked(prisma.territory.updateMany as unknown as ReturnType<typeof vi.fn>);
+
+const savedBoundaryRow = {
+  id: 'boundary_1',
+  name: 'Brooklyn',
+  description: null,
+  color: '#16a34a',
+  borderWidth: 3,
+  isVisibleByDefault: true,
+  geojson: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [-73.99, 40.7],
+        [-73.94, 40.7],
+        [-73.94, 40.73],
+        [-73.99, 40.7],
+      ],
+    ],
+  },
+  createdByEmail: 'admin@piccplatform.com',
+  updatedByEmail: 'admin@piccplatform.com',
+  createdAt: new Date('2026-05-31T12:00:00.000Z'),
+  updatedAt: new Date('2026-05-31T12:00:00.000Z'),
+};
+
+function sqlText(value: unknown) {
+  const sql = value as { strings?: string[] };
+  return Array.isArray(sql.strings) ? sql.strings.join(' ') : String(value);
+}
+
+describe('territory boundaries persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExecuteRaw.mockResolvedValue(1);
+    mockedFindFirst.mockResolvedValue(savedBoundaryRow);
+    mockedUpdateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('creates boundaries without writing the removed geometry column', async () => {
+    const boundary = await createTerritoryBoundary({
+      orgId: 'org_picc',
+      name: 'Brooklyn',
+      color: '#16A34A',
+      borderWidth: 3,
+      actorEmail: 'ADMIN@PICCPLATFORM.COM',
+      coordinates: [
+        [-73.99, 40.7],
+        [-73.94, 40.7],
+        [-73.94, 40.73],
+      ],
+    });
+
+    expect(boundary).toMatchObject({
+      id: 'boundary_1',
+      name: 'Brooklyn',
+      color: '#16a34a',
+      coordinates: [
+        [-73.99, 40.7],
+        [-73.94, 40.7],
+        [-73.94, 40.73],
+      ],
+    });
+    expect(mockedExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(sqlText(mockedExecuteRaw.mock.calls[0]?.[0])).not.toContain('"geometry"');
+  });
+
+  it('updates boundary coordinates without writing the removed geometry column', async () => {
+    await updateTerritoryBoundary({
+      orgId: 'org_picc',
+      boundaryId: 'boundary_1',
+      actorEmail: 'admin@piccplatform.com',
+      coordinates: [
+        [-73.99, 40.7],
+        [-73.94, 40.7],
+        [-73.94, 40.73],
+      ],
+    });
+
+    expect(mockedExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(sqlText(mockedExecuteRaw.mock.calls[0]?.[0])).not.toContain('"geometry"');
+  });
+});

--- a/lib/server/territory-boundaries.ts
+++ b/lib/server/territory-boundaries.ts
@@ -81,10 +81,6 @@ function toGeoJsonString(coordinates: TerritoryBoundaryCoordinates) {
   return JSON.stringify(toGeoJsonPolygon(coordinates));
 }
 
-function geometryFromCoordinates(coordinates: TerritoryBoundaryCoordinates) {
-  return Prisma.sql`ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON(${toGeoJsonString(coordinates)}), 4326))`;
-}
-
 function readCoordinatesFromGeoJson(value: unknown): TerritoryBoundaryCoordinates {
   const polygon = value as GeoJsonPolygon | null | undefined;
   const ring = Array.isArray(polygon?.coordinates?.[0]) ? polygon.coordinates[0] : [];
@@ -187,7 +183,6 @@ export async function createTerritoryBoundary(input: {
         "orgId",
         "name",
         "description",
-        "geometry",
         "color",
         "borderWidth",
         "isVisibleByDefault",
@@ -202,7 +197,6 @@ export async function createTerritoryBoundary(input: {
         ${input.orgId},
         ${name},
         ${description},
-        ${geometryFromCoordinates(coordinates)},
         ${color},
         ${borderWidth},
         ${isVisibleByDefault},
@@ -255,7 +249,7 @@ export async function updateTerritoryBoundary(input: {
   actorEmail?: string | null;
 }) {
   const updateData: Record<string, unknown> = {};
-  let coordinatesForGeometry: TerritoryBoundaryCoordinates | null = null;
+  let coordinatesForGeoJson: TerritoryBoundaryCoordinates | null = null;
 
   if (typeof input.name === 'string') {
     const name = input.name.trim();
@@ -280,7 +274,7 @@ export async function updateTerritoryBoundary(input: {
   if (input.coordinates !== undefined) {
     const coordinates = normalizeCoordinates(input.coordinates);
     updateData.geojson = toGeoJsonPolygon(coordinates);
-    coordinatesForGeometry = coordinates;
+    coordinatesForGeoJson = coordinates;
   }
 
   if (input.isVisibleByDefault !== undefined) {
@@ -289,10 +283,9 @@ export async function updateTerritoryBoundary(input: {
 
   updateData.updatedByEmail = input.actorEmail?.trim().toLowerCase() || null;
 
-  if (coordinatesForGeometry) {
+  if (coordinatesForGeoJson) {
     const setClauses: Prisma.Sql[] = [
-      Prisma.sql`"geojson" = ${toGeoJsonString(coordinatesForGeometry)}::jsonb`,
-      Prisma.sql`"geometry" = ${geometryFromCoordinates(coordinatesForGeometry)}`,
+      Prisma.sql`"geojson" = ${toGeoJsonString(coordinatesForGeoJson)}::jsonb`,
       Prisma.sql`"updatedByEmail" = ${updateData.updatedByEmail as string | null}`,
       Prisma.sql`"updatedAt" = NOW()`,
     ];


### PR DESCRIPTION
Closes #85

## Why
Territory boundary editing failed with Prisma/Postgres error 42703 because the persistence path still wrote the removed "Territory"."geometry" column. The current schema stores territory shapes in "geojson", and the list/read path already maps from "geojson" for everyone signed into the app.

## What changed
- Removed stale "geometry" writes from territory boundary create and coordinate-update SQL.
- Kept boundary create/update/delete scoped by org and behind the existing admin mutation routes.
- Added regression tests proving create/update SQL no longer references the removed column.
- Updated SESSION.md for issue #85 scope and validation.

## What did not change
- No map provider changes.
- No schema migration or production data writes.
- No auth/RBAC broadening beyond existing signed-in read and admin mutation guards.

## Validation
- npm test -- lib/server/territory-boundaries.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build
- Browser check: http://127.0.0.1:3010/territory loads the route shell, but full UI/data verification is blocked locally because OrbStack/Docker is not running, so local Postgres at localhost:5432 is unavailable.

## Owned path globs
- lib/server/territory-boundaries.ts
- lib/server/territory-boundaries.test.ts
- app/api/territory/boundaries/**
- components/mobile/**territory**
- SESSION.md

## Open PR overlap checked
- #82 docs: document PICC/map-app project boundary - docs-only, no overlapping owned path globs.

## Remaining risk
- Full browser interaction against seeded local data is still unverified until local Postgres is available, or after deployment via production browser verification.