### PR TITLE
fix: use demo org for local territory sync

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,41 +1,49 @@
-# Session: Issue #85 Territory Boundary Editing
+# Session: Issue #87 Local Territory Read-Model FK Warning
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/85
+- https://github.com/brycejohnson1417/Picc-web-app/issues/87
 
 ## Scope
-- Restore territory boundary create/update persistence after the `Territory.geometry` column was removed.
-- Preserve shared boundary visibility through the existing signed-in territory read API.
-- Preserve admin-only mutation access for boundary create/update/delete.
-- Add regression coverage for the removed geometry-column path.
+- Stop local territory sync/read-model writes from targeting a non-seeded production org while demo mode is active.
+- Preserve production territory org behavior when demo mode is disabled.
+- Add regression coverage for the local demo-mode org resolution path.
+- Browser-verify `/territory` against local Postgres without the `TerritoryStoreReadModel_orgId_fkey` warning.
 
 ## Out Of Scope
+- No production data writes.
+- No schema migration or backfill.
+- No territory map drawing UX changes.
 - No map provider changes.
-- No schema migration, production data backfill, or production write operation.
-- No new territory map surface or drawing UX redesign.
-- No Clerk/auth provider changes.
+- No auth provider changes.
 
 ## Owned Paths
-- `lib/server/territory-boundaries.ts`
-- `lib/server/territory-boundaries.test.ts`
-- `app/api/territory/boundaries/**`
-- `components/mobile/**territory**`
+- `lib/server/notion-territory.ts`
+- `lib/server/notion-territory.test.ts`
+- `lib/server/territory-read-model.ts`
+- `lib/server/territory-read-model.test.ts`
 - `SESSION.md`
 
 ## Open PR Overlap Check
-- Checked open PR #82. It is docs-only project-boundary work and does not overlap this territory slice.
+- Checked open PR #82. It is docs-only project-boundary work and does not overlap this territory runtime fix.
+
+## Current Evidence
+- Local seed creates `OrganizationWorkspace.id = org_picc_demo`.
+- Local `.env.local` has `DEMO_MODE=true` and `TERRITORY_ORG_ID=org_picc_prod`.
+- `territory-read-model.ts` and `notion-territory.ts` both preferred configured `TERRITORY_ORG_ID` before demo fallback when no explicit org ID was passed.
 
 ## Constraints
 - Keep Google Maps as the only map provider.
 - Keep the current mobile-first PWA shell.
 - Keep business logic in server modules and UI components thin.
 - Keep mutations scoped by `orgId`.
+- Do not rely on editing untracked local env files as the durable fix.
 
 ## Validation Plan
-- Add a failing Vitest test proving boundary create/update persistence does not reference the removed `geometry` column.
-- Run `npm test -- lib/server/territory-boundaries.test.ts`.
+- Add failing Vitest tests proving demo-mode territory read-model writes and sync jobs use `DEMO_ORG_ID` even if `TERRITORY_ORG_ID` is set to the production org.
+- Run the focused regression test.
 - Run `npm run typecheck`.
 - Run `npm run lint`.
 - Run `npm test`.
 - Run `npm run build`.
-- Start `npm run dev:local` and browser-check `/territory` with the real territory controls reachable.
+- Run `npm run db:local:setup`.
+- Start `npm run dev:local` and browser-check `/territory` with no local FK warning in server logs.

--- a/lib/server/notion-territory.test.ts
+++ b/lib/server/notion-territory.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = process.env;
+
+const { territoryStoreSyncJobUpsert } = vi.hoisted(() => ({
+  territoryStoreSyncJobUpsert: vi.fn(),
+}));
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    territoryStoreSyncJob: {
+      upsert: territoryStoreSyncJobUpsert,
+    },
+  },
+}));
+
+describe('notion territory org resolution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      DEMO_MODE: 'true',
+      DEMO_ORG_ID: 'org_picc_demo',
+      TERRITORY_ORG_ID: 'org_picc_prod',
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: '',
+      CLERK_SECRET_KEY: '',
+    };
+    territoryStoreSyncJobUpsert.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses the seeded demo org for queued store sync jobs in demo mode', async () => {
+    const { enqueueTerritoryStoreSync } = await import('@/lib/server/notion-territory');
+
+    await enqueueTerritoryStoreSync(' notion-page-1 ', { reason: 'webhook' });
+
+    expect(territoryStoreSyncJobUpsert).toHaveBeenCalledWith({
+      where: {
+        orgId_notionPageId: {
+          orgId: 'org_picc_demo',
+          notionPageId: 'notion-page-1',
+        },
+      },
+      create: {
+        orgId: 'org_picc_demo',
+        notionPageId: 'notion-page-1',
+        reason: 'webhook',
+        status: 'pending',
+      },
+      update: {
+        reason: 'webhook',
+        status: 'pending',
+        completedAt: null,
+        lastError: null,
+      },
+    });
+  });
+});

--- a/lib/server/notion-territory.ts
+++ b/lib/server/notion-territory.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { prisma } from '@/lib/db/prisma';
 import { isExcludedInternalTransferRetailerName } from '@/lib/nabis/internal-transfers';
-import { AUTH_BYPASS_MODE, DEMO_ORG_ID } from '@/lib/config/runtime';
+import { AUTH_BYPASS_MODE, DEMO_MODE, DEMO_ORG_ID } from '@/lib/config/runtime';
 import {
   getSyncTtlMinutes,
   isSnapshotStale,
@@ -211,6 +211,9 @@ function requiredEnv(name: 'NOTION_API_KEY' | 'NOTION_MASTER_LIST_DATABASE_ID') 
 }
 
 function territoryOrgId() {
+  if (DEMO_MODE) {
+    return DEMO_ORG_ID;
+  }
   const configured = process.env.TERRITORY_ORG_ID?.trim();
   if (configured) {
     return configured;

--- a/lib/server/territory-read-model.test.ts
+++ b/lib/server/territory-read-model.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = process.env;
+
+const {
+  accountFindFirst,
+  checkInCount,
+  executeRawUnsafe,
+  nabisOrderFindMany,
+  territoryStoreReadModelUpsert,
+} = vi.hoisted(() => ({
+  accountFindFirst: vi.fn(),
+  checkInCount: vi.fn(),
+  executeRawUnsafe: vi.fn(),
+  nabisOrderFindMany: vi.fn(),
+  territoryStoreReadModelUpsert: vi.fn(),
+}));
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    $executeRawUnsafe: executeRawUnsafe,
+    account: {
+      findFirst: accountFindFirst,
+    },
+    checkIn: {
+      count: checkInCount,
+    },
+    nabisOrder: {
+      findMany: nabisOrderFindMany,
+    },
+    territoryStoreReadModel: {
+      upsert: territoryStoreReadModelUpsert,
+    },
+  },
+}));
+
+describe('territory read model org resolution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      DEMO_MODE: 'true',
+      DEMO_ORG_ID: 'org_picc_demo',
+      TERRITORY_ORG_ID: 'org_picc_prod',
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: '',
+      CLERK_SECRET_KEY: '',
+    };
+    accountFindFirst.mockResolvedValue(null);
+    checkInCount.mockResolvedValue(0);
+    executeRawUnsafe.mockResolvedValue(1);
+    nabisOrderFindMany.mockResolvedValue([]);
+    territoryStoreReadModelUpsert.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses the seeded demo org for single-store read-model writes in demo mode', async () => {
+    const { syncTerritoryStoreToReadModel } = await import('@/lib/server/territory-read-model');
+
+    const result = await syncTerritoryStoreToReadModel({
+      id: 'store_1',
+      notionPageId: 'notion-page-1',
+      name: 'Demo Store',
+      status: 'Prospect',
+      statusKey: 'prospect',
+      statusColor: 'blue',
+      pinKind: 'lead',
+      repNames: [],
+      repEmails: [],
+      lat: 40.7128,
+      lng: -74.006,
+      locationLabel: 'Demo Store',
+      locationAddress: '1 Demo Way',
+      locationSource: 'notion-place',
+      locationPrecision: 'address',
+      isApproximate: false,
+      lastEditedTime: '2026-05-31T12:00:00.000Z',
+      licenseNumber: null,
+      city: 'New York',
+      state: 'NY',
+      daysOverdue: null,
+      phoneNumber: null,
+      email: null,
+      referralSource: null,
+      followUpDate: null,
+      notes: null,
+      lastCheckIn: null,
+      geometry: {
+        type: 'Point',
+        coordinates: [-74.006, 40.7128],
+      },
+      metrics: {
+        interactionsScore: 0,
+        purchasesScore: 0,
+        followUpUrgencyScore: 0,
+      },
+    });
+
+    expect(result.orgId).toBe('org_picc_demo');
+    expect(territoryStoreReadModelUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          orgId: 'org_picc_demo',
+        }),
+      }),
+    );
+  });
+});

--- a/lib/server/territory-read-model.ts
+++ b/lib/server/territory-read-model.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db/prisma';
-import { AUTH_BYPASS_MODE, DEMO_ORG_ID } from '@/lib/config/runtime';
+import { AUTH_BYPASS_MODE, DEMO_MODE, DEMO_ORG_ID } from '@/lib/config/runtime';
 import {
   normalizeTerritoryOption,
   preferredPartnerLabel,
@@ -160,6 +160,9 @@ function orgIdOrDefault(orgId?: string) {
   const clean = orgId?.trim();
   if (clean) {
     return clean;
+  }
+  if (DEMO_MODE) {
+    return DEMO_ORG_ID;
   }
   if (CONFIGURED_ORG_ID) {
     return CONFIGURED_ORG_ID;


### PR DESCRIPTION
Closes #87.

## Why
Local `/territory` verification was still noisy after the database setup was fixed because demo mode could use a production `TERRITORY_ORG_ID` from local env drift. The local seed creates `org_picc_demo`, so writes under `org_picc_prod` can trigger `TerritoryStoreReadModel_orgId_fkey`.

## What changed
- Demo mode now resolves no-explicit-org territory read-model writes to `DEMO_ORG_ID` before considering `TERRITORY_ORG_ID`.
- Demo mode now resolves queued Notion territory sync jobs to `DEMO_ORG_ID` before considering `TERRITORY_ORG_ID`.
- Added regression coverage for both territory read-model writes and queued territory sync jobs with `DEMO_MODE=true` and `TERRITORY_ORG_ID=org_picc_prod`.
- Updated `SESSION.md` for issue #87.

## What did not change
- No production data writes.
- No schema migration or backfill.
- No territory map drawing UX changes.
- No map provider changes.
- Explicit `orgId` inputs still win for call sites that intentionally pass an org.
- Production `TERRITORY_ORG_ID` behavior remains in place when `DEMO_MODE` is off.

## Validation
- RED: `npm test -- lib/server/notion-territory.test.ts lib/server/territory-read-model.test.ts` failed before the fix because writes used `org_picc_prod`.
- PASS: `npm test -- lib/server/notion-territory.test.ts lib/server/territory-read-model.test.ts`
- PASS: `npm run lint`
- PASS: `npm test`
- PASS: `npm run typecheck`
- PASS: `npm run build`
- PASS: `npm run db:local:setup`
- PASS: local browser check at `http://127.0.0.1:3010/territory`: map rendered, territory APIs returned 200, layers drawer opened, and dev server logs showed no `TerritoryStoreReadModel_orgId_fkey` warning.

## Production proof
Not applicable. This PR does not mutate production data and changes only demo-mode org resolution for no-explicit-org territory sync/read-model operations.

## Remaining risk
Low. The behavior change is gated by `DEMO_MODE`; production runtime with demo mode disabled continues to honor configured `TERRITORY_ORG_ID`.
