### PR TITLE
chore: patch Next and Clerk vulnerabilities

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,49 +1,54 @@
-# Session: Issue #87 Local Territory Read-Model FK Warning
+# Session: Issue #106 Patch Next and Clerk Vulnerabilities
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/87
+- https://github.com/brycejohnson1417/Picc-web-app/issues/106
 
 ## Scope
-- Stop local territory sync/read-model writes from targeting a non-seeded production org while demo mode is active.
-- Preserve production territory org behavior when demo mode is disabled.
-- Add regression coverage for the local demo-mode org resolution path.
-- Browser-verify `/territory` against local Postgres without the `TerritoryStoreReadModel_orgId_fkey` warning.
+- Patch vulnerable production dependency versions for `next` and `@clerk/nextjs`.
+- Keep supporting Next packages on the matching safe `15.x` line.
+- Preserve the current Next 15 app architecture and Clerk Google-only auth model.
+- Add or run focused protected-route/auth verification after the dependency update.
+- Document the remaining audit surface after the direct production vulnerabilities are patched.
 
 ## Out Of Scope
+- No Next 16 migration.
+- No Clerk 7 migration.
+- No auth provider changes.
 - No production data writes.
 - No schema migration or backfill.
-- No territory map drawing UX changes.
-- No map provider changes.
-- No auth provider changes.
+- No UI redesign or route behavior changes beyond dependency compatibility fixes.
 
 ## Owned Paths
-- `lib/server/notion-territory.ts`
-- `lib/server/notion-territory.test.ts`
-- `lib/server/territory-read-model.ts`
-- `lib/server/territory-read-model.test.ts`
+- `package.json`
+- `package-lock.json`
 - `SESSION.md`
+- Auth or middleware regression test files only if dependency compatibility requires coverage changes.
 
 ## Open PR Overlap Check
-- Checked open PR #82. It is docs-only project-boundary work and does not overlap this territory runtime fix.
+- Checked open PR #82. It is docs-only project-boundary work and does not overlap this dependency patch.
 
 ## Current Evidence
-- Local seed creates `OrganizationWorkspace.id = org_picc_demo`.
-- Local `.env.local` has `DEMO_MODE=true` and `TERRITORY_ORG_ID=org_picc_prod`.
-- `territory-read-model.ts` and `notion-territory.ts` both preferred configured `TERRITORY_ORG_ID` before demo fallback when no explicit org ID was passed.
+- `npm audit --json` reports direct production vulnerabilities in `@clerk/nextjs` and `next`.
+- Issue #106 says the safe compatible Next patch target is `15.5.18`.
+- `npm view next@15 version`, `npm view @next/bundle-analyzer@15 version`, and `npm view eslint-config-next@15 version` confirm `15.5.18` exists on the Next 15 line.
+- `npm view @clerk/nextjs@6 version` confirms patched Clerk 6 releases exist after the vulnerable `<=6.39.2` range.
 
 ## Constraints
-- Keep Google Maps as the only map provider.
+- Keep working only in `/Users/brycejohnson/Code/PICC-Web-App`.
+- Keep Google Maps as the only supported map provider.
 - Keep the current mobile-first PWA shell.
-- Keep business logic in server modules and UI components thin.
-- Keep mutations scoped by `orgId`.
-- Do not rely on editing untracked local env files as the durable fix.
+- Keep Clerk as the auth provider and sign-in Google-only.
+- Do not silently bundle unrelated dependency upgrades.
 
 ## Validation Plan
-- Add failing Vitest tests proving demo-mode territory read-model writes and sync jobs use `DEMO_ORG_ID` even if `TERRITORY_ORG_ID` is set to the production org.
-- Run the focused regression test.
+- Run a focused dependency install for:
+  - `next@15.5.18`
+  - `eslint-config-next@15.5.18`
+  - `@next/bundle-analyzer@15.5.18`
+  - `@clerk/nextjs@6.39.5`
+- Rerun `npm audit --omit=dev --audit-level=moderate`.
 - Run `npm run typecheck`.
 - Run `npm run lint`.
 - Run `npm test`.
 - Run `npm run build`.
-- Run `npm run db:local:setup`.
-- Start `npm run dev:local` and browser-check `/territory` with no local FK warning in server logs.
+- Run a protected-route check against the local app after build/dev startup if the dependency update passes static validation.

--- a/SESSION.md
+++ b/SESSION.md
@@ -32,6 +32,8 @@
 - Issue #106 says the safe compatible Next patch target is `15.5.18`.
 - `npm view next@15 version`, `npm view @next/bundle-analyzer@15 version`, and `npm view eslint-config-next@15 version` confirm `15.5.18` exists on the Next 15 line.
 - `npm view @clerk/nextjs@6 version` confirms patched Clerk 6 releases exist after the vulnerable `<=6.39.2` range.
+- `npm audit --omit=dev --audit-level=moderate --json` after the patch no longer reports Clerk vulnerabilities, Next middleware/proxy bypass advisories, or critical vulnerabilities.
+- The remaining production audit findings are outside this issue: Prisma/effect, lodash/defu/dompurify, and `xlsx`.
 
 ## Constraints
 - Keep working only in `/Users/brycejohnson/Code/PICC-Web-App`.
@@ -41,14 +43,16 @@
 - Do not silently bundle unrelated dependency upgrades.
 
 ## Validation Plan
-- Run a focused dependency install for:
+- Completed a focused dependency install for:
   - `next@15.5.18`
   - `eslint-config-next@15.5.18`
   - `@next/bundle-analyzer@15.5.18`
   - `@clerk/nextjs@6.39.5`
-- Rerun `npm audit --omit=dev --audit-level=moderate`.
-- Run `npm run typecheck`.
-- Run `npm run lint`.
-- Run `npm test`.
-- Run `npm run build`.
-- Run a protected-route check against the local app after build/dev startup if the dependency update passes static validation.
+- Added a narrow npm override for `next`'s nested `postcss` dependency to `8.5.15` because Next `15.5.18` still pins audited `postcss@8.4.31`.
+- `npm audit --omit=dev --audit-level=moderate --json`: exits `1` with `0` critical findings and `7` remaining production findings outside this issue.
+- `npm run typecheck`: exits `0`.
+- `npm run lint`: exits `0`.
+- `npm test`: exits `0`; `17` test files and `82` tests passed.
+- `npm run build`: exits `0` with Next `15.5.18`.
+- Local browser check at `http://127.0.0.1:3010/territory`: status `200`, rendered the PICC territory Google map in demo mode.
+- Protected API fail-closed check at `http://127.0.0.1:3011/api/accounts` with `DEMO_MODE=false` and no Clerk keys: returned `503` and `{"error":"Auth environment not configured for production."}`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@clerk/nextjs": "^6.0.0",
+        "@clerk/nextjs": "^6.39.5",
         "@hookform/resolvers": "^4.1.0",
         "@prisma/client": "^6.3.0",
         "@radix-ui/react-avatar": "^1.1.2",
@@ -39,7 +39,7 @@
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
         "lucide-react": "^0.475.0",
-        "next": "^15.1.6",
+        "next": "^15.5.18",
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -54,13 +54,13 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@lhci/cli": "^0.15.1",
-        "@next/bundle-analyzer": "^15.5.0",
+        "@next/bundle-analyzer": "^15.5.18",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.13.0",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "eslint": "^9.19.0",
-        "eslint-config-next": "^15.5.12",
+        "eslint-config-next": "^15.5.18",
         "eslint-plugin-react": "^7.37.5",
         "postcss": "^8.5.1",
         "prisma": "^6.3.0",
@@ -96,13 +96,13 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.31.2.tgz",
-      "integrity": "sha512-eXISM/UAXf8O+YHPGKKcnftUDERut00P/T/ILCYIRq9BiNNv3r+CuZitn4kRyeMW0u9EPlh/l5hiyUjrSrXyXw==",
+      "version": "2.33.5",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.5.tgz",
+      "integrity": "sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.46.0",
-        "@clerk/types": "^4.101.17",
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -111,12 +111,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.0.tgz",
-      "integrity": "sha512-M20kv1rSftll7pZdc3gD5jppcbJSHWDnFHr26CXDOzsqLCYP4ESlqJgv75U0PUcNoM4TgmqsbAP5MrbWIx5Xmg==",
+      "version": "5.61.8",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.8.tgz",
+      "integrity": "sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.46.0",
+        "@clerk/shared": "^3.47.7",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -128,15 +128,15 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.38.0.tgz",
-      "integrity": "sha512-Ot4e6k4oBrP/vN4xYhEum25Sj8M/9ezRpEAKQo/6W64eKEa2ZBaDW1TVN4X52zTMRwA8ENV6QKXuc0ZXEDwhJQ==",
+      "version": "6.39.5",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.5.tgz",
+      "integrity": "sha512-hvdvpiuHXPhlx3iaNfoXO1joZkNP4Lzw83teUNPrzsbOX0rT9QE0uSxS2J/UEAeqoPK6JhNK7dZGvZ9knsB/mg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.31.2",
-        "@clerk/clerk-react": "^5.61.0",
-        "@clerk/shared": "^3.46.0",
-        "@clerk/types": "^4.101.17",
+        "@clerk/backend": "^2.33.5",
+        "@clerk/clerk-react": "^5.61.8",
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -150,16 +150,16 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.46.0.tgz",
-      "integrity": "sha512-JPjpGehaqaWVf9o3EDYpxjQJd0T+ZuzWATbhE+V/Z9hOKvBxbtuKfAAIr/F9o8EbFB5SM+//Vmhs+s6uoAQa5w==",
+      "version": "3.47.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.7.tgz",
+      "integrity": "sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
+        "js-cookie": "3.0.7",
         "std-env": "^3.9.0",
         "swr": "2.3.4"
       },
@@ -186,12 +186,12 @@
       "license": "MIT"
     },
     "node_modules/@clerk/types": {
-      "version": "4.101.17",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.17.tgz",
-      "integrity": "sha512-jg98vDHMew5dSrNKiucgqqd4cbxtLf1CktT8B0G5IqCG+CqbKUawmBEZzm+z7jaQ/zfONN5O8TAC7gK32JbeyA==",
+      "version": "4.101.25",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.25.tgz",
+      "integrity": "sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.46.0"
+        "@clerk/shared": "^3.47.7"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -1160,9 +1160,9 @@
       }
     },
     "node_modules/@next/bundle-analyzer": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.5.12.tgz",
-      "integrity": "sha512-tDkdfvuKz9JlH+B/CEIY0+XqQ5gymVZZWvDer5HJI68rPI0EYfbSadbvIUvHTugYnMkyxSBf8u0P2yGOSQ4h+w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.5.18.tgz",
+      "integrity": "sha512-v5/UNFwYbBlRQg/Bt+wU65XuxCxPu1AeCOI6s4s6Cludsj7FdVO9E9uzr7GIj8OykSrYtGuEQAUX0Ulje8W2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1170,55 +1170,25 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
-      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.12.tgz",
-      "integrity": "sha512-+ZRSDFTv4aC96aMb5E41rMjysx8ApkryevnvEYZvPZO52KvkqP5rNExLUXJFr9P4s0f3oqNQR6vopCZsPWKDcQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.18.tgz",
+      "integrity": "sha512-w4MYq8M26a8PNrfto0JosLf5/3ssln1rsyP96g2DkC8uFVymStM5DLSz5ElxxrPRg2XnTMnFo3kREFlhYvxhWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
       }
     },
-    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
-      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1232,9 +1202,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
-      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -1248,9 +1218,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
-      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -1264,9 +1234,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
-      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -1280,9 +1250,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
-      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -1296,9 +1266,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
-      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -1312,9 +1282,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
-      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -1328,9 +1298,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
-      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -7502,13 +7472,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.12.tgz",
-      "integrity": "sha512-ktW3XLfd+ztEltY5scJNjxjHwtKWk6vU2iwzZqSN09UsbBmMeE/cVlJ1yESg6Yx5LW7p/Z8WzUAgYXGLEmGIpg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.18.tgz",
+      "integrity": "sha512-HuoJU6uUPD00eyiud78IBnT4HLhztFj2V+ild2Uon5ZUrYZKe0Olu2QRD99e9IgL4/H1eg5Onka3BsfRW2U0Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.12",
+        "@next/eslint-plugin-next": "15.5.18",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -8100,6 +8070,36 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -9645,12 +9645,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-library-detector": {
@@ -10652,9 +10652,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -10713,12 +10713,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
-      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.12",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -10731,14 +10731,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.12",
-        "@next/swc-darwin-x64": "15.5.12",
-        "@next/swc-linux-arm64-gnu": "15.5.12",
-        "@next/swc-linux-arm64-musl": "15.5.12",
-        "@next/swc-linux-x64-gnu": "15.5.12",
-        "@next/swc-linux-x64-musl": "15.5.12",
-        "@next/swc-win32-arm64-msvc": "15.5.12",
-        "@next/swc-win32-x64-msvc": "15.5.12",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -10775,9 +10775,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10794,9 +10794,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -11323,9 +11323,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sync:odoo": "tsx services/odoo-sync/src/index.ts"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.0.0",
+    "@clerk/nextjs": "^6.39.5",
     "@hookform/resolvers": "^4.1.0",
     "@prisma/client": "^6.3.0",
     "@radix-ui/react-avatar": "^1.1.2",
@@ -66,7 +66,7 @@
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.475.0",
-    "next": "^15.1.6",
+    "next": "^15.5.18",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -81,13 +81,13 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@lhci/cli": "^0.15.1",
-    "@next/bundle-analyzer": "^15.5.0",
+    "@next/bundle-analyzer": "^15.5.18",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.13.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "eslint": "^9.19.0",
-    "eslint-config-next": "^15.5.12",
+    "eslint-config-next": "^15.5.18",
     "eslint-plugin-react": "^7.37.5",
     "postcss": "^8.5.1",
     "prisma": "^6.3.0",
@@ -95,6 +95,11 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.1.0"
+  },
+  "overrides": {
+    "next": {
+      "postcss": "8.5.15"
+    }
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
## Summary
- Closes #106.
- Patches production auth/routing dependencies: `@clerk/nextjs` to `6.39.5` and `next` to `15.5.18`.
- Keeps matching Next tooling on `15.5.18`: `eslint-config-next` and `@next/bundle-analyzer`.
- Adds a narrow npm override for Next's nested `postcss` to `8.5.15` because Next `15.5.18` still pins audited `postcss@8.4.31`.
- Updates `SESSION.md` with scope, validation, audit result, and remaining out-of-scope audit findings.

## Scope
- In scope: package manifests, lockfile, session documentation, dependency/audit verification.
- Out of scope: Next 16, Clerk 7, auth provider changes, production data/schema changes, UI redesign, unrelated audit findings.

## Validation
- `npm ls next @clerk/nextjs eslint-config-next @next/bundle-analyzer --depth=0`: installed versions are `next@15.5.18`, `@clerk/nextjs@6.39.5`, `eslint-config-next@15.5.18`, `@next/bundle-analyzer@15.5.18`.
- `npm audit --omit=dev --audit-level=moderate --json`: no Clerk findings, no Next middleware/proxy bypass findings, no critical findings. Exits `1` because 7 remaining production findings are outside #106: Prisma/effect, lodash/defu/dompurify, and `xlsx`.
- `npm run typecheck`: pass.
- `npm run lint`: pass.
- `npm test`: pass, 17 files / 82 tests.
- `npm run build`: pass on Next `15.5.18`.
- Local browser check: `http://127.0.0.1:3010/territory` returned 200 and rendered the PICC Google territory map in demo mode.
- Protected API fail-closed check: `DEMO_MODE=false` with no Clerk keys, `GET http://127.0.0.1:3011/api/accounts` returned 503 with `Auth environment not configured for production.`.

## Production Proof
- Not run. This PR changes package versions only and does not perform production data writes or production verification.

## Remaining Risk
- The npm override for Next's nested PostCSS is intentionally narrow but still depends on build/lint/test coverage to catch incompatibility.
- Other production audit findings remain for follow-up issues, especially #107 for `xlsx`.