### PR TITLE
fix: lock down cron route authorization

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,56 +1,53 @@
-# Session: Issue #89 Signed Notion Webhooks
+# Session: Issue #88 Lock Down Cron Sync Routes
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/89
+- https://github.com/brycejohnson1417/Picc-web-app/issues/88
 
 ## Scope
-- Make production Notion webhook handling fail closed when `NOTION_WEBHOOK_SECRET` is missing.
-- Require signature headers and valid `standardwebhooks` verification in production.
-- Ensure invalid signatures return `401` without queuing or syncing work.
-- Stop logging raw Notion verification token values.
-- Preserve local/development setup usability.
-- Add focused route-level tests for webhook authorization and verification-token handling.
+- Make cron route authorization fail closed in production when `CRON_SECRET` is missing.
+- Require `Authorization: Bearer <CRON_SECRET>` when a cron secret is configured.
+- Keep local/development `x-vercel-cron` behavior available when `CRON_SECRET` is not configured.
+- Reuse shared authorization logic between `notion-sync` and `nabis-sync`.
+- Add focused regression coverage for production and local cron authorization behavior.
 
 ## Out Of Scope
-- No redesign of the Notion sync queue.
-- No changes to supported Notion event types unless needed for safety.
-- No production webhook calls.
+- No changes to what the Notion or Nabis sync jobs do.
+- No production sync runs.
 - No production data writes.
 - No schema migration or backfill.
 - No unrelated auth, middleware, or dependency changes.
 
 ## Owned Paths
-- `app/api/webhooks/notion/route.ts`
-- `lib/server/notion-webhook-route.test.ts`
+- `app/api/cron/notion-sync/route.ts`
+- `app/api/cron/nabis-sync/route.ts`
+- `lib/server/cron-auth.ts`
+- `lib/server/cron-auth.test.ts`
 - `SESSION.md`
 
 ## Open PR Overlap Check
-- Checked open PR #82. It is docs-only project-boundary work and does not overlap this webhook route.
-- Checked open PR #116. It is cron route authorization work and does not overlap this webhook route.
+- Checked open PR #82. It is docs-only project-boundary work and does not overlap these cron route paths.
+- Checked open PR #115. It is dependency-manifest work for issue #106 and does not overlap these cron route paths.
+- Checked merged PR #117. It is Notion webhook authorization work and does not overlap these cron route paths.
 
 ## Current Evidence
-- `app/api/webhooks/notion/route.ts` handles `verification_token` before signature enforcement.
-- The endpoint logs the raw verification token value.
-- The endpoint only verifies signatures when both `NOTION_WEBHOOK_SECRET` and all signature headers are present.
-- If the secret is missing, production can accept page/comment events and queue sync work.
-- Red test evidence: `npx vitest run lib/server/notion-webhook-route.test.ts` failed before implementation with `3` failing tests:
-  - production missing secret returned `200` instead of `401`.
-  - production missing signature headers returned `200` instead of `401`.
-  - raw verification token appeared in `console.info` calls.
+- `app/api/cron/notion-sync/route.ts` and `app/api/cron/nabis-sync/route.ts` each define duplicated `isAuthorized` logic.
+- Both routes currently accept any request containing `x-vercel-cron` when `CRON_SECRET` is not configured.
+- Headers are client-controlled, so production must not trust `x-vercel-cron` as the only authorization signal.
+- Red test evidence: `npx vitest run lib/server/cron-auth.test.ts` failed before implementation because `@/lib/server/cron-auth` did not exist.
 
 ## Constraints
 - Keep working only in `/Users/brycejohnson/Code/PICC-Web-App`.
-- Keep webhook changes surgical and isolated to request authorization/token handling.
-- Keep sync queue and mirror behavior untouched after authorization succeeds.
+- Keep cron changes surgical and isolated to route authorization.
+- Keep sync job behavior untouched after authorization succeeds.
 - Keep docs updated as implementation and validation evidence changes.
 
 ## Validation Plan
-- Added Vitest route coverage:
-  - production without `NOTION_WEBHOOK_SECRET` rejects signed or unsigned webhooks before queueing work.
-  - production with `NOTION_WEBHOOK_SECRET` rejects missing signature headers before queueing work.
-  - invalid signatures return `401` before queueing work.
-  - valid signed verification-token handling returns `200` without logging the raw token.
-- `npx vitest run lib/server/notion-webhook-route.test.ts`: exits `0`; `4` tests passed.
+- Added Vitest coverage for the shared cron authorization helper:
+  - production without `CRON_SECRET` rejects `x-vercel-cron`.
+  - production with `CRON_SECRET` rejects missing or wrong bearer token.
+  - production with `CRON_SECRET` accepts the exact bearer token.
+  - development without `CRON_SECRET` still accepts `x-vercel-cron`.
+- `npx vitest run lib/server/cron-auth.test.ts`: exits `0`; `4` tests passed.
 - `npm run typecheck`: exits `0`.
 - `npm run lint`: exits `0`.
 - `npm test`: exits `0`; `18` test files and `86` tests passed.

--- a/app/api/cron/nabis-sync/route.ts
+++ b/app/api/cron/nabis-sync/route.ts
@@ -1,22 +1,13 @@
 import { NextResponse } from 'next/server';
 import { getSharedWorkspaceId } from '@/lib/auth/access-policy';
+import { isCronRequestAuthorized } from '@/lib/server/cron-auth';
 import { nabisCronSyncOptions } from '@/lib/server/nabis-sync-options';
 import { NabisSyncLeaseError, syncNabisRetailersAndOrders } from '@/lib/server/nabis-sync';
 
 export const dynamic = 'force-dynamic';
 
-function isAuthorized(request: Request) {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (secret) {
-    const authHeader = request.headers.get('authorization') ?? '';
-    return authHeader === `Bearer ${secret}`;
-  }
-
-  return Boolean(request.headers.get('x-vercel-cron'));
-}
-
 export async function GET(request: Request) {
-  if (!isAuthorized(request)) {
+  if (!isCronRequestAuthorized(request)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/app/api/cron/notion-sync/route.ts
+++ b/app/api/cron/notion-sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getSharedWorkspaceId } from '@/lib/auth/access-policy';
+import { isCronRequestAuthorized } from '@/lib/server/cron-auth';
 import { prewarmLiveCrmCaches } from '@/lib/server/notion-live-crm';
 import { prewarmTerritoryGeocodeCache, processPendingTerritoryStoreSyncQueue } from '@/lib/server/notion-territory';
 import { syncPendingVendorDayArchiveRequests } from '@/lib/server/notion-vendor-days';
@@ -7,19 +8,8 @@ import { runVendorDayMaintenance } from '@/lib/server/vendor-day-ops';
 
 export const dynamic = 'force-dynamic';
 
-function isAuthorized(request: Request) {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (secret) {
-    const authHeader = request.headers.get('authorization') ?? '';
-    return authHeader === `Bearer ${secret}`;
-  }
-
-  const cronHeader = request.headers.get('x-vercel-cron');
-  return Boolean(cronHeader);
-}
-
 export async function GET(request: Request) {
-  if (!isAuthorized(request)) {
+  if (!isCronRequestAuthorized(request)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/lib/server/cron-auth.test.ts
+++ b/lib/server/cron-auth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { isCronRequestAuthorized } from '@/lib/server/cron-auth';
+
+function requestWithHeaders(headers: HeadersInit = {}) {
+  return new Request('https://piccnewyork.org/api/cron/notion-sync', {
+    headers,
+  });
+}
+
+describe('isCronRequestAuthorized', () => {
+  it('fails closed in production when CRON_SECRET is missing even if x-vercel-cron is present', () => {
+    const authorized = isCronRequestAuthorized(requestWithHeaders({ 'x-vercel-cron': '1' }), {
+      cronSecret: undefined,
+      nodeEnv: 'production',
+    });
+
+    expect(authorized).toBe(false);
+  });
+
+  it('rejects production cron requests when the bearer token is missing or wrong', () => {
+    const missing = isCronRequestAuthorized(requestWithHeaders(), {
+      cronSecret: 'expected-secret',
+      nodeEnv: 'production',
+    });
+    const wrong = isCronRequestAuthorized(requestWithHeaders({ authorization: 'Bearer wrong-secret' }), {
+      cronSecret: 'expected-secret',
+      nodeEnv: 'production',
+    });
+
+    expect(missing).toBe(false);
+    expect(wrong).toBe(false);
+  });
+
+  it('accepts production cron requests with the exact configured bearer token', () => {
+    const authorized = isCronRequestAuthorized(requestWithHeaders({ authorization: 'Bearer expected-secret' }), {
+      cronSecret: 'expected-secret',
+      nodeEnv: 'production',
+    });
+
+    expect(authorized).toBe(true);
+  });
+
+  it('keeps local Vercel cron header behavior when CRON_SECRET is missing outside production', () => {
+    const authorized = isCronRequestAuthorized(requestWithHeaders({ 'x-vercel-cron': '1' }), {
+      cronSecret: undefined,
+      nodeEnv: 'development',
+    });
+
+    expect(authorized).toBe(true);
+  });
+});

--- a/lib/server/cron-auth.ts
+++ b/lib/server/cron-auth.ts
@@ -1,0 +1,20 @@
+type CronAuthorizationOptions = {
+  cronSecret?: string;
+  nodeEnv?: string;
+};
+
+export function isCronRequestAuthorized(request: Request, options: CronAuthorizationOptions = {}) {
+  const secret = (options.cronSecret ?? process.env.CRON_SECRET)?.trim();
+  const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+
+  if (secret) {
+    const authHeader = request.headers.get('authorization') ?? '';
+    return authHeader === `Bearer ${secret}`;
+  }
+
+  if (nodeEnv === 'production') {
+    return false;
+  }
+
+  return Boolean(request.headers.get('x-vercel-cron'));
+}


### PR DESCRIPTION
## Summary
- Closes #88.
- Replaces duplicated cron route authorization logic with shared `isCronRequestAuthorized`.
- Production now fails closed when `CRON_SECRET` is missing, even if callers send `x-vercel-cron`.
- When `CRON_SECRET` is configured, cron requests require the exact `Authorization: Bearer <CRON_SECRET>` header.
- Local/development keeps `x-vercel-cron` fallback only when no secret is configured.
- Updates `SESSION.md` with ownership, red/green test evidence, and validation results.

## Scope
- In scope: `app/api/cron/notion-sync/route.ts`, `app/api/cron/nabis-sync/route.ts`, `lib/server/cron-auth.ts`, `lib/server/cron-auth.test.ts`, `SESSION.md`.
- Out of scope: sync job behavior, production sync runs, production data writes, schema changes, unrelated auth/middleware work.

## Validation
- Red test: `npx vitest run lib/server/cron-auth.test.ts` failed before implementation because `@/lib/server/cron-auth` did not exist.
- `npx vitest run lib/server/cron-auth.test.ts`: pass, 4 tests.
- `npm run typecheck`: pass.
- `npm run lint`: pass.
- `npm test`: pass, 18 files / 86 tests.
- `npm run build`: pass.

## Production Proof
- Not run. This PR changes authorization code only and does not run production cron jobs.

## Remaining Risk
- Production must have `CRON_SECRET` configured in Vercel before scheduled cron calls will succeed. That is intentional for this security fix.