### PR TITLE
fix: require signed Notion webhooks

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -21,7 +21,7 @@
 
 ## Owned Paths
 - `app/api/webhooks/notion/route.ts`
-- `app/api/webhooks/notion/route.test.ts`
+- `lib/server/notion-webhook-route.test.ts`
 - `SESSION.md`
 
 ## Open PR Overlap Check
@@ -33,6 +33,10 @@
 - The endpoint logs the raw verification token value.
 - The endpoint only verifies signatures when both `NOTION_WEBHOOK_SECRET` and all signature headers are present.
 - If the secret is missing, production can accept page/comment events and queue sync work.
+- Red test evidence: `npx vitest run lib/server/notion-webhook-route.test.ts` failed before implementation with `3` failing tests:
+  - production missing secret returned `200` instead of `401`.
+  - production missing signature headers returned `200` instead of `401`.
+  - raw verification token appeared in `console.info` calls.
 
 ## Constraints
 - Keep working only in `/Users/brycejohnson/Code/PICC-Web-App`.
@@ -41,13 +45,13 @@
 - Keep docs updated as implementation and validation evidence changes.
 
 ## Validation Plan
-- Add failing Vitest route coverage:
+- Added Vitest route coverage:
   - production without `NOTION_WEBHOOK_SECRET` rejects signed or unsigned webhooks before queueing work.
   - production with `NOTION_WEBHOOK_SECRET` rejects missing signature headers before queueing work.
   - invalid signatures return `401` before queueing work.
   - valid signed verification-token handling returns `200` without logging the raw token.
-- Run focused webhook route test red, then green after implementation.
-- Run `npm run typecheck`.
-- Run `npm run lint`.
-- Run `npm test`.
-- Run `npm run build`.
+- `npx vitest run lib/server/notion-webhook-route.test.ts`: exits `0`; `4` tests passed.
+- `npm run typecheck`: exits `0`.
+- `npm run lint`: exits `0`.
+- `npm test`: exits `0`; `18` test files and `86` tests passed.
+- `npm run build`: exits `0`.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,58 +1,53 @@
-# Session: Issue #106 Patch Next and Clerk Vulnerabilities
+# Session: Issue #89 Signed Notion Webhooks
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/106
+- https://github.com/brycejohnson1417/Picc-web-app/issues/89
 
 ## Scope
-- Patch vulnerable production dependency versions for `next` and `@clerk/nextjs`.
-- Keep supporting Next packages on the matching safe `15.x` line.
-- Preserve the current Next 15 app architecture and Clerk Google-only auth model.
-- Add or run focused protected-route/auth verification after the dependency update.
-- Document the remaining audit surface after the direct production vulnerabilities are patched.
+- Make production Notion webhook handling fail closed when `NOTION_WEBHOOK_SECRET` is missing.
+- Require signature headers and valid `standardwebhooks` verification in production.
+- Ensure invalid signatures return `401` without queuing or syncing work.
+- Stop logging raw Notion verification token values.
+- Preserve local/development setup usability.
+- Add focused route-level tests for webhook authorization and verification-token handling.
 
 ## Out Of Scope
-- No Next 16 migration.
-- No Clerk 7 migration.
-- No auth provider changes.
+- No redesign of the Notion sync queue.
+- No changes to supported Notion event types unless needed for safety.
+- No production webhook calls.
 - No production data writes.
 - No schema migration or backfill.
-- No UI redesign or route behavior changes beyond dependency compatibility fixes.
+- No unrelated auth, middleware, or dependency changes.
 
 ## Owned Paths
-- `package.json`
-- `package-lock.json`
+- `app/api/webhooks/notion/route.ts`
+- `app/api/webhooks/notion/route.test.ts`
 - `SESSION.md`
-- Auth or middleware regression test files only if dependency compatibility requires coverage changes.
 
 ## Open PR Overlap Check
-- Checked open PR #82. It is docs-only project-boundary work and does not overlap this dependency patch.
+- Checked open PR #82. It is docs-only project-boundary work and does not overlap this webhook route.
+- Checked open PR #116. It is cron route authorization work and does not overlap this webhook route.
 
 ## Current Evidence
-- `npm audit --json` reports direct production vulnerabilities in `@clerk/nextjs` and `next`.
-- Issue #106 says the safe compatible Next patch target is `15.5.18`.
-- `npm view next@15 version`, `npm view @next/bundle-analyzer@15 version`, and `npm view eslint-config-next@15 version` confirm `15.5.18` exists on the Next 15 line.
-- `npm view @clerk/nextjs@6 version` confirms patched Clerk 6 releases exist after the vulnerable `<=6.39.2` range.
-- `npm audit --omit=dev --audit-level=moderate --json` after the patch no longer reports Clerk vulnerabilities, Next middleware/proxy bypass advisories, or critical vulnerabilities.
-- The remaining production audit findings are outside this issue: Prisma/effect, lodash/defu/dompurify, and `xlsx`.
+- `app/api/webhooks/notion/route.ts` handles `verification_token` before signature enforcement.
+- The endpoint logs the raw verification token value.
+- The endpoint only verifies signatures when both `NOTION_WEBHOOK_SECRET` and all signature headers are present.
+- If the secret is missing, production can accept page/comment events and queue sync work.
 
 ## Constraints
 - Keep working only in `/Users/brycejohnson/Code/PICC-Web-App`.
-- Keep Google Maps as the only supported map provider.
-- Keep the current mobile-first PWA shell.
-- Keep Clerk as the auth provider and sign-in Google-only.
-- Do not silently bundle unrelated dependency upgrades.
+- Keep webhook changes surgical and isolated to request authorization/token handling.
+- Keep sync queue and mirror behavior untouched after authorization succeeds.
+- Keep docs updated as implementation and validation evidence changes.
 
 ## Validation Plan
-- Completed a focused dependency install for:
-  - `next@15.5.18`
-  - `eslint-config-next@15.5.18`
-  - `@next/bundle-analyzer@15.5.18`
-  - `@clerk/nextjs@6.39.5`
-- Added a narrow npm override for `next`'s nested `postcss` dependency to `8.5.15` because Next `15.5.18` still pins audited `postcss@8.4.31`.
-- `npm audit --omit=dev --audit-level=moderate --json`: exits `1` with `0` critical findings and `7` remaining production findings outside this issue.
-- `npm run typecheck`: exits `0`.
-- `npm run lint`: exits `0`.
-- `npm test`: exits `0`; `17` test files and `82` tests passed.
-- `npm run build`: exits `0` with Next `15.5.18`.
-- Local browser check at `http://127.0.0.1:3010/territory`: status `200`, rendered the PICC territory Google map in demo mode.
-- Protected API fail-closed check at `http://127.0.0.1:3011/api/accounts` with `DEMO_MODE=false` and no Clerk keys: returned `503` and `{"error":"Auth environment not configured for production."}`.
+- Add failing Vitest route coverage:
+  - production without `NOTION_WEBHOOK_SECRET` rejects signed or unsigned webhooks before queueing work.
+  - production with `NOTION_WEBHOOK_SECRET` rejects missing signature headers before queueing work.
+  - invalid signatures return `401` before queueing work.
+  - valid signed verification-token handling returns `200` without logging the raw token.
+- Run focused webhook route test red, then green after implementation.
+- Run `npm run typecheck`.
+- Run `npm run lint`.
+- Run `npm test`.
+- Run `npm run build`.

--- a/app/api/webhooks/notion/route.ts
+++ b/app/api/webhooks/notion/route.ts
@@ -25,6 +25,42 @@ function webhookSecret() {
   return process.env.NOTION_WEBHOOK_SECRET?.trim() || '';
 }
 
+function isProductionWebhookRuntime() {
+  return process.env.NODE_ENV === 'production' || process.env.VERCEL_ENV === 'production';
+}
+
+function hasRequiredSignatureHeaders(headers: Headers) {
+  return Boolean(headers.get('webhook-id')) && Boolean(headers.get('webhook-signature')) && Boolean(headers.get('webhook-timestamp'));
+}
+
+function verifyWebhookRequest(rawBody: string, headers: Headers) {
+  const secret = webhookSecret();
+
+  if (!secret) {
+    if (isProductionWebhookRuntime()) {
+      return NextResponse.json({ error: 'Notion webhook secret is not configured' }, { status: 401 });
+    }
+
+    return null;
+  }
+
+  if (!hasRequiredSignatureHeaders(headers)) {
+    return NextResponse.json({ error: 'Missing Notion webhook signature headers' }, { status: 401 });
+  }
+
+  try {
+    const verifier = new Webhook(secret);
+    verifier.verify(rawBody, Object.fromEntries(headers.entries()));
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Webhook verification failed' },
+      { status: 401 },
+    );
+  }
+
+  return null;
+}
+
 function resolvePageId(payload: NotionWebhookPayload) {
   const explicitPageId = payload.data?.page_id?.trim();
   if (explicitPageId) {
@@ -53,6 +89,11 @@ function isPageEvent(type: string | undefined) {
 
 export async function POST(request: Request) {
   const rawBody = await request.text();
+  const verificationError = verifyWebhookRequest(rawBody, request.headers);
+  if (verificationError) {
+    return verificationError;
+  }
+
   let parsedPayload: NotionWebhookPayload;
 
   try {
@@ -62,28 +103,10 @@ export async function POST(request: Request) {
   }
 
   if (parsedPayload.verification_token) {
-    console.info('Notion webhook verification token received. Save it to NOTION_WEBHOOK_SECRET if your integration requires signed delivery.', {
-      token: parsedPayload.verification_token,
+    console.info('Notion webhook verification token received. Store it securely if your integration requires signed delivery.', {
+      hasVerificationToken: true,
     });
     return NextResponse.json({ ok: true });
-  }
-
-  const secret = webhookSecret();
-  const hasSignatureHeaders =
-    Boolean(request.headers.get('webhook-id')) &&
-    Boolean(request.headers.get('webhook-signature')) &&
-    Boolean(request.headers.get('webhook-timestamp'));
-
-  if (secret && hasSignatureHeaders) {
-    try {
-      const verifier = new Webhook(secret);
-      verifier.verify(rawBody, Object.fromEntries(request.headers.entries()));
-    } catch (error) {
-      return NextResponse.json(
-        { error: error instanceof Error ? error.message : 'Webhook verification failed' },
-        { status: 401 },
-      );
-    }
   }
 
   if (!isCommentEvent(parsedPayload.type) && !isPageEvent(parsedPayload.type)) {

--- a/lib/server/notion-webhook-route.test.ts
+++ b/lib/server/notion-webhook-route.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Webhook } from 'standardwebhooks';
+
+type LoadedRoute = {
+  POST: (request: Request) => Promise<Response>;
+  enqueueTerritoryStoreSync: ReturnType<typeof vi.fn>;
+  syncTerritoryCheckInMirrorByPageId: ReturnType<typeof vi.fn>;
+};
+
+function setProductionWebhookEnv(secret?: string) {
+  vi.stubEnv('NODE_ENV', 'production');
+  if (secret === undefined) {
+    vi.stubEnv('NOTION_WEBHOOK_SECRET', '');
+  } else {
+    vi.stubEnv('NOTION_WEBHOOK_SECRET', secret);
+  }
+}
+
+async function loadRoute(): Promise<LoadedRoute> {
+  vi.resetModules();
+
+  const enqueueTerritoryStoreSync = vi.fn().mockResolvedValue({ queued: true });
+  const syncTerritoryCheckInMirrorByPageId = vi.fn().mockResolvedValue({ synced: true });
+
+  vi.doMock('@/lib/server/notion-territory', () => ({
+    enqueueTerritoryStoreSync,
+    syncTerritoryCheckInMirrorByPageId,
+  }));
+
+  const route = await import('../../app/api/webhooks/notion/route');
+
+  return {
+    POST: route.POST,
+    enqueueTerritoryStoreSync,
+    syncTerritoryCheckInMirrorByPageId,
+  };
+}
+
+function notionRequest(payload: unknown, headers: HeadersInit = {}) {
+  return new Request('https://piccnewyork.org/api/webhooks/notion', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function signedHeaders(rawBody: string, secret: string) {
+  const verifier = new Webhook(secret);
+  const date = new Date();
+  const signature = await verifier.sign('msg_test', date, rawBody);
+
+  return {
+    'webhook-id': 'msg_test',
+    'webhook-signature': signature,
+    'webhook-timestamp': Math.floor(date.getTime() / 1000).toString(),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.doUnmock('@/lib/server/notion-territory');
+});
+
+describe('Notion webhook route', () => {
+  it('rejects production webhooks when NOTION_WEBHOOK_SECRET is missing before queueing work', async () => {
+    setProductionWebhookEnv();
+    const payload = { type: 'page.updated', entity: { type: 'page', id: 'page_123' } };
+    const rawBody = JSON.stringify(payload);
+    const { POST, enqueueTerritoryStoreSync } = await loadRoute();
+
+    const response = await POST(notionRequest(payload, await signedHeaders(rawBody, 'whsec_testsecret')));
+
+    expect(response.status).toBe(401);
+    expect(enqueueTerritoryStoreSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects production webhooks missing signature headers before queueing work', async () => {
+    setProductionWebhookEnv('whsec_testsecret');
+    const { POST, enqueueTerritoryStoreSync } = await loadRoute();
+
+    const response = await POST(notionRequest({ type: 'page.updated', entity: { type: 'page', id: 'page_123' } }));
+
+    expect(response.status).toBe(401);
+    expect(enqueueTerritoryStoreSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid signatures before queueing work', async () => {
+    setProductionWebhookEnv('whsec_testsecret');
+    const { POST, enqueueTerritoryStoreSync } = await loadRoute();
+
+    const response = await POST(
+      notionRequest(
+        { type: 'page.updated', entity: { type: 'page', id: 'page_123' } },
+        {
+          'webhook-id': 'msg_test',
+          'webhook-signature': 'v1,not-valid',
+          'webhook-timestamp': Math.floor(Date.now() / 1000).toString(),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    expect(enqueueTerritoryStoreSync).not.toHaveBeenCalled();
+  });
+
+  it('accepts signed verification tokens without logging the raw token value', async () => {
+    setProductionWebhookEnv('whsec_testsecret');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const payload = { verification_token: 'raw-token-should-not-be-logged' };
+    const rawBody = JSON.stringify(payload);
+    const { POST } = await loadRoute();
+
+    const response = await POST(notionRequest(payload, await signedHeaders(rawBody, 'whsec_testsecret')));
+
+    expect(response.status).toBe(200);
+    expect(JSON.stringify(infoSpy.mock.calls)).not.toContain('raw-token-should-not-be-logged');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #89.
- Enforces Notion webhook signature verification before payload handling.
- Production now rejects webhook requests when `NOTION_WEBHOOK_SECRET` is missing.
- Requests with a configured secret now require `webhook-id`, `webhook-signature`, and `webhook-timestamp` headers.
- Invalid signatures return `401` before queueing or syncing work.
- Verification-token handling no longer logs the raw token value.
- Updates `SESSION.md` with ownership, red/green evidence, and validation results.

## Scope
- In scope: `app/api/webhooks/notion/route.ts`, `lib/server/notion-webhook-route.test.ts`, `SESSION.md`.
- Out of scope: Notion sync queue redesign, supported event type changes, production webhook calls, production data writes, schema changes, unrelated auth/middleware work.

## Validation
- Red test: `npx vitest run lib/server/notion-webhook-route.test.ts` failed before implementation with 3 failing tests: missing production secret returned 200, missing signatures returned 200, and raw verification token was logged.
- `npx vitest run lib/server/notion-webhook-route.test.ts`: pass, 4 tests.
- `npm run typecheck`: pass.
- `npm run lint`: pass.
- `npm test`: pass, 18 files / 86 tests.
- `npm run build`: pass.

## Production Proof
- Not run. This PR changes webhook authorization only and does not call production webhooks or perform production writes.

## Remaining Risk
- Production must have `NOTION_WEBHOOK_SECRET` configured for real Notion webhook delivery to succeed. Missing configuration will now fail closed intentionally.