### PR TITLE
Add Google My Maps export for territory view

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -31,6 +31,10 @@
 - `ARCHITECTURE.md` keeps the active app surface under `app/`, `components/`, `lib/`, and `prisma/`.
 - `components/mobile/territory-map-mobile.tsx` passes current pins, boundaries, markers, hidden overlay IDs, and map state into `GoogleTerritoryMap`.
 - `components/territory/google-territory-map.tsx` renders the active Google map surface.
+- Red test evidence: `npx vitest run lib/territory/google-my-maps-export.test.ts` initially failed because `@/lib/territory/google-my-maps-export` did not exist.
+- Browser evidence: a fresh Playwright context opened local `/territory`, found the export control, opened the sheet, switched to filtered results, downloaded `picc-territory-view-202606010355.kml`, and confirmed the KML has Accounts, Territories, and Home markers folders.
+- Local data note: the seeded/current local view had 733 exportable pins and 0 visible territory/home overlays at verification time.
+- In-app Browser note: the Codex in-app browser kept serving stale territory controls after restart and hard reload, so rendered proof used the bundled fresh Playwright browser context after recording that cache issue.
 
 ## Constraints
 - Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
@@ -39,9 +43,9 @@
 - Keep business/export formatting logic outside the map component where practical.
 
 ## Validation Plan
-- RED test first for KML generation and hidden overlay filtering.
-- `npm run typecheck`
-- `npm run lint`
-- `npm test`
-- `npm run build`
-- Browser verification on local `/territory` for export UI, state changes, download readiness, and no runtime overlay.
+- `npx vitest run lib/territory/google-my-maps-export.test.ts`: exits `0`; 2 tests passed.
+- `npm run typecheck`: exits `0`.
+- `npm run lint`: exits `0`.
+- `npm test`: exits `0`; 20 test files and 92 tests passed.
+- `npm run build`: exits `0`.
+- Browser verification on local `/territory`: passed in a fresh Playwright context at 390x844; export button visible, sheet interactive, filtered-result scope selectable, KML download emitted, downloaded file parsed for expected folders, and no relevant console errors beyond the existing Google `Marker` deprecation warning.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,54 +1,47 @@
-# Session: Issue #88 Lock Down Cron Sync Routes
+# Session: Issue #118 Google My Maps Export
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/88
+- https://github.com/brycejohnson1417/Picc-web-app/issues/118
 
 ## Scope
-- Make cron route authorization fail closed in production when `CRON_SECRET` is missing.
-- Require `Authorization: Bearer <CRON_SECRET>` when a cron secret is configured.
-- Keep local/development `x-vercel-cron` behavior available when `CRON_SECRET` is not configured.
-- Reuse shared authorization logic between `notion-sync` and `nabis-sync`.
-- Add focused regression coverage for production and local cron authorization behavior.
+- Add a polished `/territory` UI action for exporting the current filtered map view.
+- Generate a Google My Maps-friendly KML file from the current pins, visible territory boundaries, and visible home markers.
+- Include configurable export contents, clear download/import guidance, and empty-state feedback directly in the browser UI.
+- Add focused test coverage for KML generation, escaping, and hidden overlay filtering.
 
 ## Out Of Scope
-- No changes to what the Notion or Nabis sync jobs do.
-- No production sync runs.
-- No production data writes.
-- No schema migration or backfill.
-- No unrelated auth, middleware, or dependency changes.
+- No OAuth write/import into a user's Google account.
+- No production data writes, schema changes, backfills, or new background jobs.
+- No map provider change and no reintroduction of MapLibre, Carto, Leaflet, `MapCanvas`, heatmap, hex, or `/api/territory/layers`.
+- No unrelated territory refactors.
 
 ## Owned Paths
-- `app/api/cron/notion-sync/route.ts`
-- `app/api/cron/nabis-sync/route.ts`
-- `lib/server/cron-auth.ts`
-- `lib/server/cron-auth.test.ts`
+- `components/mobile/territory*.tsx`
+- `components/territory/google-territory-map.tsx`
+- `components/territory/*export*.tsx`
+- `lib/territory/*export*.ts`
+- `lib/territory/*export*.test.ts`
 - `SESSION.md`
 
 ## Open PR Overlap Check
-- Checked open PR #82. It is docs-only project-boundary work and does not overlap these cron route paths.
-- Checked open PR #115. It is dependency-manifest work for issue #106 and does not overlap these cron route paths.
-- Checked merged PR #117. It is Notion webhook authorization work and does not overlap these cron route paths.
+- Checked open PR #82 before starting. It touches `AGENTS.md` and `AI_HANDOFF.md` only, so it does not overlap this slice.
 
 ## Current Evidence
-- `app/api/cron/notion-sync/route.ts` and `app/api/cron/nabis-sync/route.ts` each define duplicated `isAuthorized` logic.
-- Both routes currently accept any request containing `x-vercel-cron` when `CRON_SECRET` is not configured.
-- Headers are client-controlled, so production must not trust `x-vercel-cron` as the only authorization signal.
-- Red test evidence: `npx vitest run lib/server/cron-auth.test.ts` failed before implementation because `@/lib/server/cron-auth` did not exist.
+- `README.md` and `AI_HANDOFF.md` confirm Google Maps is the active and only supported territory map provider.
+- `ARCHITECTURE.md` keeps the active app surface under `app/`, `components/`, `lib/`, and `prisma/`.
+- `components/mobile/territory-map-mobile.tsx` passes current pins, boundaries, markers, hidden overlay IDs, and map state into `GoogleTerritoryMap`.
+- `components/territory/google-territory-map.tsx` renders the active Google map surface.
 
 ## Constraints
-- Keep working only in `/Users/brycejohnson/Code/PICC-Web-App`.
-- Keep cron changes surgical and isolated to route authorization.
-- Keep sync job behavior untouched after authorization succeeds.
-- Keep docs updated as implementation and validation evidence changes.
+- Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
+- Keep the current mobile-first PWA shell and Google Maps implementation.
+- Keep the feature fully interactive from the frontend; no backend-only or placeholder export path.
+- Keep business/export formatting logic outside the map component where practical.
 
 ## Validation Plan
-- Added Vitest coverage for the shared cron authorization helper:
-  - production without `CRON_SECRET` rejects `x-vercel-cron`.
-  - production with `CRON_SECRET` rejects missing or wrong bearer token.
-  - production with `CRON_SECRET` accepts the exact bearer token.
-  - development without `CRON_SECRET` still accepts `x-vercel-cron`.
-- `npx vitest run lib/server/cron-auth.test.ts`: exits `0`; `4` tests passed.
-- `npm run typecheck`: exits `0`.
-- `npm run lint`: exits `0`.
-- `npm test`: exits `0`; `18` test files and `86` tests passed.
-- `npm run build`: exits `0`.
+- RED test first for KML generation and hidden overlay filtering.
+- `npm run typecheck`
+- `npm run lint`
+- `npm test`
+- `npm run build`
+- Browser verification on local `/territory` for export UI, state changes, download readiness, and no runtime overlay.

--- a/components/mobile/territory-map-mobile.tsx
+++ b/components/mobile/territory-map-mobile.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { PinColorMode } from '@/lib/territory/pin-colors';
+import type { GoogleMyMapsViewportBounds } from '@/lib/territory/google-my-maps-export';
 import type { TerritoryBoundary, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
 import type { TerritoryBoundaryDraft } from '@/components/territory/google-territory-boundaries';
 import { GoogleTerritoryMap } from '@/components/territory/google-territory-map';
@@ -30,6 +31,7 @@ interface TerritoryMapMobileProps {
   onSelectStore: (id: string | null) => void;
   onDraftBoundaryChange?: (coordinates: [number, number][]) => void;
   onSelectionBoundaryChange?: (coordinates: [number, number][]) => void;
+  onViewportBoundsChange?: (bounds: GoogleMyMapsViewportBounds | null) => void;
 }
 
 export function TerritoryMapMobile({
@@ -57,6 +59,7 @@ export function TerritoryMapMobile({
   onSelectStore,
   onDraftBoundaryChange,
   onSelectionBoundaryChange,
+  onViewportBoundsChange,
 }: TerritoryMapMobileProps) {
   return (
     <GoogleTerritoryMap
@@ -89,6 +92,7 @@ export function TerritoryMapMobile({
       onSelectStore={onSelectStore}
       onDraftBoundaryChange={onDraftBoundaryChange}
       onSelectionBoundaryChange={onSelectionBoundaryChange}
+      onViewportBoundsChange={onViewportBoundsChange}
     />
   );
 }

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Crosshair, Filter, Layers3, RefreshCw, Search } from 'lucide-react';
+import { Crosshair, Download, Filter, Layers3, RefreshCw, Search } from 'lucide-react';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
@@ -38,6 +38,7 @@ interface TerritoryMapOverlayControlsProps {
   onRefreshData: () => void;
   onToggleMapSearch: () => void;
   onOpenBoundarySheet: () => void;
+  onOpenMyMapsExport: () => void;
   showBoundaries: boolean;
   onOpenFilters: () => void;
   activeFiltersCount: number;
@@ -69,6 +70,7 @@ export function TerritoryMapOverlayControls({
   onRefreshData,
   onToggleMapSearch,
   onOpenBoundarySheet,
+  onOpenMyMapsExport,
   showBoundaries,
   onOpenFilters,
   activeFiltersCount,
@@ -289,6 +291,15 @@ export function TerritoryMapOverlayControls({
         >
           <Filter className={cn('h-5 w-5', activeFiltersCount > 0 ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
           {activeFiltersCount > 0 ? <span className="absolute -right-1 -top-1 grid h-5 min-w-5 place-items-center rounded-full bg-[#cd3814] px-1 text-[11px] font-semibold text-white">{activeFiltersCount}</span> : null}
+        </button>
+        <button
+          type="button"
+          aria-label="Export current map view to Google My Maps"
+          title="Export to My Maps"
+          className="grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow"
+          onClick={onOpenMyMapsExport}
+        >
+          <Download className="h-5 w-5 text-[#7f828a]" />
         </button>
       </div>
     </>

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -12,6 +12,7 @@ import { AccountDetailSheet } from '@/components/mobile/account-detail-sheet';
 import { TerritoryFocusedCard } from '@/components/mobile/territory-focused-card';
 import { TerritoryListPane } from '@/components/mobile/territory-list-pane';
 import { TerritoryMapOverlayControls } from '@/components/mobile/territory-map-overlay-controls';
+import { TerritoryMyMapsExportSheet } from '@/components/mobile/territory-my-maps-export-sheet';
 import {
   TerritoryBoundaryEditor,
   TerritoryBoundarySheet,
@@ -22,6 +23,7 @@ import { StoreFilterSheet } from '@/components/mobile/store-filter-sheet';
 import { useTerritoryData } from '@/components/mobile/use-territory-data';
 import { useTerritoryOverlays } from '@/components/mobile/use-territory-overlays';
 import { MapRenderBoundary } from '@/components/mobile/map-render-boundary';
+import type { GoogleMyMapsViewportBounds } from '@/lib/territory/google-my-maps-export';
 import { createRepColorMap, type PinColorMode } from '@/lib/territory/pin-colors';
 import type { PreferredPartnerFilter } from '@/lib/territory/preferred-partner';
 import type { TerritoryStorePin } from '@/lib/territory/types';
@@ -121,6 +123,8 @@ export function TerritoryMobile() {
   const [locationRequestToken, setLocationRequestToken] = useState(0);
   const [currentLocation, setCurrentLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [showRepLegend, setShowRepLegend] = useState(false);
+  const [showMyMapsExport, setShowMyMapsExport] = useState(false);
+  const [mapViewportBounds, setMapViewportBounds] = useState<GoogleMyMapsViewportBounds | null>(null);
   const [lassoSelection, setLassoSelection] = useState<TerritoryBoundaryEditorState | null>(null);
   const [lassoDrawingMode, setLassoDrawingMode] = useState(false);
   const [lassoSelectedIds, setLassoSelectedIds] = useState<string[]>([]);
@@ -706,6 +710,7 @@ export function TerritoryMobile() {
               onSelectionBoundaryChange={(coordinates) =>
                 setLassoSelection((current) => (current ? { ...current, coordinates } : current))
               }
+              onViewportBoundsChange={setMapViewportBounds}
             />
           </MapRenderBoundary>
 
@@ -755,6 +760,7 @@ export function TerritoryMobile() {
             onRefreshData={() => setRefreshNonce((value) => value + 1)}
             onToggleMapSearch={() => setShowMapSearch((current) => !current)}
             onOpenBoundarySheet={() => setShowBoundarySheet(true)}
+            onOpenMyMapsExport={() => setShowMyMapsExport(true)}
             showBoundaries={showBoundaries}
             onOpenFilters={openFiltersSheet}
             activeFiltersCount={activeFiltersCount}
@@ -859,6 +865,20 @@ export function TerritoryMobile() {
         onCreateMarker={startCreatingMarker}
         onEditMarker={startEditingMarker}
         onDeleteMarker={deleteMarker}
+      />
+      <TerritoryMyMapsExportSheet
+        open={showMyMapsExport}
+        onClose={() => setShowMyMapsExport(false)}
+        stores={mapStores}
+        boundaries={boundaries}
+        markers={markers}
+        showBoundaries={showBoundaries}
+        hiddenBoundaryIds={hiddenBoundaryIds}
+        showMarkers={showMarkers}
+        hiddenMarkerIds={hiddenMarkerIds}
+        viewportBounds={mapViewportBounds}
+        activeFiltersCount={activeFiltersCount}
+        showRouteOnly={showRouteOnly}
       />
       <TerritoryBoundaryEditor
         open={Boolean(boundaryEditor)}

--- a/components/mobile/territory-my-maps-export-sheet.tsx
+++ b/components/mobile/territory-my-maps-export-sheet.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { Download, ExternalLink, Layers3, MapPinned, Pin, X } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  buildGoogleMyMapsKml,
+  googleMyMapsExportFilename,
+  selectGoogleMyMapsExportData,
+  type GoogleMyMapsExportScope,
+  type GoogleMyMapsViewportBounds,
+} from '@/lib/territory/google-my-maps-export';
+import type { TerritoryBoundary, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
+import { cn } from '@/lib/utils';
+
+interface TerritoryMyMapsExportSheetProps {
+  open: boolean;
+  onClose: () => void;
+  stores: TerritoryStorePin[];
+  boundaries: TerritoryBoundary[];
+  markers: TerritoryMarker[];
+  showBoundaries: boolean;
+  hiddenBoundaryIds: string[];
+  showMarkers: boolean;
+  hiddenMarkerIds: string[];
+  viewportBounds: GoogleMyMapsViewportBounds | null;
+  activeFiltersCount: number;
+  showRouteOnly: boolean;
+}
+
+export function TerritoryMyMapsExportSheet({
+  open,
+  onClose,
+  stores,
+  boundaries,
+  markers,
+  showBoundaries,
+  hiddenBoundaryIds,
+  showMarkers,
+  hiddenMarkerIds,
+  viewportBounds,
+  activeFiltersCount,
+  showRouteOnly,
+}: TerritoryMyMapsExportSheetProps) {
+  const [scope, setScope] = useState<GoogleMyMapsExportScope>('viewport');
+  const [includePins, setIncludePins] = useState(true);
+  const [includeBoundaries, setIncludeBoundaries] = useState(true);
+  const [includeMarkers, setIncludeMarkers] = useState(true);
+  const [lastExportLabel, setLastExportLabel] = useState('');
+  const viewportReady = Boolean(viewportBounds);
+  const effectiveScope: GoogleMyMapsExportScope = scope === 'viewport' && !viewportReady ? 'filtered' : scope;
+
+  const exportData = useMemo(
+    () =>
+      selectGoogleMyMapsExportData({
+        stores,
+        boundaries,
+        markers,
+        showBoundaries,
+        hiddenBoundaryIds,
+        showMarkers,
+        hiddenMarkerIds,
+        scope: effectiveScope,
+        viewportBounds,
+        includePins,
+        includeBoundaries,
+        includeMarkers,
+      }),
+    [
+      boundaries,
+      hiddenBoundaryIds,
+      hiddenMarkerIds,
+      includeBoundaries,
+      includeMarkers,
+      includePins,
+      markers,
+      effectiveScope,
+      showBoundaries,
+      showMarkers,
+      stores,
+      viewportBounds,
+    ],
+  );
+
+  const totalExportItems = exportData.stores.length + exportData.boundaries.length + exportData.markers.length;
+
+  function downloadKml() {
+    if (totalExportItems === 0) {
+      toast.message('Nothing visible to export. Adjust the map, filters, or export options first.');
+      return;
+    }
+
+    const generatedAt = new Date();
+    const kml = buildGoogleMyMapsKml({
+      name: `PICC territory ${effectiveScope === 'viewport' ? 'current map view' : 'filtered view'}`,
+      generatedAt: generatedAt.toISOString(),
+      ...exportData,
+    });
+    const blob = new Blob([kml], {
+      type: 'application/vnd.google-earth.kml+xml;charset=utf-8',
+    });
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = googleMyMapsExportFilename(generatedAt);
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    window.setTimeout(() => {
+      window.URL.revokeObjectURL(url);
+    }, 1000);
+
+    const label = `${exportData.stores.length} pins, ${exportData.boundaries.length} territories, ${exportData.markers.length} home markers`;
+    setLastExportLabel(label);
+    toast.success(`KML export ready: ${label}`);
+  }
+
+  function openGoogleMyMaps() {
+    window.open('https://www.google.com/maps/d/u/0/', '_blank', 'noopener,noreferrer');
+  }
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[5000] flex items-end bg-black/35">
+      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close Google My Maps export" onClick={onClose} />
+      <section className="relative mx-auto max-h-[86dvh] w-full max-w-[560px] overflow-y-auto rounded-t-3xl bg-white shadow-[0_-16px_40px_rgba(0,0,0,0.22)]">
+        <div className="sticky top-0 z-10 border-b border-[#e5e7eb] bg-white/95 px-4 pb-3 pt-4 backdrop-blur">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[12px] font-semibold uppercase tracking-wide text-[#c93412]">Google My Maps</p>
+              <h2 className="mt-1 text-[18px] font-semibold text-[#1f2937]">Export current map view</h2>
+              <p className="mt-1 text-[13px] leading-5 text-[#667085]">
+                Download a KML file, import it into My Maps, then share that Google map.
+              </p>
+            </div>
+            <button type="button" className="grid h-10 w-10 shrink-0 place-items-center rounded-xl text-[#667085] hover:bg-[#f2f4f7]" onClick={onClose} aria-label="Close export">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-4 px-4 pb-[calc(env(safe-area-inset-bottom)+24px)] pt-4">
+          <div className="grid grid-cols-3 gap-2 rounded-2xl border border-[#e5e7eb] bg-[#f8fafc] p-2">
+            <Stat label="Pins" value={exportData.stores.length} icon={<Pin className="h-4 w-4" />} />
+            <Stat label="Territories" value={exportData.boundaries.length} icon={<Layers3 className="h-4 w-4" />} />
+            <Stat label="Homes" value={exportData.markers.length} icon={<MapPinned className="h-4 w-4" />} />
+          </div>
+
+          <div className="rounded-2xl border border-[#e5e7eb] bg-white p-3">
+            <p className="text-[13px] font-semibold text-[#1f2937]">Export range</p>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <OptionButton
+                active={effectiveScope === 'viewport'}
+                disabled={!viewportReady}
+                title="Current viewport"
+                description={viewportReady ? 'Only what is inside the map bounds.' : 'Move or load the map first.'}
+                onClick={() => setScope('viewport')}
+              />
+              <OptionButton
+                active={effectiveScope === 'filtered'}
+                title="Filtered results"
+                description="Everything matching active filters."
+                onClick={() => setScope('filtered')}
+              />
+            </div>
+            <p className="mt-3 text-[12px] leading-5 text-[#667085]">
+              {showRouteOnly ? 'Route-only mode is active, so pins are limited to selected route stops. ' : null}
+              {activeFiltersCount > 0 ? `${activeFiltersCount} active filter${activeFiltersCount === 1 ? '' : 's'} are applied. ` : 'No account filters are applied. '}
+              Hidden territory layers stay hidden in the export.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-[#e5e7eb] bg-white p-3">
+            <p className="text-[13px] font-semibold text-[#1f2937]">Include layers</p>
+            <div className="mt-3 space-y-2">
+              <ToggleRow checked={includePins} onChange={setIncludePins} label="Dispensary pins" count={exportData.stores.length} />
+              <ToggleRow checked={includeBoundaries} onChange={setIncludeBoundaries} label="Visible territories" count={exportData.boundaries.length} disabled={!showBoundaries} />
+              <ToggleRow checked={includeMarkers} onChange={setIncludeMarkers} label="Visible home markers" count={exportData.markers.length} disabled={!showMarkers} />
+            </div>
+          </div>
+
+          {totalExportItems === 0 ? (
+            <div className="rounded-2xl border border-[#fed7aa] bg-[#fff7ed] px-3 py-2 text-[13px] leading-5 text-[#9a3412]">
+              This export is empty. Pan back to the accounts, switch to filtered results, or turn on at least one layer.
+            </div>
+          ) : null}
+
+          {lastExportLabel ? (
+            <div className="rounded-2xl border border-[#bbf7d0] bg-[#f0fdf4] px-3 py-2 text-[13px] leading-5 text-[#166534]">
+              Last export included {lastExportLabel}. Open My Maps and import the downloaded KML file.
+            </div>
+          ) : null}
+
+          <div className="sticky bottom-0 -mx-4 grid grid-cols-[1fr_auto] gap-2 border-t border-[#e5e7eb] bg-white/95 px-4 py-3 backdrop-blur">
+            <button
+              type="button"
+              onClick={downloadKml}
+              disabled={totalExportItems === 0}
+              className={cn(
+                'inline-flex h-12 items-center justify-center gap-2 rounded-xl px-4 text-[14px] font-semibold shadow-sm',
+                totalExportItems === 0 ? 'cursor-not-allowed bg-[#e5e7eb] text-[#98a2b3]' : 'bg-[#c93412] text-white active:bg-[#a72b10]',
+              )}
+            >
+              <Download className="h-4 w-4" />
+              Download KML
+            </button>
+            <button
+              type="button"
+              onClick={openGoogleMyMaps}
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-[#d0d5dd] bg-white px-3 text-[14px] font-semibold text-[#344054]"
+            >
+              <ExternalLink className="h-4 w-4" />
+              My Maps
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Stat({ label, value, icon }: { label: string; value: number; icon: ReactNode }) {
+  return (
+    <div className="rounded-xl bg-white px-2 py-2 text-center shadow-sm">
+      <div className="mx-auto flex h-7 w-7 items-center justify-center rounded-lg bg-[#f2f4f7] text-[#667085]">{icon}</div>
+      <p className="mt-1 text-[18px] font-semibold text-[#1f2937]">{value.toLocaleString()}</p>
+      <p className="text-[11px] font-medium text-[#667085]">{label}</p>
+    </div>
+  );
+}
+
+function OptionButton({
+  active,
+  disabled = false,
+  title,
+  description,
+  onClick,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        'min-h-[76px] rounded-xl border px-3 py-2 text-left',
+        active ? 'border-[#c93412] bg-[#fff4f0] text-[#1f2937]' : 'border-[#d0d5dd] bg-white text-[#344054]',
+        disabled ? 'cursor-not-allowed opacity-50' : 'active:bg-[#f9fafb]',
+      )}
+    >
+      <span className="block text-[13px] font-semibold">{title}</span>
+      <span className="mt-1 block text-[12px] leading-4 text-[#667085]">{description}</span>
+    </button>
+  );
+}
+
+function ToggleRow({
+  checked,
+  onChange,
+  label,
+  count,
+  disabled = false,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+  count: number;
+  disabled?: boolean;
+}) {
+  return (
+    <label className={cn('flex min-h-11 items-center justify-between gap-3 rounded-xl border border-[#edf0f3] px-3 py-2', disabled ? 'opacity-50' : '')}>
+      <span>
+        <span className="block text-[14px] font-medium text-[#1f2937]">{label}</span>
+        <span className="block text-[12px] text-[#667085]">{disabled ? 'Layer is hidden on the map' : `${count.toLocaleString()} selected`}</span>
+      </span>
+      <input
+        type="checkbox"
+        className="h-5 w-5 accent-[#c93412]"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+    </label>
+  );
+}

--- a/components/territory/google-territory-map.tsx
+++ b/components/territory/google-territory-map.tsx
@@ -5,6 +5,7 @@ import { AdvancedMarker, APIProvider, Map as GoogleMap, Marker, Pin, useMap } fr
 import { GoogleTerritoryBoundaries, type TerritoryBoundaryDraft } from '@/components/territory/google-territory-boundaries';
 import { GoogleTerritoryMarkers, GoogleTerritoryMarkersFallback } from '@/components/territory/google-territory-markers';
 import { pinColorForStore, pinGlyphColorForStore, pinGlyphForStore, type PinColorMode } from '@/lib/territory/pin-colors';
+import type { GoogleMyMapsViewportBounds } from '@/lib/territory/google-my-maps-export';
 import type { TerritoryBoundary, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
 
@@ -34,6 +35,7 @@ interface GoogleTerritoryMapProps {
   onSelectStore: (storeId: string | null) => void;
   onDraftBoundaryChange?: (coordinates: [number, number][]) => void;
   onSelectionBoundaryChange?: (coordinates: [number, number][]) => void;
+  onViewportBoundsChange?: (bounds: GoogleMyMapsViewportBounds | null) => void;
   className?: string;
   fitPadding?: number;
   maxFitZoom?: number;
@@ -301,6 +303,47 @@ function CurrentLocationController({
   return null;
 }
 
+function ViewportBoundsController({
+  onViewportBoundsChange,
+}: {
+  onViewportBoundsChange?: (bounds: GoogleMyMapsViewportBounds | null) => void;
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map || !onViewportBoundsChange || typeof google === 'undefined') {
+      return;
+    }
+
+    const emitBounds = () => {
+      const bounds = map.getBounds();
+      const northEast = bounds?.getNorthEast();
+      const southWest = bounds?.getSouthWest();
+      if (!northEast || !southWest) {
+        onViewportBoundsChange(null);
+        return;
+      }
+
+      onViewportBoundsChange({
+        north: northEast.lat(),
+        east: northEast.lng(),
+        south: southWest.lat(),
+        west: southWest.lng(),
+      });
+    };
+
+    emitBounds();
+    const listeners = [map.addListener('idle', emitBounds), map.addListener('bounds_changed', emitBounds)];
+    return () => {
+      for (const listener of listeners) {
+        listener.remove();
+      }
+    };
+  }, [map, onViewportBoundsChange]);
+
+  return null;
+}
+
 function markerScale({
   focused,
   highlighted,
@@ -369,6 +412,7 @@ export function GoogleTerritoryMap({
   onSelectStore,
   onDraftBoundaryChange,
   onSelectionBoundaryChange,
+  onViewportBoundsChange,
   className,
   fitPadding = 36,
   maxFitZoom = 12,
@@ -573,6 +617,7 @@ export function GoogleTerritoryMap({
             focusRequestToken={focusRequestToken}
           />
           <CurrentLocationController currentLocation={currentLocation} locationRequestToken={locationRequestToken} />
+          <ViewportBoundsController onViewportBoundsChange={onViewportBoundsChange} />
           <RouteLine routeCoordinates={routeCoordinates} />
           <GoogleTerritoryBoundaries
             boundaries={boundaries}

--- a/lib/territory/google-my-maps-export.test.ts
+++ b/lib/territory/google-my-maps-export.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { buildGoogleMyMapsKml, selectGoogleMyMapsExportData } from '@/lib/territory/google-my-maps-export';
+import type { TerritoryBoundary, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
+
+const baseStore: TerritoryStorePin = {
+  id: 'store-1',
+  notionPageId: 'notion-1',
+  name: 'Astoria & Co',
+  status: 'Customer',
+  statusKey: 'customer',
+  statusColor: '#16a34a',
+  pinKind: 'customer',
+  repNames: ['Ben'],
+  repEmails: ['ben@piccplatform.com'],
+  lat: 40.7643,
+  lng: -73.9235,
+  locationLabel: 'Astoria, NY',
+  locationAddress: '31-01 Ditmars Blvd, Astoria, NY',
+  locationSource: 'google-address-cache',
+  locationPrecision: 'exact',
+  isApproximate: false,
+  lastEditedTime: '2026-05-01T12:00:00.000Z',
+  city: 'Astoria',
+  state: 'NY',
+  referralSource: 'Referral',
+};
+
+const boundary: TerritoryBoundary = {
+  id: 'boundary-1',
+  name: 'Queens <North>',
+  description: 'Primary territory & expansion zone',
+  color: '#cd3814',
+  borderWidth: 2,
+  isVisibleByDefault: true,
+  coordinates: [
+    [-73.95, 40.75],
+    [-73.9, 40.75],
+    [-73.9, 40.8],
+    [-73.95, 40.8],
+  ],
+  createdAt: '2026-05-01T12:00:00.000Z',
+  updatedAt: '2026-05-01T12:00:00.000Z',
+};
+
+const marker: TerritoryMarker = {
+  id: 'marker-1',
+  name: 'Ben Home',
+  address: 'Astoria, NY',
+  lat: 40.765,
+  lng: -73.925,
+  color: '#2563eb',
+  kind: 'home',
+  isVisibleByDefault: true,
+  createdAt: '2026-05-01T12:00:00.000Z',
+  updatedAt: '2026-05-01T12:00:00.000Z',
+};
+
+describe('Google My Maps export', () => {
+  it('exports the current viewport and visible overlays only by default', () => {
+    const selected = selectGoogleMyMapsExportData({
+      stores: [
+        baseStore,
+        {
+          ...baseStore,
+          id: 'store-2',
+          name: 'Brooklyn Shop',
+          lat: 40.6782,
+          lng: -73.9442,
+        },
+      ],
+      boundaries: [boundary, { ...boundary, id: 'hidden-boundary', name: 'Hidden' }],
+      markers: [marker, { ...marker, id: 'hidden-marker', name: 'Hidden Marker' }],
+      showBoundaries: true,
+      hiddenBoundaryIds: ['hidden-boundary'],
+      showMarkers: true,
+      hiddenMarkerIds: ['hidden-marker'],
+      scope: 'viewport',
+      viewportBounds: {
+        north: 40.82,
+        south: 40.72,
+        east: -73.88,
+        west: -73.98,
+      },
+      includePins: true,
+      includeBoundaries: true,
+      includeMarkers: true,
+    });
+
+    expect(selected.stores.map((store) => store.id)).toEqual(['store-1']);
+    expect(selected.boundaries.map((entry) => entry.id)).toEqual(['boundary-1']);
+    expect(selected.markers.map((entry) => entry.id)).toEqual(['marker-1']);
+  });
+
+  it('builds escaped KML folders for accounts, territories, and home markers', () => {
+    const kml = buildGoogleMyMapsKml({
+      name: 'PICC current territory view',
+      generatedAt: '2026-05-31T14:00:00.000Z',
+      stores: [baseStore],
+      boundaries: [boundary],
+      markers: [marker],
+    });
+
+    expect(kml).toContain('<kml xmlns="http://www.opengis.net/kml/2.2">');
+    expect(kml).toContain('<Folder><name>Accounts</name>');
+    expect(kml).toContain('<name>Astoria &amp; Co</name>');
+    expect(kml).toContain('<Folder><name>Territories</name>');
+    expect(kml).toContain('<name>Queens &lt;North&gt;</name>');
+    expect(kml).toContain('<coordinates>-73.95,40.75,0 -73.9,40.75,0 -73.9,40.8,0 -73.95,40.8,0 -73.95,40.75,0</coordinates>');
+    expect(kml).toContain('<Folder><name>Home markers</name>');
+    expect(kml).toContain('<name>Ben Home</name>');
+    expect(kml).toContain('Generated for Google My Maps import on 2026-05-31T14:00:00.000Z.');
+  });
+});

--- a/lib/territory/google-my-maps-export.ts
+++ b/lib/territory/google-my-maps-export.ts
@@ -1,0 +1,239 @@
+import type { TerritoryBoundary, TerritoryBoundaryCoordinates, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
+
+export type GoogleMyMapsExportScope = 'viewport' | 'filtered';
+
+export interface GoogleMyMapsViewportBounds {
+  north: number;
+  south: number;
+  east: number;
+  west: number;
+}
+
+export interface GoogleMyMapsExportSelectionInput {
+  stores: TerritoryStorePin[];
+  boundaries: TerritoryBoundary[];
+  markers: TerritoryMarker[];
+  showBoundaries: boolean;
+  hiddenBoundaryIds: string[];
+  showMarkers: boolean;
+  hiddenMarkerIds: string[];
+  scope: GoogleMyMapsExportScope;
+  viewportBounds?: GoogleMyMapsViewportBounds | null;
+  includePins: boolean;
+  includeBoundaries: boolean;
+  includeMarkers: boolean;
+}
+
+export interface GoogleMyMapsExportData {
+  stores: TerritoryStorePin[];
+  boundaries: TerritoryBoundary[];
+  markers: TerritoryMarker[];
+}
+
+export interface GoogleMyMapsKmlInput extends GoogleMyMapsExportData {
+  name: string;
+  generatedAt: string;
+}
+
+function isFiniteCoordinate(lat: unknown, lng: unknown) {
+  return (
+    typeof lat === 'number' &&
+    Number.isFinite(lat) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    typeof lng === 'number' &&
+    Number.isFinite(lng) &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+function pointInBounds(lat: number, lng: number, bounds: GoogleMyMapsViewportBounds) {
+  const withinLat = lat >= bounds.south && lat <= bounds.north;
+  const withinLng = bounds.west <= bounds.east ? lng >= bounds.west && lng <= bounds.east : lng >= bounds.west || lng <= bounds.east;
+  return withinLat && withinLng;
+}
+
+function boundaryIntersectsBounds(coordinates: TerritoryBoundaryCoordinates, bounds: GoogleMyMapsViewportBounds) {
+  const validCoordinates = coordinates.filter(([lng, lat]) => isFiniteCoordinate(lat, lng));
+  if (validCoordinates.length === 0) {
+    return false;
+  }
+
+  if (validCoordinates.some(([lng, lat]) => pointInBounds(lat, lng, bounds))) {
+    return true;
+  }
+
+  const lats = validCoordinates.map(([, lat]) => lat);
+  const lngs = validCoordinates.map(([lng]) => lng);
+  const boundaryNorth = Math.max(...lats);
+  const boundarySouth = Math.min(...lats);
+  const boundaryEast = Math.max(...lngs);
+  const boundaryWest = Math.min(...lngs);
+
+  return boundaryNorth >= bounds.south && boundarySouth <= bounds.north && boundaryEast >= bounds.west && boundaryWest <= bounds.east;
+}
+
+function viewportFilter<T>(items: T[], scope: GoogleMyMapsExportScope, viewportBounds: GoogleMyMapsViewportBounds | null | undefined, predicate: (item: T, bounds: GoogleMyMapsViewportBounds) => boolean) {
+  if (scope !== 'viewport' || !viewportBounds) {
+    return items;
+  }
+  return items.filter((item) => predicate(item, viewportBounds));
+}
+
+export function selectGoogleMyMapsExportData(input: GoogleMyMapsExportSelectionInput): GoogleMyMapsExportData {
+  const hiddenBoundaryIds = new Set(input.hiddenBoundaryIds);
+  const hiddenMarkerIds = new Set(input.hiddenMarkerIds);
+
+  const stores = input.includePins
+    ? viewportFilter(
+        input.stores.filter((store) => store.locationPrecision !== 'unavailable' && isFiniteCoordinate(store.lat, store.lng)),
+        input.scope,
+        input.viewportBounds,
+        (store, bounds) => pointInBounds(store.lat, store.lng, bounds),
+      )
+    : [];
+
+  const visibleBoundaries =
+    input.includeBoundaries && input.showBoundaries
+      ? input.boundaries.filter((boundary) => !hiddenBoundaryIds.has(boundary.id) && boundary.coordinates.length >= 3)
+      : [];
+  const boundaries = viewportFilter(
+    visibleBoundaries,
+    input.scope,
+    input.viewportBounds,
+    (boundary, bounds) => boundaryIntersectsBounds(boundary.coordinates, bounds),
+  );
+
+  const visibleMarkers =
+    input.includeMarkers && input.showMarkers
+      ? input.markers.filter((marker) => !hiddenMarkerIds.has(marker.id) && isFiniteCoordinate(marker.lat, marker.lng))
+      : [];
+  const markers = viewportFilter(
+    visibleMarkers,
+    input.scope,
+    input.viewportBounds,
+    (marker, bounds) => pointInBounds(marker.lat, marker.lng, bounds),
+  );
+
+  return { stores, boundaries, markers };
+}
+
+function escapeXml(value: string | number | null | undefined) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function kmlColor(hexColor: string, alpha = 'ff') {
+  const match = hexColor.trim().match(/^#?([0-9a-f]{6})$/i);
+  if (!match) {
+    return `${alpha}777777`;
+  }
+  const value = match[1];
+  const red = value.slice(0, 2);
+  const green = value.slice(2, 4);
+  const blue = value.slice(4, 6);
+  return `${alpha}${blue}${green}${red}`.toLowerCase();
+}
+
+function closePolygon(coordinates: TerritoryBoundaryCoordinates) {
+  if (coordinates.length === 0) {
+    return [];
+  }
+  const first = coordinates[0];
+  const last = coordinates[coordinates.length - 1];
+  if (first[0] === last[0] && first[1] === last[1]) {
+    return coordinates;
+  }
+  return [...coordinates, first];
+}
+
+function coordinatesText(coordinates: TerritoryBoundaryCoordinates) {
+  return coordinates.map(([lng, lat]) => `${lng},${lat},0`).join(' ');
+}
+
+function storeDescription(store: TerritoryStorePin) {
+  const lines = [
+    ['Status', store.status],
+    ['Rep', store.repNames.join(', ') || 'Unassigned'],
+    ['Address', store.locationAddress || store.locationLabel || ''],
+    ['City', [store.city, store.state].filter(Boolean).join(', ')],
+    ['Referral source', store.referralSource ?? ''],
+    ['PPP status', store.pppStatus ?? ''],
+    ['Follow-up', store.followUpDate ?? ''],
+  ];
+  return lines
+    .filter(([, value]) => value)
+    .map(([label, value]) => `${label}: ${value}`)
+    .join('\n');
+}
+
+export function buildGoogleMyMapsKml(input: GoogleMyMapsKmlInput) {
+  const styles = [
+    '<Style id="account-pin"><IconStyle><color>ff1238cd</color><scale>1.0</scale><Icon><href>https://maps.google.com/mapfiles/kml/paddle/red-circle.png</href></Icon></IconStyle></Style>',
+    '<Style id="home-marker"><IconStyle><color>ffeb6325</color><scale>1.0</scale><Icon><href>https://maps.google.com/mapfiles/kml/paddle/blu-circle.png</href></Icon></IconStyle></Style>',
+  ];
+
+  const accountPlacemarks = input.stores
+    .map(
+      (store) => `<Placemark>
+  <name>${escapeXml(store.name)}</name>
+  <description>${escapeXml(storeDescription(store))}</description>
+  <styleUrl>#account-pin</styleUrl>
+  <Point><coordinates>${store.lng},${store.lat},0</coordinates></Point>
+</Placemark>`,
+    )
+    .join('\n');
+
+  const boundaryPlacemarks = input.boundaries
+    .map((boundary) => {
+      const styleId = `territory-${boundary.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+      styles.push(`<Style id="${escapeXml(styleId)}"><LineStyle><color>${kmlColor(boundary.color)}</color><width>${boundary.borderWidth}</width></LineStyle><PolyStyle><color>${kmlColor(boundary.color, '33')}</color></PolyStyle></Style>`);
+      return `<Placemark>
+  <name>${escapeXml(boundary.name)}</name>
+  <description>${escapeXml(boundary.description)}</description>
+  <styleUrl>#${escapeXml(styleId)}</styleUrl>
+  <Polygon><outerBoundaryIs><LinearRing><coordinates>${coordinatesText(closePolygon(boundary.coordinates))}</coordinates></LinearRing></outerBoundaryIs></Polygon>
+</Placemark>`;
+    })
+    .join('\n');
+
+  const markerPlacemarks = input.markers
+    .map(
+      (marker) => `<Placemark>
+  <name>${escapeXml(marker.name)}</name>
+  <description>${escapeXml(marker.address || marker.description || 'Home marker')}</description>
+  <styleUrl>#home-marker</styleUrl>
+  <Point><coordinates>${marker.lng},${marker.lat},0</coordinates></Point>
+</Placemark>`,
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+<Document>
+  <name>${escapeXml(input.name)}</name>
+  <description>${escapeXml(`Generated for Google My Maps import on ${input.generatedAt}.`)}</description>
+  ${styles.join('\n  ')}
+  <Folder><name>Accounts</name>
+${accountPlacemarks}
+  </Folder>
+  <Folder><name>Territories</name>
+${boundaryPlacemarks}
+  </Folder>
+  <Folder><name>Home markers</name>
+${markerPlacemarks}
+  </Folder>
+</Document>
+</kml>
+`;
+}
+
+export function googleMyMapsExportFilename(generatedAt = new Date()) {
+  const stamp = generatedAt.toISOString().slice(0, 16).replace(/[-:T]/g, '');
+  return `picc-territory-view-${stamp}.kml`;
+}


### PR DESCRIPTION
## Summary
- Adds a fully interactive Google My Maps export sheet on `/territory`.
- Exports the current map pins plus visible territory and home-marker overlays into a Google My Maps-friendly `.kml` file.
- Tracks live Google Maps viewport bounds, supports current-viewport vs filtered-result export scope, includes layer toggles, empty-state copy, download status, and a My Maps launch button.

Closes #118

## Scope
- In scope: `/territory` export UI, KML generation, visible overlay filtering, viewport-bound tracking, focused tests, browser proof.
- Out of scope: OAuth writes to Google accounts, production data writes, schema changes, alternate map providers.

## Owned path globs
- `components/mobile/territory*.tsx`
- `components/territory/google-territory-map.tsx`
- `components/territory/*export*.tsx`
- `lib/territory/*export*.ts`
- `lib/territory/*export*.test.ts`
- `SESSION.md`

## Active PR overlap check
- Checked PR #82; it touches `AGENTS.md` and `AI_HANDOFF.md` only. No path overlap.

## Validation
- RED: `npx vitest run lib/territory/google-my-maps-export.test.ts` initially failed because the module did not exist.
- `npx vitest run lib/territory/google-my-maps-export.test.ts` passes: 2 tests.
- `npm run typecheck` passes.
- `npm run lint` passes.
- `npm test` passes: 20 files, 92 tests.
- `npm run build` passes.
- Browser proof: fresh Playwright context at `390x844` opened local `/territory`, opened the My Maps export sheet, switched to filtered results, downloaded `picc-territory-view-202606010355.kml`, and verified the file contains Accounts, Territories, and Home markers KML folders.

## Notes / Remaining Risk
- This is a KML export/import workflow, not direct Google account mutation. Users still import the downloaded KML into Google My Maps and share from Google.
- Local seed/current data showed 733 exportable pins and 0 visible territory/home overlays during QA; KML folder structure and overlay filtering are covered by unit tests.
- The Codex in-app browser kept showing stale cached territory controls, so rendered proof used a fresh bundled Playwright browser context after that cache issue was observed.