### PR TITLE
Add territory CSV export mode

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -34,6 +34,10 @@
 - `components/mobile/territory-map-overlay-controls.tsx` owns the left/right overlay control placement.
 - `components/mobile/territory-my-maps-export-sheet.tsx` owns the current export sheet UI and KML download action.
 - `lib/territory/google-my-maps-export.ts` owns current viewport/filtered export selection and KML generation.
+- Red test evidence: `npx vitest run lib/territory/account-csv-export.test.ts` initially failed because `@/lib/territory/account-csv-export` did not exist.
+- Browser evidence: the Codex in-app Browser loaded stale territory controls from its cache and did not expose the new export button; after recording that blocker, a fresh Playwright context verified local `/territory`.
+- Fresh Playwright evidence: export button rendered on the left control rail at `x=8`; CSV mode exported `picc-territory-accounts-202606010414.csv` with 733 account rows; unchecking `Status` and checking `Latitude`/`Longitude` changed the CSV header; KML still exported `picc-territory-view-202606010414.kml` with the Accounts folder.
+- Screenshot evidence saved outside the repo: `/tmp/picc-export-left-control.png`, `/tmp/picc-export-kml-mode.png`, `/tmp/picc-export-csv-mode-top.png`, `/tmp/picc-export-csv-mode.png`.
 
 ## Constraints
 - Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
@@ -43,9 +47,9 @@
 
 ## Validation Plan
 - Red first: add focused failing tests for configurable account CSV output.
-- `npx vitest run lib/territory/account-csv-export.test.ts`
-- `npm run typecheck`
-- `npm run lint`
-- `npm test`
-- `npm run build`
-- Browser verification on local `/territory`: export control placement, export sheet mode switching, CSV field toggles, CSV download contents, and existing KML path.
+- `npx vitest run lib/territory/account-csv-export.test.ts lib/territory/google-my-maps-export.test.ts`: exits `0`; 2 files and 4 tests passed.
+- `npm run typecheck`: exits `0`.
+- `npm run lint`: exits `0`.
+- `npm test`: exits `0`; 21 files and 94 tests passed.
+- `npm run build`: exits `0`.
+- Browser verification on local `/territory`: passed in a fresh Playwright context at 390x844; left-side export control visible, export sheet mode switching works, CSV field toggles affect downloaded CSV contents, and existing KML path still downloads.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,17 +1,19 @@
-# Session: Issue #118 Google My Maps Export
+# Session: Issue #120 Territory Export CSV Mode
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/118
+- https://github.com/brycejohnson1417/Picc-web-app/issues/120
 
 ## Scope
-- Add a polished `/territory` UI action for exporting the current filtered map view.
-- Generate a Google My Maps-friendly KML file from the current pins, visible territory boundaries, and visible home markers.
-- Include configurable export contents, clear download/import guidance, and empty-state feedback directly in the browser UI.
-- Add focused test coverage for KML generation, escaping, and hidden overlay filtering.
+- Move the `/territory` export control from the right-hand map controls to the left-hand control rail.
+- Keep the existing Google My Maps KML export workflow available from the export sheet.
+- Add an account CSV export mode for the accounts currently shown by the selected map scope.
+- Add visible CSV column toggles so the downloaded headers and row fields are configurable directly from the UI.
+- Add focused coverage for CSV escaping, selected-column order, and omitted disabled columns.
 
 ## Out Of Scope
-- No OAuth write/import into a user's Google account.
+- No Google OAuth write/import automation.
 - No production data writes, schema changes, backfills, or new background jobs.
+- No all-account detail fanout fetches; CSV uses fields already loaded for the current territory map/list view.
 - No map provider change and no reintroduction of MapLibre, Carto, Leaflet, `MapCanvas`, heatmap, hex, or `/api/territory/layers`.
 - No unrelated territory refactors.
 
@@ -27,25 +29,23 @@
 - Checked open PR #82 before starting. It touches `AGENTS.md` and `AI_HANDOFF.md` only, so it does not overlap this slice.
 
 ## Current Evidence
-- `README.md` and `AI_HANDOFF.md` confirm Google Maps is the active and only supported territory map provider.
-- `ARCHITECTURE.md` keeps the active app surface under `app/`, `components/`, `lib/`, and `prisma/`.
-- `components/mobile/territory-map-mobile.tsx` passes current pins, boundaries, markers, hidden overlay IDs, and map state into `GoogleTerritoryMap`.
-- `components/territory/google-territory-map.tsx` renders the active Google map surface.
-- Red test evidence: `npx vitest run lib/territory/google-my-maps-export.test.ts` initially failed because `@/lib/territory/google-my-maps-export` did not exist.
-- Browser evidence: a fresh Playwright context opened local `/territory`, found the export control, opened the sheet, switched to filtered results, downloaded `picc-territory-view-202606010355.kml`, and confirmed the KML has Accounts, Territories, and Home markers folders.
-- Local data note: the seeded/current local view had 733 exportable pins and 0 visible territory/home overlays at verification time.
-- In-app Browser note: the Codex in-app browser kept serving stale territory controls after restart and hard reload, so rendered proof used the bundled fresh Playwright browser context after recording that cache issue.
+- Existing issue #118 / PR #119 shipped KML generation and the export sheet from the territory map.
+- `README.md`, `AI_HANDOFF.md`, and `AGENTS.md` keep Google Maps as the active and only supported territory map provider.
+- `components/mobile/territory-map-overlay-controls.tsx` owns the left/right overlay control placement.
+- `components/mobile/territory-my-maps-export-sheet.tsx` owns the current export sheet UI and KML download action.
+- `lib/territory/google-my-maps-export.ts` owns current viewport/filtered export selection and KML generation.
 
 ## Constraints
 - Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
 - Keep the current mobile-first PWA shell and Google Maps implementation.
-- Keep the feature fully interactive from the frontend; no backend-only or placeholder export path.
-- Keep business/export formatting logic outside the map component where practical.
+- Keep the feature fully interactive from the frontend; no backend-only or placeholder CSV path.
+- Keep export formatting logic outside map rendering components where practical.
 
 ## Validation Plan
-- `npx vitest run lib/territory/google-my-maps-export.test.ts`: exits `0`; 2 tests passed.
-- `npm run typecheck`: exits `0`.
-- `npm run lint`: exits `0`.
-- `npm test`: exits `0`; 20 test files and 92 tests passed.
-- `npm run build`: exits `0`.
-- Browser verification on local `/territory`: passed in a fresh Playwright context at 390x844; export button visible, sheet interactive, filtered-result scope selectable, KML download emitted, downloaded file parsed for expected folders, and no relevant console errors beyond the existing Google `Marker` deprecation warning.
+- Red first: add focused failing tests for configurable account CSV output.
+- `npx vitest run lib/territory/account-csv-export.test.ts`
+- `npm run typecheck`
+- `npm run lint`
+- `npm test`
+- `npm run build`
+- Browser verification on local `/territory`: export control placement, export sheet mode switching, CSV field toggles, CSV download contents, and existing KML path.

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -261,6 +261,15 @@ export function TerritoryMapOverlayControls({
             <path d="M12 18.5v2.5" />
           </svg>
         </button>
+        <button
+          type="button"
+          aria-label="Open territory export options"
+          title="Export"
+          className="grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow"
+          onClick={onOpenMyMapsExport}
+        >
+          <Download className="h-5 w-5 text-[#7f828a]" />
+        </button>
       </div>
 
       <div className="absolute right-2 top-3 z-[1500] flex flex-col gap-2">
@@ -291,15 +300,6 @@ export function TerritoryMapOverlayControls({
         >
           <Filter className={cn('h-5 w-5', activeFiltersCount > 0 ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
           {activeFiltersCount > 0 ? <span className="absolute -right-1 -top-1 grid h-5 min-w-5 place-items-center rounded-full bg-[#cd3814] px-1 text-[11px] font-semibold text-white">{activeFiltersCount}</span> : null}
-        </button>
-        <button
-          type="button"
-          aria-label="Export current map view to Google My Maps"
-          title="Export to My Maps"
-          className="grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow"
-          onClick={onOpenMyMapsExport}
-        >
-          <Download className="h-5 w-5 text-[#7f828a]" />
         </button>
       </div>
     </>

--- a/components/mobile/territory-my-maps-export-sheet.tsx
+++ b/components/mobile/territory-my-maps-export-sheet.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import { Download, ExternalLink, Layers3, MapPinned, Pin, X } from 'lucide-react';
+import { Download, ExternalLink, FileSpreadsheet, Layers3, MapPinned, Pin, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import {
+  ACCOUNT_CSV_COLUMNS,
+  accountCsvExportFilename,
+  buildAccountCsv,
+  getDefaultAccountCsvColumnKeys,
+  type AccountCsvColumnKey,
+} from '@/lib/territory/account-csv-export';
 import {
   buildGoogleMyMapsKml,
   googleMyMapsExportFilename,
@@ -29,6 +36,8 @@ interface TerritoryMyMapsExportSheetProps {
   showRouteOnly: boolean;
 }
 
+type ExportMode = 'my-maps' | 'csv';
+
 export function TerritoryMyMapsExportSheet({
   open,
   onClose,
@@ -48,6 +57,8 @@ export function TerritoryMyMapsExportSheet({
   const [includeBoundaries, setIncludeBoundaries] = useState(true);
   const [includeMarkers, setIncludeMarkers] = useState(true);
   const [lastExportLabel, setLastExportLabel] = useState('');
+  const [mode, setMode] = useState<ExportMode>('my-maps');
+  const [selectedCsvColumnKeys, setSelectedCsvColumnKeys] = useState<AccountCsvColumnKey[]>(() => getDefaultAccountCsvColumnKeys());
   const viewportReady = Boolean(viewportBounds);
   const effectiveScope: GoogleMyMapsExportScope = scope === 'viewport' && !viewportReady ? 'filtered' : scope;
 
@@ -84,6 +95,33 @@ export function TerritoryMyMapsExportSheet({
   );
 
   const totalExportItems = exportData.stores.length + exportData.boundaries.length + exportData.markers.length;
+  const csvStores = useMemo(
+    () =>
+      selectGoogleMyMapsExportData({
+        stores,
+        boundaries: [],
+        markers: [],
+        showBoundaries: false,
+        hiddenBoundaryIds: [],
+        showMarkers: false,
+        hiddenMarkerIds: [],
+        scope: effectiveScope,
+        viewportBounds,
+        includePins: true,
+        includeBoundaries: false,
+        includeMarkers: false,
+      }).stores,
+    [effectiveScope, stores, viewportBounds],
+  );
+  const selectedCsvColumnCount = selectedCsvColumnKeys.length;
+
+  function toggleCsvColumn(key: AccountCsvColumnKey, checked: boolean) {
+    setSelectedCsvColumnKeys((current) => {
+      const next = checked ? [...current, key] : current.filter((value) => value !== key);
+      const selected = new Set(next);
+      return ACCOUNT_CSV_COLUMNS.map((column) => column.key).filter((columnKey) => selected.has(columnKey));
+    });
+  }
 
   function downloadKml() {
     if (totalExportItems === 0) {
@@ -116,6 +154,37 @@ export function TerritoryMyMapsExportSheet({
     toast.success(`KML export ready: ${label}`);
   }
 
+  function downloadCsv() {
+    if (csvStores.length === 0) {
+      toast.message('No accounts are available for this CSV range. Pan the map or switch to filtered results.');
+      return;
+    }
+    if (selectedCsvColumnKeys.length === 0) {
+      toast.message('Select at least one CSV column before downloading.');
+      return;
+    }
+
+    const generatedAt = new Date();
+    const csv = buildAccountCsv({ stores: csvStores, columnKeys: selectedCsvColumnKeys });
+    const blob = new Blob([csv], {
+      type: 'text/csv;charset=utf-8',
+    });
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = accountCsvExportFilename(generatedAt);
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    window.setTimeout(() => {
+      window.URL.revokeObjectURL(url);
+    }, 1000);
+
+    const label = `${csvStores.length} accounts, ${selectedCsvColumnKeys.length} columns`;
+    setLastExportLabel(label);
+    toast.success(`CSV export ready: ${label}`);
+  }
+
   function openGoogleMyMaps() {
     window.open('https://www.google.com/maps/d/u/0/', '_blank', 'noopener,noreferrer');
   }
@@ -126,15 +195,15 @@ export function TerritoryMyMapsExportSheet({
 
   return (
     <div className="fixed inset-0 z-[5000] flex items-end bg-black/35">
-      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close Google My Maps export" onClick={onClose} />
+      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close territory export" onClick={onClose} />
       <section className="relative mx-auto max-h-[86dvh] w-full max-w-[560px] overflow-y-auto rounded-t-3xl bg-white shadow-[0_-16px_40px_rgba(0,0,0,0.22)]">
         <div className="sticky top-0 z-10 border-b border-[#e5e7eb] bg-white/95 px-4 pb-3 pt-4 backdrop-blur">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <p className="text-[12px] font-semibold uppercase tracking-wide text-[#c93412]">Google My Maps</p>
+              <p className="text-[12px] font-semibold uppercase tracking-wide text-[#c93412]">Territory Export</p>
               <h2 className="mt-1 text-[18px] font-semibold text-[#1f2937]">Export current map view</h2>
               <p className="mt-1 text-[13px] leading-5 text-[#667085]">
-                Download a KML file, import it into My Maps, then share that Google map.
+                Export a shareable Google map file or download the visible account details as CSV.
               </p>
             </div>
             <button type="button" className="grid h-10 w-10 shrink-0 place-items-center rounded-xl text-[#667085] hover:bg-[#f2f4f7]" onClick={onClose} aria-label="Close export">
@@ -144,10 +213,27 @@ export function TerritoryMyMapsExportSheet({
         </div>
 
         <div className="space-y-4 px-4 pb-[calc(env(safe-area-inset-bottom)+24px)] pt-4">
+          <div className="grid grid-cols-2 gap-2 rounded-2xl border border-[#e5e7eb] bg-[#f8fafc] p-2">
+            <ModeButton
+              active={mode === 'my-maps'}
+              title="Google My Maps"
+              description="Pins, territories, homes"
+              icon={<MapPinned className="h-4 w-4" />}
+              onClick={() => setMode('my-maps')}
+            />
+            <ModeButton
+              active={mode === 'csv'}
+              title="Account CSV"
+              description="Accounts and fields"
+              icon={<FileSpreadsheet className="h-4 w-4" />}
+              onClick={() => setMode('csv')}
+            />
+          </div>
+
           <div className="grid grid-cols-3 gap-2 rounded-2xl border border-[#e5e7eb] bg-[#f8fafc] p-2">
-            <Stat label="Pins" value={exportData.stores.length} icon={<Pin className="h-4 w-4" />} />
+            <Stat label={mode === 'csv' ? 'Accounts' : 'Pins'} value={mode === 'csv' ? csvStores.length : exportData.stores.length} icon={<Pin className="h-4 w-4" />} />
             <Stat label="Territories" value={exportData.boundaries.length} icon={<Layers3 className="h-4 w-4" />} />
-            <Stat label="Homes" value={exportData.markers.length} icon={<MapPinned className="h-4 w-4" />} />
+            <Stat label={mode === 'csv' ? 'CSV fields' : 'Homes'} value={mode === 'csv' ? selectedCsvColumnCount : exportData.markers.length} icon={mode === 'csv' ? <FileSpreadsheet className="h-4 w-4" /> : <MapPinned className="h-4 w-4" />} />
           </div>
 
           <div className="rounded-2xl border border-[#e5e7eb] bg-white p-3">
@@ -174,52 +260,148 @@ export function TerritoryMyMapsExportSheet({
             </p>
           </div>
 
-          <div className="rounded-2xl border border-[#e5e7eb] bg-white p-3">
-            <p className="text-[13px] font-semibold text-[#1f2937]">Include layers</p>
-            <div className="mt-3 space-y-2">
-              <ToggleRow checked={includePins} onChange={setIncludePins} label="Dispensary pins" count={exportData.stores.length} />
-              <ToggleRow checked={includeBoundaries} onChange={setIncludeBoundaries} label="Visible territories" count={exportData.boundaries.length} disabled={!showBoundaries} />
-              <ToggleRow checked={includeMarkers} onChange={setIncludeMarkers} label="Visible home markers" count={exportData.markers.length} disabled={!showMarkers} />
+          {mode === 'my-maps' ? (
+            <div className="rounded-2xl border border-[#e5e7eb] bg-white p-3">
+              <p className="text-[13px] font-semibold text-[#1f2937]">Include layers</p>
+              <div className="mt-3 space-y-2">
+                <ToggleRow checked={includePins} onChange={setIncludePins} label="Dispensary pins" count={exportData.stores.length} />
+                <ToggleRow checked={includeBoundaries} onChange={setIncludeBoundaries} label="Visible territories" count={exportData.boundaries.length} disabled={!showBoundaries} />
+                <ToggleRow checked={includeMarkers} onChange={setIncludeMarkers} label="Visible home markers" count={exportData.markers.length} disabled={!showMarkers} />
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="rounded-2xl border border-[#e5e7eb] bg-white p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[13px] font-semibold text-[#1f2937]">CSV columns</p>
+                  <p className="mt-1 text-[12px] leading-5 text-[#667085]">
+                    CSV uses account fields already loaded for this map view. Select the exact columns to include.
+                  </p>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <button
+                    type="button"
+                    className="rounded-lg border border-[#d0d5dd] px-2 py-1 text-[12px] font-semibold text-[#344054]"
+                    onClick={() => setSelectedCsvColumnKeys(ACCOUNT_CSV_COLUMNS.map((column) => column.key))}
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg border border-[#d0d5dd] px-2 py-1 text-[12px] font-semibold text-[#344054]"
+                    onClick={() => setSelectedCsvColumnKeys(getDefaultAccountCsvColumnKeys())}
+                  >
+                    Default
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 grid max-h-[280px] grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+                {ACCOUNT_CSV_COLUMNS.map((column) => (
+                  <label key={column.key} className="flex min-h-10 items-center gap-2 rounded-xl border border-[#edf0f3] px-3 py-2 text-[13px] font-medium text-[#1f2937]">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 accent-[#c93412]"
+                      checked={selectedCsvColumnKeys.includes(column.key)}
+                      onChange={(event) => toggleCsvColumn(column.key, event.currentTarget.checked)}
+                    />
+                    <span className="min-w-0 truncate">{column.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
 
-          {totalExportItems === 0 ? (
+          {mode === 'my-maps' && totalExportItems === 0 ? (
             <div className="rounded-2xl border border-[#fed7aa] bg-[#fff7ed] px-3 py-2 text-[13px] leading-5 text-[#9a3412]">
               This export is empty. Pan back to the accounts, switch to filtered results, or turn on at least one layer.
             </div>
           ) : null}
 
-          {lastExportLabel ? (
-            <div className="rounded-2xl border border-[#bbf7d0] bg-[#f0fdf4] px-3 py-2 text-[13px] leading-5 text-[#166534]">
-              Last export included {lastExportLabel}. Open My Maps and import the downloaded KML file.
+          {mode === 'csv' && (csvStores.length === 0 || selectedCsvColumnKeys.length === 0) ? (
+            <div className="rounded-2xl border border-[#fed7aa] bg-[#fff7ed] px-3 py-2 text-[13px] leading-5 text-[#9a3412]">
+              {csvStores.length === 0 ? 'No accounts are available for this CSV range. Pan the map or switch to filtered results.' : 'Select at least one CSV column before downloading.'}
             </div>
           ) : null}
 
-          <div className="sticky bottom-0 -mx-4 grid grid-cols-[1fr_auto] gap-2 border-t border-[#e5e7eb] bg-white/95 px-4 py-3 backdrop-blur">
-            <button
-              type="button"
-              onClick={downloadKml}
-              disabled={totalExportItems === 0}
-              className={cn(
-                'inline-flex h-12 items-center justify-center gap-2 rounded-xl px-4 text-[14px] font-semibold shadow-sm',
-                totalExportItems === 0 ? 'cursor-not-allowed bg-[#e5e7eb] text-[#98a2b3]' : 'bg-[#c93412] text-white active:bg-[#a72b10]',
-              )}
-            >
-              <Download className="h-4 w-4" />
-              Download KML
-            </button>
-            <button
-              type="button"
-              onClick={openGoogleMyMaps}
-              className="inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-[#d0d5dd] bg-white px-3 text-[14px] font-semibold text-[#344054]"
-            >
-              <ExternalLink className="h-4 w-4" />
-              My Maps
-            </button>
+          {lastExportLabel ? (
+            <div className="rounded-2xl border border-[#bbf7d0] bg-[#f0fdf4] px-3 py-2 text-[13px] leading-5 text-[#166534]">
+              Last export included {lastExportLabel}.
+            </div>
+          ) : null}
+
+          <div className={cn('sticky bottom-0 -mx-4 gap-2 border-t border-[#e5e7eb] bg-white/95 px-4 py-3 backdrop-blur', mode === 'my-maps' ? 'grid grid-cols-[1fr_auto]' : 'grid')}>
+            {mode === 'my-maps' ? (
+              <>
+                <button
+                  type="button"
+                  onClick={downloadKml}
+                  disabled={totalExportItems === 0}
+                  className={cn(
+                    'inline-flex h-12 items-center justify-center gap-2 rounded-xl px-4 text-[14px] font-semibold shadow-sm',
+                    totalExportItems === 0 ? 'cursor-not-allowed bg-[#e5e7eb] text-[#98a2b3]' : 'bg-[#c93412] text-white active:bg-[#a72b10]',
+                  )}
+                >
+                  <Download className="h-4 w-4" />
+                  Download KML
+                </button>
+                <button
+                  type="button"
+                  onClick={openGoogleMyMaps}
+                  className="inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-[#d0d5dd] bg-white px-3 text-[14px] font-semibold text-[#344054]"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  My Maps
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={downloadCsv}
+                disabled={csvStores.length === 0 || selectedCsvColumnKeys.length === 0}
+                className={cn(
+                  'inline-flex h-12 items-center justify-center gap-2 rounded-xl px-4 text-[14px] font-semibold shadow-sm',
+                  csvStores.length === 0 || selectedCsvColumnKeys.length === 0 ? 'cursor-not-allowed bg-[#e5e7eb] text-[#98a2b3]' : 'bg-[#c93412] text-white active:bg-[#a72b10]',
+                )}
+              >
+                <Download className="h-4 w-4" />
+                Download CSV
+              </button>
+            )}
           </div>
         </div>
       </section>
     </div>
+  );
+}
+
+function ModeButton({
+  active,
+  title,
+  description,
+  icon,
+  onClick,
+}: {
+  active: boolean;
+  title: string;
+  description: string;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex min-h-[82px] flex-col items-start gap-2 rounded-xl border px-3 py-2 text-left',
+        active ? 'border-[#c93412] bg-[#fff4f0] text-[#1f2937]' : 'border-transparent bg-white text-[#344054]',
+      )}
+      onClick={onClick}
+    >
+      <span className={cn('grid h-8 w-8 shrink-0 place-items-center rounded-lg', active ? 'bg-[#c93412] text-white' : 'bg-[#f2f4f7] text-[#667085]')}>{icon}</span>
+      <span className="min-w-0">
+        <span className="block text-[13px] font-semibold leading-4">{title}</span>
+        <span className="mt-0.5 block text-[12px] leading-4 text-[#667085]">{description}</span>
+      </span>
+    </button>
   );
 }
 

--- a/lib/territory/account-csv-export.test.ts
+++ b/lib/territory/account-csv-export.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { buildAccountCsv, getDefaultAccountCsvColumnKeys } from '@/lib/territory/account-csv-export';
+import type { TerritoryStorePin } from '@/lib/territory/types';
+
+const baseStore: TerritoryStorePin = {
+  id: 'store-1',
+  notionPageId: 'notion-1',
+  name: 'Astoria & Co',
+  status: 'Customer',
+  statusKey: 'customer',
+  statusColor: '#16a34a',
+  pinKind: 'customer',
+  repNames: ['Ben', 'Roxy'],
+  repEmails: ['ben@piccplatform.com', 'roxy@piccplatform.com'],
+  lat: 40.7643,
+  lng: -73.9235,
+  locationLabel: 'Astoria, NY',
+  locationAddress: '31-01 Ditmars Blvd, Astoria, NY',
+  locationSource: 'google-address-cache',
+  locationPrecision: 'exact',
+  isApproximate: false,
+  lastEditedTime: '2026-05-01T12:00:00.000Z',
+  licenseNumber: 'OCM-CAURD-123',
+  city: 'Astoria',
+  state: 'NY',
+  daysOverdue: 4,
+  phoneNumber: '555-0100',
+  email: 'ops@example.com',
+  vendorDayStatus: 'Requested',
+  lastSampleOrderDate: '2026-04-14',
+  lastSampleDeliveryDate: '2026-04-16',
+  lastOrderDate: '2026-04-30',
+  referralSource: 'Referral, buyer',
+  pppStatus: 'Approved & Connected',
+  headsetConnectionStatus: 'Connected to PICC Headset',
+  isPreferredPartner: true,
+  followUpDate: '2026-05-10',
+  followUpNeeded: true,
+  followUpReason: 'Needs "display" reset',
+  notes: 'First line\nSecond line',
+  lastCheckIn: '2026-05-02',
+};
+
+describe('account CSV export', () => {
+  it('builds selected account columns in the requested order with CSV escaping', () => {
+    const csv = buildAccountCsv({
+      stores: [baseStore],
+      columnKeys: ['name', 'repNames', 'referralSource', 'notes', 'lat', 'lng'],
+    });
+
+    expect(csv).toBe(
+      [
+        'Account Name,Reps,Referral Source,Notes,Latitude,Longitude',
+        '"Astoria & Co","Ben; Roxy","Referral, buyer","First line\nSecond line",40.7643,-73.9235',
+      ].join('\n'),
+    );
+  });
+
+  it('omits unselected columns and exposes sensible defaults', () => {
+    const defaults = getDefaultAccountCsvColumnKeys();
+
+    expect(defaults).toContain('name');
+    expect(defaults).toContain('status');
+    expect(defaults).toContain('repNames');
+    expect(defaults).not.toContain('notionPageId');
+
+    const csv = buildAccountCsv({
+      stores: [baseStore],
+      columnKeys: ['name', 'status'],
+    });
+
+    expect(csv).toBe(['Account Name,Status', '"Astoria & Co","Customer"'].join('\n'));
+    expect(csv).not.toContain('OCM-CAURD-123');
+    expect(csv).not.toContain('notion-1');
+  });
+});

--- a/lib/territory/account-csv-export.ts
+++ b/lib/territory/account-csv-export.ts
@@ -1,0 +1,116 @@
+import type { TerritoryStorePin } from '@/lib/territory/types';
+
+export type AccountCsvColumnKey =
+  | 'name'
+  | 'status'
+  | 'pinKind'
+  | 'repNames'
+  | 'city'
+  | 'state'
+  | 'locationAddress'
+  | 'phoneNumber'
+  | 'email'
+  | 'licenseNumber'
+  | 'referralSource'
+  | 'pppStatus'
+  | 'headsetConnectionStatus'
+  | 'isPreferredPartner'
+  | 'vendorDayStatus'
+  | 'followUpDate'
+  | 'followUpNeeded'
+  | 'followUpReason'
+  | 'lastCheckIn'
+  | 'lastSampleOrderDate'
+  | 'lastSampleDeliveryDate'
+  | 'lastOrderDate'
+  | 'daysOverdue'
+  | 'notes'
+  | 'lat'
+  | 'lng'
+  | 'locationPrecision'
+  | 'locationSource'
+  | 'isApproximate'
+  | 'notionPageId'
+  | 'notionUrl'
+  | 'lastEditedTime';
+
+export interface AccountCsvColumn {
+  key: AccountCsvColumnKey;
+  label: string;
+  defaultSelected: boolean;
+  getValue: (store: TerritoryStorePin) => string | number | boolean | null | undefined;
+}
+
+export const ACCOUNT_CSV_COLUMNS: AccountCsvColumn[] = [
+  { key: 'name', label: 'Account Name', defaultSelected: true, getValue: (store) => store.name },
+  { key: 'status', label: 'Status', defaultSelected: true, getValue: (store) => store.status },
+  { key: 'pinKind', label: 'Account Type', defaultSelected: true, getValue: (store) => store.pinKind },
+  { key: 'repNames', label: 'Reps', defaultSelected: true, getValue: (store) => store.repNames.join('; ') },
+  { key: 'city', label: 'City', defaultSelected: true, getValue: (store) => store.city },
+  { key: 'state', label: 'State', defaultSelected: true, getValue: (store) => store.state },
+  { key: 'locationAddress', label: 'Address', defaultSelected: true, getValue: (store) => store.locationAddress ?? store.locationLabel },
+  { key: 'phoneNumber', label: 'Phone', defaultSelected: true, getValue: (store) => store.phoneNumber },
+  { key: 'email', label: 'Email', defaultSelected: true, getValue: (store) => store.email },
+  { key: 'licenseNumber', label: 'License Number', defaultSelected: true, getValue: (store) => store.licenseNumber },
+  { key: 'referralSource', label: 'Referral Source', defaultSelected: true, getValue: (store) => store.referralSource },
+  { key: 'pppStatus', label: 'PPP Status', defaultSelected: true, getValue: (store) => store.pppStatus },
+  { key: 'headsetConnectionStatus', label: 'Headset Connection', defaultSelected: true, getValue: (store) => store.headsetConnectionStatus },
+  { key: 'isPreferredPartner', label: 'Preferred Partner', defaultSelected: true, getValue: (store) => store.isPreferredPartner },
+  { key: 'vendorDayStatus', label: 'Vendor Day Status', defaultSelected: true, getValue: (store) => store.vendorDayStatus },
+  { key: 'followUpDate', label: 'Follow-up Date', defaultSelected: true, getValue: (store) => store.followUpDate },
+  { key: 'followUpNeeded', label: 'Follow-up Needed', defaultSelected: true, getValue: (store) => store.followUpNeeded },
+  { key: 'followUpReason', label: 'Follow-up Reason', defaultSelected: true, getValue: (store) => store.followUpReason },
+  { key: 'lastCheckIn', label: 'Last Check-in', defaultSelected: true, getValue: (store) => store.lastCheckIn },
+  { key: 'lastSampleOrderDate', label: 'Last Sample Order', defaultSelected: true, getValue: (store) => store.lastSampleOrderDate },
+  { key: 'lastSampleDeliveryDate', label: 'Last Sample Delivery', defaultSelected: true, getValue: (store) => store.lastSampleDeliveryDate },
+  { key: 'lastOrderDate', label: 'Last Order', defaultSelected: true, getValue: (store) => store.lastOrderDate },
+  { key: 'daysOverdue', label: 'Days Overdue', defaultSelected: true, getValue: (store) => store.daysOverdue },
+  { key: 'notes', label: 'Notes', defaultSelected: false, getValue: (store) => store.notes },
+  { key: 'lat', label: 'Latitude', defaultSelected: false, getValue: (store) => store.lat },
+  { key: 'lng', label: 'Longitude', defaultSelected: false, getValue: (store) => store.lng },
+  { key: 'locationPrecision', label: 'Location Precision', defaultSelected: false, getValue: (store) => store.locationPrecision },
+  { key: 'locationSource', label: 'Location Source', defaultSelected: false, getValue: (store) => store.locationSource },
+  { key: 'isApproximate', label: 'Approximate Location', defaultSelected: false, getValue: (store) => store.isApproximate },
+  { key: 'notionPageId', label: 'Notion Page ID', defaultSelected: false, getValue: (store) => store.notionPageId },
+  { key: 'notionUrl', label: 'Notion URL', defaultSelected: false, getValue: (store) => notionPageUrl(store.notionPageId) },
+  { key: 'lastEditedTime', label: 'Last Edited', defaultSelected: false, getValue: (store) => store.lastEditedTime },
+];
+
+const ACCOUNT_CSV_COLUMN_BY_KEY = new Map(ACCOUNT_CSV_COLUMNS.map((column) => [column.key, column]));
+
+export function getDefaultAccountCsvColumnKeys() {
+  return ACCOUNT_CSV_COLUMNS.filter((column) => column.defaultSelected).map((column) => column.key);
+}
+
+export function buildAccountCsv({ stores, columnKeys }: { stores: TerritoryStorePin[]; columnKeys: AccountCsvColumnKey[] }) {
+  const columns = columnKeys.map((key) => ACCOUNT_CSV_COLUMN_BY_KEY.get(key)).filter((column): column is AccountCsvColumn => Boolean(column));
+  const header = columns.map((column) => escapeCsvHeader(column.label)).join(',');
+  const rows = stores.map((store) => columns.map((column) => escapeCsvCell(column.getValue(store))).join(','));
+  return [header, ...rows].join('\n');
+}
+
+export function accountCsvExportFilename(generatedAt = new Date()) {
+  const stamp = generatedAt.toISOString().slice(0, 16).replace(/[-:T]/g, '');
+  return `picc-territory-accounts-${stamp}.csv`;
+}
+
+function notionPageUrl(pageId: string) {
+  return `https://www.notion.so/${pageId.replace(/-/g, '')}`;
+}
+
+function escapeCsvCell(value: string | number | boolean | null | undefined) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : '';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function escapeCsvHeader(value: string) {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}


### PR DESCRIPTION
## Why
Closes #120. The territory map export needs to live on the left control rail and support both shareable Google My Maps exports and spreadsheet exports of the accounts currently shown.

## What changed
- Moved the territory export button from the right-side map controls to the left-side control rail.
- Kept the Google My Maps KML workflow in the export sheet.
- Added an Account CSV mode in the same sheet.
- Added CSV column toggles with default/all controls and disabled/empty-state handling.
- Added account CSV formatter coverage for selected-column order, omitted columns, and CSV escaping.

## What did not change
- No production data writes.
- No schema changes, backfills, or background jobs.
- No Google OAuth/import automation.
- No map provider changes or retired layer systems.

## Validation
- npx vitest run lib/territory/account-csv-export.test.ts lib/territory/google-my-maps-export.test.ts: pass, 2 files / 4 tests.
- npm run typecheck: pass.
- npm run lint: pass.
- npm test: pass, 21 files / 94 tests.
- npm run build: pass.
- Browser path: Codex in-app Browser loaded stale cached territory controls and did not expose the new export button; recorded as Browser-path blocker.
- Fresh Playwright at 390x844 against local /territory: pass. Export button rendered on the left rail at x=8; CSV mode exported 733 rows; toggling Status off and Latitude/Longitude on changed the downloaded CSV header; KML still downloaded with the Accounts folder.

## Evidence
- Local screenshots saved outside the repo:
  - /tmp/picc-export-left-control.png
  - /tmp/picc-export-kml-mode.png
  - /tmp/picc-export-csv-mode-top.png
  - /tmp/picc-export-csv-mode.png

## Remaining risk
- Console still has the pre-existing Google Maps Marker deprecation warning.
- The in-app Browser cache issue is still present for this route, so fresh Playwright was used for rendered proof.