### PR TITLE
fix: accept Notion webhook HMAC signatures

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,55 +1,46 @@
-# Session: Issue #120 Territory Export CSV Mode
+# Session: Issue #122 Notion Webhook Signature Delivery
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/120
+- https://github.com/brycejohnson1417/Picc-web-app/issues/122
 
 ## Scope
-- Move the `/territory` export control from the right-hand map controls to the left-hand control rail.
-- Keep the existing Google My Maps KML export workflow available from the export sheet.
-- Add an account CSV export mode for the accounts currently shown by the selected map scope.
-- Add visible CSV column toggles so the downloaded headers and row fields are configurable directly from the UI.
-- Add focused coverage for CSV escaping, selected-column order, and omitted disabled columns.
+- Fix `/api/webhooks/notion` so it validates current Notion webhook event deliveries using `X-Notion-Signature`.
+- Keep the initial `verification_token` setup request accepted without requiring a signature.
+- Preserve the existing page/comment queue and sync behavior after the envelope is accepted.
+- Keep invalid or missing production event signatures rejected before queueing work.
 
 ## Out Of Scope
-- No Google OAuth write/import automation.
-- No production data writes, schema changes, backfills, or new background jobs.
-- No all-account detail fanout fetches; CSV uses fields already loaded for the current territory map/list view.
-- No map provider change and no reintroduction of MapLibre, Carto, Leaflet, `MapCanvas`, heatmap, hex, or `/api/territory/layers`.
-- No unrelated territory refactors.
+- No Notion dashboard mutation from code.
+- No production data writes, replay, backfill, schema migration, or new background jobs.
+- No territory sync behavior changes beyond accepting the correct webhook envelope.
+- No UI changes.
 
 ## Owned Paths
-- `components/mobile/territory*.tsx`
-- `components/territory/google-territory-map.tsx`
-- `components/territory/*export*.tsx`
-- `lib/territory/*export*.ts`
-- `lib/territory/*export*.test.ts`
+- `app/api/webhooks/notion/route.ts`
+- `lib/server/notion-webhook-route.test.ts`
 - `SESSION.md`
 
 ## Open PR Overlap Check
 - Checked open PR #82 before starting. It touches `AGENTS.md` and `AI_HANDOFF.md` only, so it does not overlap this slice.
 
 ## Current Evidence
-- Existing issue #118 / PR #119 shipped KML generation and the export sheet from the territory map.
-- `README.md`, `AI_HANDOFF.md`, and `AGENTS.md` keep Google Maps as the active and only supported territory map provider.
-- `components/mobile/territory-map-overlay-controls.tsx` owns the left/right overlay control placement.
-- `components/mobile/territory-my-maps-export-sheet.tsx` owns the current export sheet UI and KML download action.
-- `lib/territory/google-my-maps-export.ts` owns current viewport/filtered export selection and KML generation.
-- Red test evidence: `npx vitest run lib/territory/account-csv-export.test.ts` initially failed because `@/lib/territory/account-csv-export` did not exist.
-- Browser evidence: the Codex in-app Browser loaded stale territory controls from its cache and did not expose the new export button; after recording that blocker, a fresh Playwright context verified local `/territory`.
-- Fresh Playwright evidence: export button rendered on the left control rail at `x=8`; CSV mode exported `picc-territory-accounts-202606010414.csv` with 733 account rows; unchecking `Status` and checking `Latitude`/`Longitude` changed the CSV header; KML still exported `picc-territory-view-202606010414.kml` with the Accounts folder.
-- Screenshot evidence saved outside the repo: `/tmp/picc-export-left-control.png`, `/tmp/picc-export-kml-mode.png`, `/tmp/picc-export-csv-mode-top.png`, `/tmp/picc-export-csv-mode.png`.
+- User received a Notion alert that delivery to `https://piccnewyork.org/api/webhooks/notion` was paused after 8 hours of failed delivery.
+- Read-only production curl returns HTTP 401 with `{"error":"Missing Notion webhook signature headers"}`.
+- Current route expects Standard Webhooks headers: `webhook-id`, `webhook-signature`, and `webhook-timestamp`.
+- Current Notion docs say webhook event deliveries send `X-Notion-Signature`, an HMAC-SHA256 over the raw body using the subscription `verification_token`.
 
 ## Constraints
-- Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
-- Keep the current mobile-first PWA shell and Google Maps implementation.
-- Keep the feature fully interactive from the frontend; no backend-only or placeholder CSV path.
-- Keep export formatting logic outside map rendering components where practical.
+- Work only in `/Users/brycejohnson/Code/PICC-Web-App-issue-122` for this branch.
+- Do not touch the dirty unrelated territory files in `/Users/brycejohnson/Code/PICC-Web-App`.
+- Keep Notion behind the existing server route boundary.
+- Do not print secrets or full sensitive production values.
 
 ## Validation Plan
-- Red first: add focused failing tests for configurable account CSV output.
-- `npx vitest run lib/territory/account-csv-export.test.ts lib/territory/google-my-maps-export.test.ts`: exits `0`; 2 files and 4 tests passed.
+- Red first: update route tests to expect Notion `X-Notion-Signature` HMAC behavior.
+- Red evidence: `npx vitest run lib/server/notion-webhook-route.test.ts` initially failed because unsigned verification tokens and HMAC-signed Notion events returned HTTP 401.
+- `npx vitest run lib/server/notion-webhook-route.test.ts`: exits `0`; 1 file and 5 tests passed.
 - `npm run typecheck`: exits `0`.
 - `npm run lint`: exits `0`.
-- `npm test`: exits `0`; 21 files and 94 tests passed.
+- `npm test`: exits `0`; 21 files and 95 tests passed.
 - `npm run build`: exits `0`.
-- Browser verification on local `/territory`: passed in a fresh Playwright context at 390x844; left-side export control visible, export sheet mode switching works, CSV field toggles affect downloaded CSV contents, and existing KML path still downloads.
+- Read-only production endpoint check after deploy; manual Notion Webhooks tab resume remains outside code.

--- a/app/api/webhooks/notion/route.ts
+++ b/app/api/webhooks/notion/route.ts
@@ -1,5 +1,5 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import { NextResponse } from 'next/server';
-import { Webhook } from 'standardwebhooks';
 import { enqueueTerritoryStoreSync, syncTerritoryCheckInMirrorByPageId } from '@/lib/server/notion-territory';
 
 export const dynamic = 'force-dynamic';
@@ -22,15 +22,15 @@ type NotionWebhookPayload = {
 };
 
 function webhookSecret() {
-  return process.env.NOTION_WEBHOOK_SECRET?.trim() || '';
+  return (
+    process.env.NOTION_WEBHOOK_VERIFICATION_TOKEN?.trim() ||
+    process.env.NOTION_WEBHOOK_SECRET?.trim() ||
+    ''
+  );
 }
 
 function isProductionWebhookRuntime() {
   return process.env.NODE_ENV === 'production' || process.env.VERCEL_ENV === 'production';
-}
-
-function hasRequiredSignatureHeaders(headers: Headers) {
-  return Boolean(headers.get('webhook-id')) && Boolean(headers.get('webhook-signature')) && Boolean(headers.get('webhook-timestamp'));
 }
 
 function verifyWebhookRequest(rawBody: string, headers: Headers) {
@@ -44,21 +44,32 @@ function verifyWebhookRequest(rawBody: string, headers: Headers) {
     return null;
   }
 
-  if (!hasRequiredSignatureHeaders(headers)) {
-    return NextResponse.json({ error: 'Missing Notion webhook signature headers' }, { status: 401 });
+  const signature = headers.get('x-notion-signature')?.trim();
+  if (!signature) {
+    return NextResponse.json({ error: 'Missing Notion webhook signature header' }, { status: 401 });
   }
 
-  try {
-    const verifier = new Webhook(secret);
-    verifier.verify(rawBody, Object.fromEntries(headers.entries()));
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Webhook verification failed' },
-      { status: 401 },
-    );
+  if (!isValidNotionSignature(rawBody, secret, signature)) {
+    return NextResponse.json({ error: 'Webhook verification failed' }, { status: 401 });
   }
 
   return null;
+}
+
+function isValidNotionSignature(rawBody: string, secret: string, signature: string) {
+  if (!signature.startsWith('sha256=')) {
+    return false;
+  }
+
+  const expected = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+  const expectedBuffer = Buffer.from(expected);
+  const receivedBuffer = Buffer.from(signature);
+
+  if (expectedBuffer.length !== receivedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, receivedBuffer);
 }
 
 function resolvePageId(payload: NotionWebhookPayload) {
@@ -89,11 +100,6 @@ function isPageEvent(type: string | undefined) {
 
 export async function POST(request: Request) {
   const rawBody = await request.text();
-  const verificationError = verifyWebhookRequest(rawBody, request.headers);
-  if (verificationError) {
-    return verificationError;
-  }
-
   let parsedPayload: NotionWebhookPayload;
 
   try {
@@ -107,6 +113,11 @@ export async function POST(request: Request) {
       hasVerificationToken: true,
     });
     return NextResponse.json({ ok: true });
+  }
+
+  const verificationError = verifyWebhookRequest(rawBody, request.headers);
+  if (verificationError) {
+    return verificationError;
   }
 
   if (!isCommentEvent(parsedPayload.type) && !isPageEvent(parsedPayload.type)) {

--- a/lib/server/notion-webhook-route.test.ts
+++ b/lib/server/notion-webhook-route.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Webhook } from 'standardwebhooks';
+import { createHmac } from 'node:crypto';
 
 type LoadedRoute = {
   POST: (request: Request) => Promise<Response>;
@@ -47,15 +47,9 @@ function notionRequest(payload: unknown, headers: HeadersInit = {}) {
   });
 }
 
-async function signedHeaders(rawBody: string, secret: string) {
-  const verifier = new Webhook(secret);
-  const date = new Date();
-  const signature = await verifier.sign('msg_test', date, rawBody);
-
+function signedHeaders(rawBody: string, secret: string) {
   return {
-    'webhook-id': 'msg_test',
-    'webhook-signature': signature,
-    'webhook-timestamp': Math.floor(date.getTime() / 1000).toString(),
+    'x-notion-signature': `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`,
   };
 }
 
@@ -72,7 +66,7 @@ describe('Notion webhook route', () => {
     const rawBody = JSON.stringify(payload);
     const { POST, enqueueTerritoryStoreSync } = await loadRoute();
 
-    const response = await POST(notionRequest(payload, await signedHeaders(rawBody, 'whsec_testsecret')));
+    const response = await POST(notionRequest(payload, signedHeaders(rawBody, 'whsec_testsecret')));
 
     expect(response.status).toBe(401);
     expect(enqueueTerritoryStoreSync).not.toHaveBeenCalled();
@@ -95,11 +89,7 @@ describe('Notion webhook route', () => {
     const response = await POST(
       notionRequest(
         { type: 'page.updated', entity: { type: 'page', id: 'page_123' } },
-        {
-          'webhook-id': 'msg_test',
-          'webhook-signature': 'v1,not-valid',
-          'webhook-timestamp': Math.floor(Date.now() / 1000).toString(),
-        },
+        { 'x-notion-signature': 'sha256=not-valid' },
       ),
     );
 
@@ -107,16 +97,30 @@ describe('Notion webhook route', () => {
     expect(enqueueTerritoryStoreSync).not.toHaveBeenCalled();
   });
 
-  it('accepts signed verification tokens without logging the raw token value', async () => {
-    setProductionWebhookEnv('whsec_testsecret');
+  it('accepts unsigned verification tokens without logging the raw token value', async () => {
+    setProductionWebhookEnv();
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const payload = { verification_token: 'raw-token-should-not-be-logged' };
-    const rawBody = JSON.stringify(payload);
     const { POST } = await loadRoute();
 
-    const response = await POST(notionRequest(payload, await signedHeaders(rawBody, 'whsec_testsecret')));
+    const response = await POST(notionRequest(payload));
 
     expect(response.status).toBe(200);
     expect(JSON.stringify(infoSpy.mock.calls)).not.toContain('raw-token-should-not-be-logged');
+  });
+
+  it('accepts Notion HMAC-signed page events and queues page sync work', async () => {
+    const secret = 'secret_test_verification_token';
+    setProductionWebhookEnv(secret);
+    const payload = { type: 'page.content_updated', entity: { type: 'page', id: 'page_123' } };
+    const rawBody = JSON.stringify(payload);
+    const { POST, enqueueTerritoryStoreSync } = await loadRoute();
+
+    const response = await POST(notionRequest(payload, signedHeaders(rawBody, secret)));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ ok: true, queuedPageId: 'page_123', queued: true });
+    expect(enqueueTerritoryStoreSync).toHaveBeenCalledWith('page_123', { reason: 'page.content_updated' });
   });
 });


### PR DESCRIPTION
## Summary

- Closes #122
- Updates `/api/webhooks/notion` to validate Notion's current `X-Notion-Signature` HMAC header instead of Standard Webhooks headers.
- Allows the initial `verification_token` setup payload to return 200 without requiring a signature.

## Why

Notion paused delivery to `https://piccnewyork.org/api/webhooks/notion` after repeated failed deliveries. Read-only production reproduction returned HTTP 401 with `Missing Notion webhook signature headers`. The root cause is that the route expected `webhook-id`, `webhook-signature`, and `webhook-timestamp`, while current Notion webhook deliveries use `X-Notion-Signature` signed with the subscription verification token.

## Scope

- In scope:
  - HMAC-SHA256 validation for `X-Notion-Signature`.
  - Unsigned verification-token setup response.
  - Focused route tests for valid, missing, invalid, and unconfigured production cases.
- Out of scope:
  - Notion dashboard mutation or replay.
  - Production data writes/backfills/schema changes.
  - Territory sync behavior changes after webhook acceptance.
  - UI changes.
- Files changed:
  - `app/api/webhooks/notion/route.ts`
  - `lib/server/notion-webhook-route.test.ts`
  - `SESSION.md`
- If this PR changes more than 10 files, explain why: N/A.

## Coordination

- Owned path globs:
  - `app/api/webhooks/notion/route.ts`
  - `lib/server/notion-webhook-route.test.ts`
  - `SESSION.md`
- Open PRs checked for overlap: PR #82, docs-only, no overlap.
- Blocked by: none.
- Blocks: resuming Notion webhook delivery.
- Parallel label: `parallel:exclusive`
- Lane: fast lane for code; Notion dashboard Resume remains manual unless Bryce explicitly approves/does it.
- Approval-lane reason, if any: none for code; no production data write, schema migration, auth/RLS change, or destructive operation.
- Large diff / boundary note, if any: live integration endpoint, so validation includes full test/build stack and read-only production checks after deploy.
- Process note: issue, branch, scope, out-of-scope, overlap check, and red test were established before the source fix. The draft PR was opened after the first fix commit because GitHub requires a pushed branch delta.

## Labels And Review Flags

- [x] PR has the right `type:*`, `priority:*`, `area:*`, and status labels
- [x] PR has `agent-generated` if opened or substantially authored by an agent
- [x] PR has `needs-prod-proof` if it discusses production data, sync state, customer-visible totals, or live integration behavior
- [x] PR has the right `parallel:*` label and `meta:protocol-change` when it changes repo rules
- [x] Title and commit use a conventional prefix (`fix:`, `feat:`, `chore:`, `docs:`, `test:`, or `refactor:`)
- [ ] Draft PR was opened at claim time before non-test source edits

## Validation

- [x] Red first: route test failed because unsigned verification-token requests and HMAC-signed Notion events returned HTTP 401.
- [x] `npx vitest run lib/server/notion-webhook-route.test.ts`
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Browser/UI proof attached when UI behavior changed: N/A, no UI change.
- [ ] Read-only production proof included when production data/state is discussed
- [x] `SESSION.md` describes current scope, out-of-scope items, and constraints

## Screenshots / Browser Proof

No visual/browser surface changed.

## Production Proof

Pre-fix read-only production curl returned HTTP 401 with `Missing Notion webhook signature headers`. Post-deploy read-only production verification still needs to run before this is considered fully closed. Do not paste secrets or connection strings.

## Risk And Rollback

- Risk: if production does not have the Notion subscription verification token configured under `NOTION_WEBHOOK_VERIFICATION_TOKEN` or legacy `NOTION_WEBHOOK_SECRET`, event deliveries will still reject before queueing.
- Rollback: revert this PR; no schema or data migration involved.
