### PR TITLE
Fix territory rep pin colors

### DIFF
--- a/lib/territory/pin-colors.test.ts
+++ b/lib/territory/pin-colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { followUpPinPresentation, pinColorForStore, pinGlyphForStore } from '@/lib/territory/pin-colors';
+import { createRepColorMap, followUpPinPresentation, pinColorForStore, pinGlyphForStore, repColorForLabel } from '@/lib/territory/pin-colors';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 
 function buildStore(overrides: Partial<TerritoryStorePin> = {}): TerritoryStorePin {
@@ -85,5 +85,24 @@ describe('territory pin colors', () => {
 
     expect(pinGlyphForStore(store, 'status', referenceDate)).toBe('P');
     expect(pinGlyphForStore(store, 'follow-up-date', referenceDate)).toBe('0');
+  });
+
+  it('uses the fixed PICC territory colors for known rep labels', () => {
+    expect(repColorForLabel('Roxy')).toBe('#dc2626');
+    expect(repColorForLabel('roxy')).toBe('#dc2626');
+    expect(repColorForLabel('Bryce')).toBe('#60a5fa');
+    expect(repColorForLabel('Bryce Johnson')).toBe('#60a5fa');
+    expect(repColorForLabel('Donovan Snyder')).toBe('#7c3aed');
+    expect(repColorForLabel('Ben')).toBe('#f97316');
+    expect(repColorForLabel('Benjamin Rosenthal')).toBe('#f97316');
+    expect(repColorForLabel('Eric Acosta')).toBe('#16a34a');
+  });
+
+  it('keeps fixed rep colors when labels include extra Notion context', () => {
+    const colorMap = createRepColorMap(['Bryce Johnson - PICC', 'Donovan Snyder', 'Roxy']);
+    const store = buildStore({ repNames: ['Bryce Johnson - PICC'] });
+
+    expect(colorMap.get('Bryce Johnson - PICC')).toBe('#60a5fa');
+    expect(pinColorForStore(store, 'rep', colorMap, referenceDate)).toBe('#60a5fa');
   });
 });

--- a/lib/territory/pin-colors.ts
+++ b/lib/territory/pin-colors.ts
@@ -31,14 +31,24 @@ const DISTINCT_REP_COLORS = [
 ];
 
 const FIXED_REP_COLORS: Record<string, string> = {
-  roxy: '#22c55e',
-  'bryce johnson': '#fde047',
-  ben: '#dc2626',
-  'benjamin rosenthal': '#dc2626',
-  donovan: '#f97316',
-  'donovan snyder': '#f97316',
-  eric: '#60a5fa',
-  'eric acosta': '#60a5fa',
+  roxy: '#dc2626',
+  'bryce johnson': '#60a5fa',
+  bryce: '#60a5fa',
+  ben: '#f97316',
+  'benjamin rosenthal': '#f97316',
+  donovan: '#7c3aed',
+  'donovan snyder': '#7c3aed',
+  eric: '#16a34a',
+  'eric acosta': '#16a34a',
+};
+
+const FIXED_REP_WORD_COLORS: Record<string, string> = {
+  roxy: '#dc2626',
+  bryce: '#60a5fa',
+  ben: '#f97316',
+  benjamin: '#f97316',
+  donovan: '#7c3aed',
+  eric: '#16a34a',
 };
 
 const FOLLOW_UP_NO_DATE_COLOR = '#0616b7';
@@ -56,12 +66,30 @@ function normalizeRepKey(label: string) {
   return normalizeRepLabel(label).toLowerCase();
 }
 
+function fixedRepColorForLabel(label: string) {
+  const key = normalizeRepKey(label);
+  const exact = FIXED_REP_COLORS[key];
+  if (exact) {
+    return exact;
+  }
+
+  const words = key.match(/[a-z0-9]+/g) ?? [];
+  for (const word of words) {
+    const wordColor = FIXED_REP_WORD_COLORS[word];
+    if (wordColor) {
+      return wordColor;
+    }
+  }
+
+  return null;
+}
+
 export function repColorForLabel(label: string) {
   const normalized = normalizeRepLabel(label);
   if (!normalized) {
     return '#64748b';
   }
-  const fixed = FIXED_REP_COLORS[normalizeRepKey(normalized)];
+  const fixed = fixedRepColorForLabel(normalized);
   if (fixed) {
     return fixed;
   }
@@ -82,7 +110,7 @@ export function createRepColorMap(labels: string[]) {
       map.set(label, '#64748b');
       return;
     }
-    const fixed = FIXED_REP_COLORS[normalizeRepKey(label)];
+    const fixed = fixedRepColorForLabel(label);
     if (fixed) {
       map.set(label, fixed);
       return;


### PR DESCRIPTION
Closes #124.\n\n## Why\nThe live territory map still used the old fixed rep-color mapping, so rep visualization showed Bryce as yellow, Donovan as orange, Eric as blue, and roxy as green.\n\n## What changed\n- Updated fixed territory rep colors to match the requested territory palette.\n- Added word-based matching so labels with extra Notion context, such as `Bryce Johnson - PICC`, still resolve to the fixed rep color.\n- Added tests for the known rep labels and context-suffixed labels.\n\n## What did not change\n- Status color mode is unchanged.\n- Follow-up-date color mode is unchanged.\n- Unknown reps still use the rotating fallback palette.\n\n## Validation\n- `npm run test -- lib/territory/pin-colors.test.ts`\n- `npm run lint`\n- `npm run typecheck`\n- `npm run build`