### PR TITLE
Polish territory loading and interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,9 @@
   --primary: 201 52 18;
   --border: 201 202 208;
   --app-shell-max: 1120px;
+  --picc-motion-fast: 150ms;
+  --picc-motion-normal: 240ms;
+  --picc-motion-ease: cubic-bezier(0.2, 0, 0, 1);
 }
 
 .dark {
@@ -31,6 +34,68 @@ body {
   color: rgb(var(--foreground));
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: "rlig" 1, "calt" 1;
+}
+
+@keyframes picc-shell-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes picc-skeleton-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+.picc-shell-enter {
+  animation: picc-shell-enter var(--picc-motion-normal) var(--picc-motion-ease) both;
+}
+
+.picc-soft-transition {
+  transition:
+    transform var(--picc-motion-normal) var(--picc-motion-ease),
+    opacity var(--picc-motion-normal) var(--picc-motion-ease),
+    box-shadow var(--picc-motion-normal) var(--picc-motion-ease),
+    border-color var(--picc-motion-fast) var(--picc-motion-ease),
+    background-color var(--picc-motion-fast) var(--picc-motion-ease),
+    color var(--picc-motion-fast) var(--picc-motion-ease);
+}
+
+.picc-shimmer {
+  background: linear-gradient(
+    90deg,
+    rgb(225 226 231 / 60%) 0%,
+    rgb(248 249 252) 46%,
+    rgb(234 236 241 / 78%) 54%,
+    rgb(219 222 227) 100%
+  );
+  background-size: 200% 100%;
+  animation: picc-skeleton-shimmer 1.4s linear infinite;
+}
+
+.picc-stagger-enter {
+  animation:
+    picc-shell-enter var(--picc-motion-normal) var(--picc-motion-ease) var(--picc-shell-delay, 0ms) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .picc-shell-enter,
+  .picc-stagger-enter,
+  .picc-soft-transition,
+  .picc-shimmer {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 ::-webkit-scrollbar {

--- a/components/mobile/territory-focused-card.tsx
+++ b/components/mobile/territory-focused-card.tsx
@@ -30,7 +30,7 @@ export function TerritoryFocusedCard({
 }: TerritoryFocusedCardProps) {
   return (
     <div className="fixed bottom-[86px] left-0 right-0 z-[2500]">
-      <div className="mx-auto max-w-[720px] bg-[#1d1f24]/95 text-white shadow-[0_-2px_8px_rgba(0,0,0,0.35)] backdrop-blur-sm">
+      <div className="mx-auto max-w-[720px] picc-shell-enter bg-[#1d1f24]/95 text-white shadow-[0_-2px_8px_rgba(0,0,0,0.35)] backdrop-blur-sm">
         <button type="button" onClick={() => onOpenDetails(store.id)} className="w-full border-b border-[#30333b] px-3 py-2 text-left">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">

--- a/components/mobile/territory-list-pane.tsx
+++ b/components/mobile/territory-list-pane.tsx
@@ -40,6 +40,8 @@ export function TerritoryListPane({
   repColorMap,
   onOpenStore,
 }: TerritoryListPaneProps) {
+  let rowIndex = 0;
+
   return (
     <div className="h-full overflow-y-auto px-3 pb-28 pt-2">
       {storesQueryError ? (
@@ -76,14 +78,17 @@ export function TerritoryListPane({
         >
           <div className="border-b border-[#c6c7cb] px-1 py-1.5 text-[26px] text-[#8a8d95]">{letter}</div>
           {list.map((store) => {
+            const staggerDelayMs = `${rowIndex * 20}ms`;
             const selected = routeSelectedIds.includes(store.id);
             const pinColor = pinColorForStore(store, pinColorMode, repColorMap);
+            rowIndex += 1;
             return (
               <button
                 key={store.id}
                 type="button"
                 onClick={() => onOpenStore(store.id)}
-                className="flex w-full items-center gap-2 border-b border-[#d0d1d4] px-1 py-2 text-left"
+                className="picc-stagger-enter picc-soft-transition flex w-full items-center gap-2 border-b border-[#d0d1d4] px-1 py-2 text-left hover:bg-[#f4f6f8] active:scale-[0.985] active:shadow-sm"
+                style={{ animationDelay: staggerDelayMs }}
               >
                 <span className="inline-block h-3.5 w-3.5 shrink-0 rounded-full" style={{ backgroundColor: pinColor }} />
                 <span

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -83,7 +83,7 @@ export function TerritoryMapOverlayControls({
             type="button"
             disabled={!canVisualizeRoute}
             className={cn(
-              'rounded-full border px-3 py-1.5 text-[12px] font-semibold shadow',
+              'picc-soft-transition rounded-full border px-3 py-1.5 text-[12px] font-semibold shadow transition shadow-sm hover:bg-white/95 active:scale-[0.985]',
               !canVisualizeRoute
                 ? 'cursor-not-allowed border-white/40 bg-white/65 text-[#80848d]'
                 : showRouteOnly
@@ -99,7 +99,7 @@ export function TerritoryMapOverlayControls({
               <button
                 type="button"
                 className={cn(
-                  'rounded-full border px-3 py-1.5 text-[12px] font-semibold shadow',
+                  'picc-soft-transition rounded-full border px-3 py-1.5 text-[12px] font-semibold shadow transition hover:bg-white/95 active:scale-[0.985]',
                   lassoDrawingMode ? 'border-[#2563eb] bg-[#2563eb] text-white' : 'border-white/70 bg-white/92 text-[#25313d]',
                 )}
                 onClick={onToggleLassoMode}
@@ -108,7 +108,7 @@ export function TerritoryMapOverlayControls({
               </button>
               <button
                 type="button"
-                className="rounded-full border border-[#2563eb] bg-white/92 px-3 py-1.5 text-[12px] font-semibold text-[#1d4ed8] shadow"
+                className="picc-soft-transition rounded-full border border-[#2563eb] bg-white/92 px-3 py-1.5 text-[12px] font-semibold text-[#1d4ed8] shadow hover:bg-white"
                 onClick={onFinishLasso}
               >
                 Finish Lasso
@@ -128,11 +128,11 @@ export function TerritoryMapOverlayControls({
                 placeholder="Search dispensaries on the map"
                 className="flex-1 bg-[#eef0f3]"
               />
-              <button
-                type="button"
-                onClick={onClearMapSearch}
-                className="rounded-xl border border-[#d0d3d9] bg-white px-3 py-2 text-[13px] font-medium text-[#4b4f57]"
-              >
+          <button
+            type="button"
+            onClick={onClearMapSearch}
+            className="picc-soft-transition rounded-xl border border-[#d0d3d9] bg-white px-3 py-2 text-[13px] font-medium text-[#4b4f57] hover:bg-[#f4f7fb] active:scale-[0.985]"
+          >
                 Clear
               </button>
             </div>
@@ -150,7 +150,7 @@ export function TerritoryMapOverlayControls({
                           aria-selected={selected}
                           onClick={() => onSelectSearchSuggestion(store.id)}
                           className={cn(
-                            'flex w-full items-center justify-between gap-3 border-b px-3 py-2.5 text-left last:border-b-0 active:bg-[#f3f5f8]',
+                            'picc-soft-transition flex w-full items-center justify-between gap-3 border-b px-3 py-2.5 text-left last:border-b-0 hover:bg-[#f4f7fb] active:scale-[0.985]',
                             selected ? 'border-[#cfe2ff] bg-[#f4f8ff]' : 'border-[#eef0f3]',
                           )}
                         >
@@ -183,11 +183,13 @@ export function TerritoryMapOverlayControls({
 
       {showRouteOnly && hasRoadRouteGeometry ? (
         <div className={cn('absolute left-3 z-[1500] rounded-xl bg-black/70 px-2.5 py-1.5 text-[11px] text-white', focusedStoreVisible ? 'bottom-[108px]' : 'bottom-3')}>
-          {routeModeLabel ?? 'Driving'} route on roads
+          <span className="picc-shell-enter inline-flex items-center gap-1">
+            {routeModeLabel ?? 'Driving'} route on roads
+          </span>
         </div>
       ) : showRouteOnly ? (
         <div className={cn('absolute left-3 z-[1500] rounded-xl bg-black/70 px-2.5 py-1.5 text-[11px] text-white', focusedStoreVisible ? 'bottom-[108px]' : 'bottom-3')}>
-          Add 2+ stops and tap Optimize in Route view
+          <span className="picc-shell-enter inline-flex items-center gap-1">Add 2+ stops and tap Optimize in Route view</span>
         </div>
       ) : null}
 
@@ -195,17 +197,20 @@ export function TerritoryMapOverlayControls({
         <div className={cn('absolute left-3 z-[1500]', focusedStoreVisible ? 'bottom-[148px]' : 'bottom-12')}>
           <button
             type="button"
-            className="rounded-full bg-black/70 px-3 py-2 text-[12px] font-semibold text-white shadow"
+            className="picc-soft-transition rounded-full bg-black/70 px-3 py-2 text-[12px] font-semibold text-white shadow hover:bg-black/85 active:scale-[0.985]"
             onClick={onToggleRepLegend}
           >
             {showRepLegend ? 'Hide rep colors' : `Rep colors (${repLegend.length})`}
           </button>
           {showRepLegend ? (
-            <div className="mt-2 max-h-[40vh] max-w-[240px] overflow-y-auto rounded-xl bg-black/70 px-2.5 py-2 text-white">
+            <div className="mt-2 max-h-[40vh] max-w-[240px] overflow-y-auto rounded-xl bg-black/70 px-2.5 py-2 text-white picc-soft-transition picc-shell-enter">
               <p className="mb-1 text-[11px] uppercase tracking-wide text-white/70">Rep Colors</p>
               <div className="space-y-1">
                 {repLegend.map((entry) => (
-                  <div key={entry.label} className="flex items-center justify-between gap-3 text-[12px]">
+                  <div
+                    key={entry.label}
+                    className="picc-soft-transition flex items-center justify-between gap-3 rounded-md px-1 py-1 text-[12px] hover:bg-white/10 active:scale-[0.985]"
+                  >
                     <span className="flex min-w-0 items-center gap-2">
                       <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: entry.color }} />
                       <span className="truncate">{entry.label}</span>
@@ -224,7 +229,7 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label="Center on your current location"
           title="Current location"
-          className="grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow"
+          className="picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]"
           onClick={onCenterCurrentLocation}
         >
           <Crosshair className="h-5 w-5 text-[#7f828a]" />
@@ -233,7 +238,7 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label="Refresh territory data"
           title="Refresh territory data"
-          className="grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow"
+          className="picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]"
           onClick={onRefreshData}
         >
           <RefreshCw className="h-5 w-5 text-[#7f828a]" />
@@ -242,7 +247,10 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label={lassoActive ? 'Clear lasso selection' : 'Start lasso selection'}
           title={lassoActive ? 'Clear lasso selection' : 'Lasso accounts'}
-          className={cn('grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow', lassoActive ? 'ring-2 ring-[#2563eb]' : '')}
+            className={cn(
+            'picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]',
+            lassoActive ? 'ring-2 ring-[#2563eb]' : '',
+          )}
           onClick={onToggleLassoMode}
         >
           <svg
@@ -265,7 +273,7 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label="Open territory export options"
           title="Export"
-          className="grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow"
+          className="picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]"
           onClick={onOpenMyMapsExport}
         >
           <Download className="h-5 w-5 text-[#7f828a]" />
@@ -277,7 +285,10 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label="Search dispensaries on the map"
           title="Search map"
-          className={cn('grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow', showMapSearch || mapSearch.trim().length > 0 ? 'ring-2 ring-[#cd3814]' : '')}
+          className={cn(
+            'picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]',
+            showMapSearch || mapSearch.trim().length > 0 ? 'ring-2 ring-[#cd3814]' : '',
+          )}
           onClick={onToggleMapSearch}
         >
           <Search className={cn('h-5 w-5', showMapSearch || mapSearch.trim().length > 0 ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
@@ -286,7 +297,10 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label="Open territory layers"
           title="Territory layers"
-          className={cn('grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow', showBoundaries ? 'ring-2 ring-[#cd3814]' : '')}
+          className={cn(
+            'picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]',
+            showBoundaries ? 'ring-2 ring-[#cd3814]' : '',
+          )}
           onClick={onOpenBoundarySheet}
         >
           <Layers3 className={cn('h-5 w-5', showBoundaries ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
@@ -295,7 +309,10 @@ export function TerritoryMapOverlayControls({
           type="button"
           aria-label="Open filters"
           title="Filters"
-          className={cn('relative grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow', activeFiltersCount > 0 ? 'ring-2 ring-[#cd3814]' : '')}
+          className={cn(
+            'picc-soft-transition relative grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]',
+            activeFiltersCount > 0 ? 'ring-2 ring-[#cd3814]' : '',
+          )}
           onClick={onOpenFilters}
         >
           <Filter className={cn('h-5 w-5', activeFiltersCount > 0 ? 'text-[#cd3814]' : 'text-[#7f828a]')} />

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -414,6 +414,8 @@ export function TerritoryMobile() {
   );
 
   const selectedOnCard = focusedStore ? routePlan.selectedStopIds.includes(focusedStore.id) : false;
+  const isInitialLoading = storesQuery.isLoading && !storesQuery.data;
+  const isRefreshing = storesQuery.isFetching && Boolean(storesQuery.data);
   const activeFiltersCount = countActiveTerritoryFilters({
     selectedStatuses,
     selectedReps,
@@ -626,17 +628,34 @@ export function TerritoryMobile() {
     );
   }
 
-  if (storesQuery.isLoading && !storesQuery.data) {
+  if (isInitialLoading) {
     return (
-      <div className="flex min-h-[calc(100dvh-76px)] items-center justify-center bg-[#e6e6e9]">
-        <Loader2 className="h-8 w-8 animate-spin text-[#5f636d]" />
+      <div className="relative flex min-h-[calc(100dvh-76px)] flex-col overflow-hidden bg-[#e6e6e9]">
+        <MobileHeader className="z-[2600]">
+          <div className="mx-auto flex w-full max-w-[560px]">
+            <div className="h-9 w-full rounded-full bg-white/95 picc-shimmer" />
+          </div>
+        </MobileHeader>
+        <div className="relative mt-2 flex-1 px-3 pb-3">
+          <div className="mb-2 h-11 rounded-2xl bg-[#e0e2e8] px-3 py-2">
+            <div className="h-3.5 w-24 rounded bg-[#f2f3f7]" />
+            <div className="mt-2 h-3.5 w-2/3 rounded bg-[#dce0e7]" />
+          </div>
+          <div className="relative h-full overflow-hidden rounded-2xl border border-[#cacdd4] bg-[#dbdde4]">
+            <div className="h-full w-full picc-shimmer" />
+            <div className="pointer-events-none absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-2 text-sm text-[#636873]">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading territory map...
+            </div>
+          </div>
+        </div>
       </div>
     );
   }
 
   if (storesQuery.isError && !storesQuery.data) {
     return (
-      <div className="min-h-[calc(100dvh-76px)] bg-[#e6e6e9] px-5 py-8">
+      <div className="min-h-[calc(100dvh-76px)] bg-[#e6e6e9] px-5 py-8 picc-shell-enter">
         <div className="rounded-xl border border-[#e0b4ab] bg-[#fbe8e4] p-4 text-[#8f2410]">
           <div className="mb-2 flex items-center gap-2 text-[18px] font-semibold">
             <AlertTriangle className="h-5 w-5" />
@@ -663,7 +682,7 @@ export function TerritoryMobile() {
   }
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col bg-[#e6e6e9]">
+    <div className="relative flex h-full min-h-0 flex-col bg-[#e6e6e9] picc-shell-enter">
       <MobileHeader className="z-[2600]">
         <div className="mx-auto flex w-full max-w-[560px] items-center gap-2">
           <SegmentedControl
@@ -677,6 +696,15 @@ export function TerritoryMobile() {
           />
         </div>
       </MobileHeader>
+
+      {isRefreshing ? (
+        <div className="pointer-events-none absolute left-3 right-3 top-[66px] z-[2500] px-1">
+          <div className="mx-auto flex max-w-[560px] items-center justify-center rounded-full border border-[#d4d7de] bg-white/95 px-3 py-1 text-[11px] font-medium text-[#5f6672] shadow">
+            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+            Syncing territory data
+          </div>
+        </div>
+      ) : null}
 
       {view === 'map' ? (
         <div className="relative min-h-0 flex-1">

--- a/components/territory/google-territory-map.tsx
+++ b/components/territory/google-territory-map.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AdvancedMarker, APIProvider, Map as GoogleMap, Marker, Pin, useMap } from '@vis.gl/react-google-maps';
+import { AlertTriangle, Loader2 } from 'lucide-react';
 import { GoogleTerritoryBoundaries, type TerritoryBoundaryDraft } from '@/components/territory/google-territory-boundaries';
 import { GoogleTerritoryMarkers, GoogleTerritoryMarkersFallback } from '@/components/territory/google-territory-markers';
 import { pinColorForStore, pinGlyphColorForStore, pinGlyphForStore, type PinColorMode } from '@/lib/territory/pin-colors';
@@ -551,26 +552,49 @@ export function GoogleTerritoryMap({
 
   if (!apiKey && configLoading) {
     return (
-      <div className={cn('grid h-full w-full place-items-center rounded-xl border border-slate-300 bg-slate-100 p-4 text-sm text-slate-700', className)}>
-        Loading Google Maps configuration...
+      <div
+        className={cn(
+          'picc-shell-enter grid h-full w-full place-items-center rounded-xl border border-slate-300 bg-slate-100 text-sm text-slate-700',
+          className,
+        )}
+      >
+        <div className="rounded-lg bg-white/90 px-3 py-2 text-center">
+          <Loader2 className="mx-auto h-5 w-5 animate-spin text-slate-500" />
+          <p className="mt-2">Loading Google Maps configuration...</p>
+        </div>
       </div>
     );
   }
 
   if (!apiKey) {
     return (
-      <div className={cn('grid h-full w-full place-items-center rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900', className)}>
-        Google Maps API key is not configured. Set `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`.
-        {configError ? <span className="mt-2 block text-xs text-amber-800">{configError}</span> : null}
+      <div
+        className={cn(
+          'picc-shell-enter grid h-full w-full place-items-center rounded-xl border border-amber-300 bg-amber-50 text-sm text-amber-900',
+          className,
+        )}
+      >
+        <div className="mx-4 rounded-xl border border-amber-300 bg-white/85 p-4 text-left">
+          Google Maps API key is not configured. Set `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`.
+          {configError ? <span className="mt-2 block text-xs text-amber-800">{configError}</span> : null}
+        </div>
       </div>
     );
   }
 
   if (mapLoadError) {
     return (
-      <div className={cn('grid h-full w-full place-items-center rounded-xl border border-red-300 bg-red-50 p-4 text-sm text-red-900', className)}>
-        <div>
-          <p>Google Maps failed to load.</p>
+      <div
+        className={cn(
+          'picc-shell-enter grid h-full w-full place-items-center rounded-xl border border-red-300 bg-red-50 text-sm text-red-900',
+          className,
+        )}
+      >
+        <div className="mx-4 rounded-xl border border-red-300 bg-white/85 p-4">
+          <div className="mb-1 inline-flex items-center gap-1.5 font-medium text-red-900">
+            <AlertTriangle className="h-4 w-4" />
+            Google Maps failed to load.
+          </div>
           <p className="mt-1 text-xs text-red-800">{mapLoadError}</p>
         </div>
       </div>

--- a/components/territory/route-sheet.tsx
+++ b/components/territory/route-sheet.tsx
@@ -36,7 +36,7 @@ export function RouteSheet({
   onClearStops,
 }: RouteSheetProps) {
   return (
-    <div className="space-y-3 rounded-t-2xl border border-slate-200 bg-white p-4 shadow-2xl dark:border-slate-700 dark:bg-slate-950">
+    <div className="space-y-3 rounded-t-2xl border border-slate-200 bg-white p-4 shadow-2xl picc-shell-enter dark:border-slate-700 dark:bg-slate-950">
       <div className="mx-auto h-1.5 w-14 rounded-full bg-slate-300" />
 
       <div className="flex items-center justify-between gap-2">
@@ -44,7 +44,13 @@ export function RouteSheet({
           <p className="text-sm font-semibold">Route Planner</p>
           <p className="text-xs text-slate-500">Tap pins to add stops, then optimize.</p>
         </div>
-        <Button variant="ghost" size="sm" onClick={onClearStops} disabled={selectedStops.length === 0}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClearStops}
+          disabled={selectedStops.length === 0}
+          className="picc-soft-transition hover:bg-slate-100"
+        >
           <Trash2 className="mr-1 h-4 w-4" />
           Clear
         </Button>
@@ -54,7 +60,13 @@ export function RouteSheet({
         <ModeButton icon={Car} label="Car" active={mode === 'car'} onClick={() => onSetMode('car')} />
         <ModeButton icon={Bike} label="Bike" active={mode === 'bike'} onClick={() => onSetMode('bike')} />
         <ModeButton icon={Train} label="Transit" active={mode === 'transit'} onClick={() => onSetMode('transit')} />
-        <Button variant="outline" size="sm" className="h-9" onClick={onLaunchDirections} disabled={selectedStops.length < 2}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9 picc-soft-transition border-slate-300 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+          onClick={onLaunchDirections}
+          disabled={selectedStops.length < 2}
+        >
           <ExternalLink className="mr-1 h-3.5 w-3.5" />
           Open Maps
         </Button>
@@ -71,7 +83,7 @@ export function RouteSheet({
         </div>
       </div>
 
-      <Button className="h-10 w-full" onClick={onOptimize} disabled={selectedStops.length < 2 || optimizing}>
+      <Button className="h-10 w-full picc-soft-transition" onClick={onOptimize} disabled={selectedStops.length < 2 || optimizing}>
         <Navigation2 className="mr-2 h-4 w-4" />
         {optimizing ? 'Optimizing...' : `Optimize ${mode === 'transit' ? 'Transit' : mode === 'bike' ? 'Bike' : 'Car'} Route`}
       </Button>
@@ -81,16 +93,25 @@ export function RouteSheet({
           <p className="text-xs text-slate-500">No stops selected yet.</p>
         ) : (
           orderedStops.map((stop, index) => (
-            <div key={stop.id} className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-2 py-2 dark:border-slate-700 dark:bg-slate-900">
+            <div
+              key={stop.id}
+              className="picc-stagger-enter picc-soft-transition flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-2 py-2 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+              style={{ animationDelay: `${index * 22}ms` }}
+            >
               <div className="flex flex-col gap-0.5">
-                <button type="button" onClick={() => onMoveStop(stop.id, 'up')} disabled={index === 0} className="rounded p-0.5 text-slate-500 disabled:text-slate-300">
+                <button
+                  type="button"
+                  onClick={() => onMoveStop(stop.id, 'up')}
+                  disabled={index === 0}
+                  className="picc-soft-transition rounded p-0.5 text-slate-500 disabled:text-slate-300 active:scale-[0.9]"
+                >
                   <ArrowUp className="h-3.5 w-3.5" />
                 </button>
                 <button
                   type="button"
                   onClick={() => onMoveStop(stop.id, 'down')}
                   disabled={index === orderedStops.length - 1}
-                  className="rounded p-0.5 text-slate-500 disabled:text-slate-300"
+                  className="picc-soft-transition rounded p-0.5 text-slate-500 disabled:text-slate-300 active:scale-[0.9]"
                 >
                   <ArrowDown className="h-3.5 w-3.5" />
                 </button>
@@ -100,7 +121,7 @@ export function RouteSheet({
                 <p className="truncate text-sm font-medium">{stop.name}</p>
                 <p className="truncate text-xs text-slate-500">{stop.status}</p>
               </div>
-              <Button size="sm" variant="ghost" onClick={() => onRemoveStop(stop.id)}>
+              <Button size="sm" variant="ghost" onClick={() => onRemoveStop(stop.id)} className="picc-soft-transition">
                 Remove
               </Button>
             </div>
@@ -127,7 +148,7 @@ function ModeButton({
       type="button"
       onClick={onClick}
       className={cn(
-        'inline-flex h-9 items-center gap-1 rounded-md border px-3 text-sm font-medium',
+        'picc-soft-transition inline-flex h-9 items-center gap-1 rounded-md border px-3 text-sm font-medium hover:shadow-sm active:scale-[0.985]',
         active ? 'border-blue-600 bg-blue-600 text-white' : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200',
       )}
     >

--- a/components/territory/territory-client.tsx
+++ b/components/territory/territory-client.tsx
@@ -109,6 +109,8 @@ export function TerritoryClient() {
 
   const totalDurationSeconds = optimizedRoute?.totalDurationSeconds ?? 0;
   const totalDistanceMeters = optimizedRoute?.totalDistanceMeters ?? 0;
+  const isInitialLoading = storesQuery.isLoading && !storesQuery.data;
+  const isRefreshing = storesQuery.isFetching && Boolean(storesQuery.data);
 
   function toggleListValue(current: string[], value: string) {
     return current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
@@ -218,17 +220,9 @@ export function TerritoryClient() {
     window.open(`https://www.google.com/maps/dir/?${params.toString()}`, '_blank', 'noopener,noreferrer');
   }
 
-  if (storesQuery.isLoading) {
+  if (storesQuery.isError && !storesQuery.data) {
     return (
-      <div className="flex min-h-[70vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-slate-500" />
-      </div>
-    );
-  }
-
-  if (storesQuery.isError) {
-    return (
-      <div className="mx-auto max-w-xl rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
+      <div className="mx-auto mt-6 max-w-xl rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 picc-shell-enter">
         <div className="mb-2 flex items-center gap-2 font-medium">
           <AlertTriangle className="h-4 w-4" />
           Failed to load live territory data
@@ -241,8 +235,12 @@ export function TerritoryClient() {
     );
   }
 
+  if (isInitialLoading) {
+    return <TerritoryClientLoadingState />;
+  }
+
   return (
-    <div className="relative h-[calc(100dvh-64px)] w-full overflow-hidden bg-white dark:bg-slate-950">
+    <div className="relative h-[calc(100dvh-64px)] w-full overflow-hidden bg-white picc-shell-enter dark:bg-slate-950">
       <div className="relative h-full w-full">
         <div className="absolute left-2 right-2 top-2 z-[1000] md:left-4 md:right-4 md:top-4">
           <TerritoryFilterBar
@@ -296,6 +294,15 @@ export function TerritoryClient() {
             {storesQuery.isFetching ? 'Refreshing...' : 'Refresh'}
           </Button>
         </div>
+
+        {isRefreshing ? (
+          <div className="absolute left-2 right-2 top-[5.6rem] z-[1000] flex justify-center md:left-4">
+            <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/95 px-3 py-1.5 text-[11px] font-medium text-slate-600 shadow">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Refreshing territory data
+            </div>
+          </div>
+        ) : null}
 
         <MapRenderBoundary>
           <GoogleTerritoryMap
@@ -392,6 +399,33 @@ export function TerritoryClient() {
           {storesQuery.data?.meta.syncing ? <p className="text-white/80">Refreshing live Notion data in background.</p> : null}
           {storesQuery.data?.meta.stale ? <p className="text-amber-300">Showing stale cache while Notion sync recovers.</p> : null}
           {storesQuery.data?.meta.syncError ? <p className="text-amber-300">{storesQuery.data.meta.syncError}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TerritoryClientLoadingState() {
+  return (
+    <div className="relative h-[calc(100dvh-64px)] w-full overflow-hidden bg-slate-100 dark:bg-slate-950">
+      <div className="absolute inset-2 rounded-xl border border-slate-200 bg-white p-2 shadow-sm picc-shell-enter md:inset-4">
+        <div className="px-3 pb-2 pt-3 md:px-4">
+          <div className="flex animate-pulse items-start justify-between gap-3">
+            <div className="h-10 w-full max-w-[420px] rounded-lg bg-slate-100 picc-shimmer" />
+            <div className="h-10 w-16 rounded-lg bg-slate-100 picc-shimmer" />
+          </div>
+          <div className="mt-3 flex animate-pulse gap-2">
+            <div className="h-9 w-24 rounded-full bg-slate-100 picc-shimmer" />
+            <div className="h-9 w-24 rounded-full bg-slate-100 picc-shimmer" />
+            <div className="h-9 w-28 rounded-full bg-slate-100 picc-shimmer" />
+          </div>
+        </div>
+        <div className="grid h-[calc(100%-128px)] min-h-[420px] place-items-center bg-slate-100 p-2">
+          <div className="h-full w-full rounded-lg border border-slate-200 bg-slate-200 picc-shimmer" />
+          <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2 text-sm text-slate-500">
+            <Loader2 className="h-7 w-7 animate-spin" />
+            <p>Loading territory map and live pins...</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #126.\n\n## Why\nThe territory map/list UI had local loading and interaction polish that was not live yet. This ships that polish as a clean frontend-only slice after the rep-color fix.\n\n## What changed\n- Added shared PICC motion utilities for shell entry, soft transitions, shimmer skeletons, staggered row entry, and reduced-motion support.\n- Added polished initial loading states for desktop and mobile territory views.\n- Added non-blocking refresh chips when data is refetching with cached results.\n- Added soft transitions and press feedback to map controls, list rows, focused cards, and route planner controls.\n- Improved Google Maps config/error placeholder states.\n\n## What did not change\n- No rep-color mapping changes.\n- No data model, auth, sync, or API behavior changes.\n- Existing filter/map/list/route behavior remains intact.\n\n## Validation\n- `npm run lint`\n- `npm run typecheck`\n- `npm run build`