### PR TITLE
Keep territory filter actions above mobile nav

### DIFF
--- a/components/mobile/store-filter-sheet.tsx
+++ b/components/mobile/store-filter-sheet.tsx
@@ -353,7 +353,7 @@ export function StoreFilterSheet({
           </section>
         </div>
 
-        <div className="border-t border-[#c8c9cf] bg-[#f2f2f5] px-4 py-3">
+        <div className="border-t border-[#c8c9cf] bg-[#f2f2f5] px-4 pb-[calc(96px+env(safe-area-inset-bottom))] pt-3 md:pb-[calc(108px+env(safe-area-inset-bottom))]">
           <div className="grid grid-cols-3 gap-2">
             <button
               type="button"


### PR DESCRIPTION
Closes #128.\n\n## Why\nThe territory filter sheet action bar could render behind the persistent bottom navigation, hiding the Apply button.\n\n## What changed\n- Reserved bottom nav/safe-area space in the filter sheet footer so Clear All, Save Filters, and Apply stay visible and tappable above the nav.\n\n## What did not change\n- No filter logic changes.\n- No territory map/list data behavior changes.\n- No desktop filter behavior changes beyond the same safe footer spacing inside the app shell.\n\n## Validation\n- `npm run lint`\n- `npm run typecheck`\n- `npm run build`