### PR TITLE
fix: keep account sheet actions above bottom nav

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,46 +1,45 @@
-# Session: Issue #122 Notion Webhook Signature Delivery
+# Session: Issue #130 Bottom Nav Sheet Overlap
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/122
+- https://github.com/brycejohnson1417/Picc-web-app/issues/130
 
 ## Scope
-- Fix `/api/webhooks/notion` so it validates current Notion webhook event deliveries using `X-Notion-Signature`.
-- Keep the initial `verification_token` setup request accepted without requiring a signature.
-- Preserve the existing page/comment queue and sync behavior after the envelope is accepted.
-- Keep invalid or missing production event signatures rejected before queueing work.
+- Fix the mobile account detail sheet so its bottom actions stay visible and tappable above the primary footer navigation.
+- Apply the bottom-safe layout contract to adjacent mobile bottom surfaces where the same collision can occur.
+- Preserve the existing mobile-first PWA shell and account detail behavior.
 
 ## Out Of Scope
-- No Notion dashboard mutation from code.
-- No production data writes, replay, backfill, schema migration, or new background jobs.
-- No territory sync behavior changes beyond accepting the correct webhook envelope.
-- No UI changes.
+- No check-in persistence or backend behavior changes.
+- No map provider, route planning, auth, RBAC, schema, or external integration changes.
+- No production data writes.
+- No broad redesign beyond the footer collision fix.
 
 ## Owned Paths
-- `app/api/webhooks/notion/route.ts`
-- `lib/server/notion-webhook-route.test.ts`
+- `components/mobile/account-detail-sheet.tsx`
+- `components/mobile/route-mobile.tsx`
+- `components/mobile/territory-focused-card.tsx`
+- `components/layout/app-shell.tsx`
 - `SESSION.md`
 
 ## Open PR Overlap Check
 - Checked open PR #82 before starting. It touches `AGENTS.md` and `AI_HANDOFF.md` only, so it does not overlap this slice.
 
 ## Current Evidence
-- User received a Notion alert that delivery to `https://piccnewyork.org/api/webhooks/notion` was paused after 8 hours of failed delivery.
-- Read-only production curl returns HTTP 401 with `{"error":"Missing Notion webhook signature headers"}`.
-- Current route expects Standard Webhooks headers: `webhook-id`, `webhook-signature`, and `webhook-timestamp`.
-- Current Notion docs say webhook event deliveries send `X-Notion-Signature`, an HMAC-SHA256 over the raw body using the subscription `verification_token`.
+- User screenshot shows account detail actions such as Check-in hidden behind the primary bottom navigation on the territory map.
+- `components/mobile/account-detail-sheet.tsx` renders a sheet action bar at the bottom while the global shell footer remains fixed at the bottom.
+- `DESIGN-SYSTEM.md` states bottom navigation consumes the lower safe area and fixed action bars must sit above it.
 
 ## Constraints
-- Work only in `/Users/brycejohnson/Code/PICC-Web-App-issue-122` for this branch.
-- Do not touch the dirty unrelated territory files in `/Users/brycejohnson/Code/PICC-Web-App`.
-- Keep Notion behind the existing server route boundary.
-- Do not print secrets or full sensitive production values.
+- Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
+- Keep the change surgical and frontend-only.
+- Keep Google Maps as the only territory map provider.
+- Use browser-visible validation for the territory account-detail flow.
 
 ## Validation Plan
-- Red first: update route tests to expect Notion `X-Notion-Signature` HMAC behavior.
-- Red evidence: `npx vitest run lib/server/notion-webhook-route.test.ts` initially failed because unsigned verification tokens and HMAC-signed Notion events returned HTTP 401.
-- `npx vitest run lib/server/notion-webhook-route.test.ts`: exits `0`; 1 file and 5 tests passed.
-- `npm run typecheck`: exits `0`.
-- `npm run lint`: exits `0`.
-- `npm test`: exits `0`; 21 files and 95 tests passed.
-- `npm run build`: exits `0`.
-- Read-only production endpoint check after deploy; manual Notion Webhooks tab resume remains outside code.
+- Red proof: reproduce the overlap through the running frontend with screenshot or DOM geometry before the layout fix when possible.
+- Green proof: verify account detail actions render above the primary footer and remain clickable.
+- Check at least one adjacent bottom surface for the same collision class.
+- Run `npm run typecheck`.
+- Run `npm run lint`.
+- Run `npm test`.
+- Run `npm run build`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,8 @@
   --primary: 201 52 18;
   --border: 201 202 208;
   --app-shell-max: 1120px;
+  --picc-bottom-nav-height: 84px;
+  --picc-bottom-nav-clearance: 92px;
   --picc-motion-fast: 150ms;
   --picc-motion-normal: 240ms;
   --picc-motion-ease: cubic-bezier(0.2, 0, 0, 1);
@@ -85,6 +87,12 @@ body {
 .picc-stagger-enter {
   animation:
     picc-shell-enter var(--picc-motion-normal) var(--picc-motion-ease) var(--picc-shell-delay, 0ms) both;
+}
+
+@media (min-width: 768px) {
+  :root {
+    --picc-bottom-nav-clearance: 96px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -118,13 +118,13 @@ export function AppShell({
               </details>
             </div>
           </header>
-          <main className={cn('min-h-0 flex-1', isTerritoryRoute ? 'overflow-hidden pb-0' : 'overflow-y-auto pb-[84px]')}>
+          <main className={cn('min-h-0 flex-1', isTerritoryRoute ? 'overflow-hidden pb-0' : 'overflow-y-auto pb-[var(--picc-bottom-nav-height)]')}>
             {children}
           </main>
         </div>
 
         <nav className="fixed bottom-0 left-0 right-0 z-[4000] text-white" aria-label="Primary navigation">
-          <div className="mx-auto grid h-[84px] max-w-[var(--app-shell-max)] grid-cols-5 border-t border-[#243041] bg-[linear-gradient(180deg,#1f2631_0%,#171d26_100%)] px-2 pb-[max(8px,env(safe-area-inset-bottom))] pt-1.5 md:mb-3 md:rounded-[22px] md:border md:shadow-[0_16px_40px_rgba(0,0,0,0.24)]">
+          <div className="mx-auto grid h-[var(--picc-bottom-nav-height)] max-w-[var(--app-shell-max)] grid-cols-5 border-t border-[#243041] bg-[linear-gradient(180deg,#1f2631_0%,#171d26_100%)] px-2 pb-[max(8px,env(safe-area-inset-bottom))] pt-1.5 md:mb-3 md:rounded-[22px] md:border md:shadow-[0_16px_40px_rgba(0,0,0,0.24)]">
             {tabs.map((item) => {
               const active = isActive(pathname, item.matchHref ?? item.href);
               const Icon = item.icon;

--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -566,7 +566,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
           />
         </div>
 
-        <div className="flex-1 overflow-y-auto pb-[132px]">
+        <div className="flex-1 overflow-y-auto pb-[calc(132px+var(--picc-bottom-nav-clearance))]">
           <div className="border-y border-[#c6c7cb] bg-[#e6e6e9] px-5 py-4">
             <h2 className="text-[24px] font-semibold leading-tight text-[#111217]">{activeStore.name}</h2>
             <div className="mt-3 flex flex-wrap gap-3">
@@ -835,7 +835,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
 
         {contactActionTarget ? (
           <div className="fixed inset-0 z-[5210] bg-black/40" onClick={() => setContactActionTarget(null)}>
-            <div className="absolute inset-x-0 bottom-0 mx-auto max-w-[720px] rounded-t-2xl bg-[#f8f8fb] px-4 pb-[max(16px,env(safe-area-inset-bottom))] pt-4" onClick={(event) => event.stopPropagation()}>
+            <div className="absolute inset-x-0 bottom-[var(--picc-bottom-nav-clearance)] mx-auto max-h-[calc(100dvh-var(--picc-bottom-nav-clearance)-24px)] max-w-[720px] overflow-y-auto rounded-t-2xl bg-[#f8f8fb] px-4 pb-[max(16px,env(safe-area-inset-bottom))] pt-4" onClick={(event) => event.stopPropagation()}>
               <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <h3 className="text-[20px] font-semibold text-[#1d1f23]">Contact {contactActionTarget.name}</h3>
@@ -889,7 +889,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
 
         {checkInModalOpen && appAccess.canEdit ? (
           <div className="fixed inset-0 z-[5200] bg-black/40" onClick={() => !checkingIn && setCheckInModalOpen(false)}>
-            <div className="absolute inset-x-0 bottom-0 mx-auto max-w-[720px] rounded-t-2xl bg-[#f8f8fb] px-4 pb-[max(16px,env(safe-area-inset-bottom))] pt-4" onClick={(event) => event.stopPropagation()}>
+            <div className="absolute inset-x-0 bottom-[var(--picc-bottom-nav-clearance)] mx-auto max-h-[calc(100dvh-var(--picc-bottom-nav-clearance)-24px)] max-w-[720px] overflow-y-auto rounded-t-2xl bg-[#f8f8fb] px-4 pb-[max(16px,env(safe-area-inset-bottom))] pt-4" onClick={(event) => event.stopPropagation()}>
               <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <h3 className="text-[20px] font-semibold text-[#1d1f23]">Create Check-in</h3>
@@ -978,7 +978,7 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
           </div>
         ) : null}
 
-        <div className="absolute inset-x-0 bottom-0 z-[5100]">
+        <div className="absolute inset-x-0 bottom-[var(--picc-bottom-nav-clearance)] z-[5100]">
           <div className={cn('mx-auto grid max-w-[720px] border-t border-[#c6c7cb] bg-[#f2f2f5] py-2 pb-[max(8px,env(safe-area-inset-bottom))] text-[#5a96e8]', appAccess.canEdit ? 'grid-cols-4' : 'grid-cols-3')}>
             <ActionButton label={routeSelected ? 'remove' : 'add to...'} onClick={() => onAddToRoute(activeStore.id)} icon={<MapPinned className="h-5 w-5" />} />
             {appAccess.canEdit ? <ActionButton label={checkingIn ? 'saving...' : 'check-in'} onClick={() => openCheckInModal()} icon={<PencilLine className="h-5 w-5" />} disabled={checkingIn} /> : null}

--- a/components/mobile/route-mobile.tsx
+++ b/components/mobile/route-mobile.tsx
@@ -339,7 +339,7 @@ export function RouteMobile() {
       )}
 
       {tab === 'current' && selectedStops.length > 0 ? (
-        <div className="fixed bottom-[92px] left-0 right-0 z-[2600]">
+        <div className="fixed bottom-[var(--picc-bottom-nav-clearance)] left-0 right-0 z-[2600]">
           <div className="mx-auto grid max-w-[var(--app-shell-max)] grid-cols-5 border-t border-[#c4c5cc] bg-[#f3f3f6] py-2 text-[#5a95e7]">
             <button onClick={launchGo} className="mx-2 rounded-3xl bg-[#3ac128] px-2 py-2 text-[20px] font-bold text-white">
               GO

--- a/components/mobile/territory-focused-card.tsx
+++ b/components/mobile/territory-focused-card.tsx
@@ -29,7 +29,7 @@ export function TerritoryFocusedCard({
   notionPageUrl,
 }: TerritoryFocusedCardProps) {
   return (
-    <div className="fixed bottom-[86px] left-0 right-0 z-[2500]">
+    <div className="fixed bottom-[var(--picc-bottom-nav-clearance)] left-0 right-0 z-[2500]">
       <div className="mx-auto max-w-[720px] picc-shell-enter bg-[#1d1f24]/95 text-white shadow-[0_-2px_8px_rgba(0,0,0,0.35)] backdrop-blur-sm">
         <button type="button" onClick={() => onOpenDetails(store.id)} className="w-full border-b border-[#30333b] px-3 py-2 text-left">
           <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- Closes #130
- Adds a shared bottom-nav spacing contract through CSS variables.
- Moves account detail actions, contact/check-in bottom sheets, route actions, and the focused territory card above the primary footer clearance.

## Scope
- In scope: mobile footer collision fix for account-detail and adjacent fixed bottom surfaces.
- Out of scope: check-in backend behavior, map provider work, auth, schema, production data writes.

## Owned paths
- app/globals.css
- components/layout/app-shell.tsx
- components/mobile/account-detail-sheet.tsx
- components/mobile/route-mobile.tsx
- components/mobile/territory-focused-card.tsx
- SESSION.md

## Open PR overlap check
- Checked open PR #82. It touches AGENTS.md and AI_HANDOFF.md only; no overlap.

## Validation
- Started OrbStack/Docker and ran `npm run db:local:setup`: passed; local Postgres seeded.
- git diff --check: passed
- npm run typecheck: passed
- npm run lint: passed
- npm test: passed, 21 files / 97 tests
- npm run build: passed
- Browser local shell check: loaded http://127.0.0.1:3010/territory and verified CSS variables are present.
- Playwright real-user flow: `/territory` -> List -> The Sanctuary Garden -> Account Details -> Check-in.
- Account action bar geometry: footer top 624px, action bar bottom 600px, 24px gap, overlap false.
- Check-in modal geometry: footer top 624px, modal bottom 600px, 24px gap, overlap false.
- Verified old hard-coded focused-card classes are absent from fresh Playwright DOM.

## Console notes
- Existing territory hydration warning still appears during local dev.
- Existing Google Maps deprecation warning for `google.maps.Marker` still appears.
- Neither is introduced by this layout-only change.

## Remaining risk
- Production deployment still needs post-merge browser smoke on `https://piccnewyork.org/territory`.