### PR TITLE
Fix PPP savings stale Nabis cache misses

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,39 +1,43 @@
-# Session: Issue #132 Tighten Footer Clearance
+# Session: Issue #136 PPP Savings Stale Cache
 
 ## Issue
-- https://github.com/brycejohnson1417/Picc-web-app/issues/132
+- https://github.com/brycejohnson1417/Picc-web-app/issues/136
 
 ## Scope
-- Tighten the account detail action bar spacing above the primary footer.
-- Keep the action bar and check-in/contact sheets above the footer with only a small visual gap.
-- Preserve the shared bottom-safe spacing contract added for issue #130.
+- Fix the PPP savings calculator so current-year calculations include newer live Nabis orders when older cached order lines already exist.
+- Keep cached order lines as the preferred source for already-cached orders.
+- De-dupe overlapping cached and live order rows by order identity.
 
 ## Out Of Scope
-- No check-in persistence or backend behavior changes.
-- No map provider, route planning, auth, RBAC, schema, or external integration changes.
-- No production data writes.
-- No broad redesign.
+- No production data writes or backfills.
+- No schema migration.
+- No Nabis sync cadence or lease changes.
+- No pricing-table changes.
+- No customer-specific details in public GitHub surfaces.
 
 ## Owned Paths
-- `app/globals.css`
+- `lib/server/preferred-partner-savings.ts`
+- `lib/server/preferred-partner-savings*.test.ts`
 - `SESSION.md`
 
 ## Open PR Overlap Check
-- Checked open PR #82 before starting. It touches `AGENTS.md` and `AI_HANDOFF.md` only, so it does not overlap this slice.
+- Checked open PR #135 before starting. It owns Nabis exception workflow paths and does not overlap this slice.
+- Checked open PR #82 before starting. It is docs-only project-boundary work and does not overlap this slice.
 
 ## Current Evidence
-- User screenshot shows the account detail action bar is no longer hidden, but the bar floats too high above the primary footer on the desktop-width shell.
-- Issue #130 browser proof showed a 24px gap above the footer; this follow-up should reduce that to a tighter intentional gap while preserving no-overlap.
+- The calculator currently uses cached rows for a year whenever any cached rows exist.
+- That cache-first branch prevents the current-year calculation from checking live Nabis for newer orders that have not been synced yet.
 
 ## Constraints
-- Work only in `/Users/brycejohnson/Code/PICC-Web-App`.
-- Keep the change surgical and frontend-only.
-- Use browser geometry proof for the territory account-detail flow.
+- Work only in `/Users/brycejohnson/Code/PICC-Web-App` via the issue branch worktree.
+- Keep Nabis access behind server modules.
+- Keep the existing account detail PPP savings panel as the user-facing UI.
 
 ## Validation Plan
-- Browser proof: `/territory -> List -> account -> Account Details -> Check-in`.
-- Verify action bar and check-in modal do not overlap footer and have a tighter gap.
+- RED test: current-year cached rows do not suppress newer live Nabis order rows.
+- Targeted Vitest for PPP savings source selection and existing savings math.
 - Run `npm run typecheck`.
 - Run `npm run lint`.
 - Run `npm test`.
 - Run `npm run build`.
+- Browser proof for the existing account detail PPP savings panel after the server fix.

--- a/lib/server/preferred-partner-savings-source.test.ts
+++ b/lib/server/preferred-partner-savings-source.test.ts
@@ -40,6 +40,7 @@ const mockedPrisma = prisma as unknown as {
 const mockedFetchNabisJson = vi.mocked(fetchNabisJson);
 const mockedResolveAccountIdentity = vi.mocked(resolveAccountIdentity);
 const mockedLoadTerritoryStoreDetail = vi.mocked(loadTerritoryStoreDetail);
+const testYear = new Date().getFullYear();
 
 describe('Preferred Partner savings source selection', () => {
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('Preferred Partner savings source selection', () => {
 
     mockedResolveAccountIdentity.mockResolvedValue({
       accountId: 'account-1',
+      orgId: 'org-1',
       notionPageId: 'notion-page-1',
     });
     mockedLoadTerritoryStoreDetail.mockResolvedValue({
@@ -56,7 +58,7 @@ describe('Preferred Partner savings source selection', () => {
       },
       crm: {},
       contacts: [],
-    } as Awaited<ReturnType<typeof loadTerritoryStoreDetail>>);
+    } as unknown as Awaited<ReturnType<typeof loadTerritoryStoreDetail>>);
     mockedPrisma.account.findUnique.mockResolvedValue({
       id: 'account-1',
       name: 'Stale Cache Dispensary',
@@ -68,11 +70,11 @@ describe('Preferred Partner savings source selection', () => {
       {
         externalOrderId: 'cached-order-1',
         orderNumber: 'NY-OLD',
-        orderCreatedDate: new Date('2026-01-10T15:00:00.000Z'),
+        orderCreatedDate: new Date(`${testYear}-01-10T15:00:00.000Z`),
         deliveryDate: null,
         orderTotal: 56.5,
         status: 'DELIVERED',
-        createdAt: new Date('2026-01-10T16:00:00.000Z'),
+        createdAt: new Date(`${testYear}-01-10T16:00:00.000Z`),
         lines: [
           {
             productName: 'Ichi-Roll Single 1g',
@@ -91,7 +93,7 @@ describe('Preferred Partner savings source selection', () => {
         {
           id: 'cached-order-1',
           order: 'NY-OLD',
-          createdTimestamp: '2026-01-10T15:00:00.000Z',
+          createdTimestamp: `${testYear}-01-10T15:00:00.000Z`,
           orderTotal: 56.5,
           status: 'DELIVERED',
           retailerId: 'retailer-1',
@@ -105,7 +107,7 @@ describe('Preferred Partner savings source selection', () => {
         {
           id: 'live-order-today',
           order: 'NY-TODAY',
-          createdTimestamp: '2026-06-03T15:00:00.000Z',
+          createdTimestamp: `${testYear}-06-03T15:00:00.000Z`,
           orderTotal: 95,
           status: 'DELIVERED',
           retailerId: 'retailer-1',
@@ -125,7 +127,7 @@ describe('Preferred Partner savings source selection', () => {
     const result = await getPreferredPartnerSavings({
       orgId: 'org-1',
       accountIdOrPageId: 'account-1',
-      year: 2026,
+      year: testYear,
     });
 
     expect(mockedFetchNabisJson).toHaveBeenCalledWith('/v2/ny/order', {

--- a/lib/server/preferred-partner-savings-source.test.ts
+++ b/lib/server/preferred-partner-savings-source.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prisma } from '@/lib/db/prisma';
+import { fetchNabisJson } from '@/lib/server/nabis-api';
+import { resolveAccountIdentity } from '@/lib/server/account-identity';
+import { loadTerritoryStoreDetail } from '@/lib/server/notion-territory';
+import { getPreferredPartnerSavings } from '@/lib/server/preferred-partner-savings';
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    account: {
+      findUnique: vi.fn(),
+    },
+    nabisOrder: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/server/nabis-api', () => ({
+  fetchNabisJson: vi.fn(),
+}));
+
+vi.mock('@/lib/server/account-identity', () => ({
+  resolveAccountIdentity: vi.fn(),
+}));
+
+vi.mock('@/lib/server/notion-territory', () => ({
+  loadTerritoryStoreDetail: vi.fn(),
+}));
+
+const mockedPrisma = prisma as unknown as {
+  account: {
+    findUnique: ReturnType<typeof vi.fn>;
+  };
+  nabisOrder: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+const mockedFetchNabisJson = vi.mocked(fetchNabisJson);
+const mockedResolveAccountIdentity = vi.mocked(resolveAccountIdentity);
+const mockedLoadTerritoryStoreDetail = vi.mocked(loadTerritoryStoreDetail);
+
+describe('Preferred Partner savings source selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedResolveAccountIdentity.mockResolvedValue({
+      accountId: 'account-1',
+      notionPageId: 'notion-page-1',
+    });
+    mockedLoadTerritoryStoreDetail.mockResolvedValue({
+      store: {
+        name: 'Stale Cache Dispensary',
+        licenseNumber: 'OCM-RETL-26-000001-D1',
+      },
+      crm: {},
+      contacts: [],
+    } as Awaited<ReturnType<typeof loadTerritoryStoreDetail>>);
+    mockedPrisma.account.findUnique.mockResolvedValue({
+      id: 'account-1',
+      name: 'Stale Cache Dispensary',
+      licenseNumber: 'OCM-RETL-26-000001-D1',
+      licensedLocationId: 'licensed-location-1',
+      nabisRetailerId: 'retailer-1',
+    });
+    mockedPrisma.nabisOrder.findMany.mockResolvedValue([
+      {
+        externalOrderId: 'cached-order-1',
+        orderNumber: 'NY-OLD',
+        orderCreatedDate: new Date('2026-01-10T15:00:00.000Z'),
+        deliveryDate: null,
+        orderTotal: 56.5,
+        status: 'DELIVERED',
+        createdAt: new Date('2026-01-10T16:00:00.000Z'),
+        lines: [
+          {
+            productName: 'Ichi-Roll Single 1g',
+            quantity: 10,
+            unitPrice: 5,
+            isSample: false,
+            itemStrain: null,
+            itemCategory: null,
+            itemClass: null,
+          },
+        ],
+      },
+    ]);
+    mockedFetchNabisJson.mockResolvedValue({
+      data: [
+        {
+          id: 'cached-order-1',
+          order: 'NY-OLD',
+          createdTimestamp: '2026-01-10T15:00:00.000Z',
+          orderTotal: 56.5,
+          status: 'DELIVERED',
+          retailerId: 'retailer-1',
+          licensedLocationId: 'licensed-location-1',
+          retailer: 'Stale Cache Dispensary',
+          skuName: 'Ichi-Roll Single 1g',
+          units: 10,
+          pricePerUnit: 5,
+          lineItemSubtotal: 50,
+        },
+        {
+          id: 'live-order-today',
+          order: 'NY-TODAY',
+          createdTimestamp: '2026-06-03T15:00:00.000Z',
+          orderTotal: 95,
+          status: 'DELIVERED',
+          retailerId: 'retailer-1',
+          licensedLocationId: 'licensed-location-1',
+          retailer: 'Stale Cache Dispensary',
+          skuName: 'O-Yeah 5-Pack 2.5g',
+          units: 5,
+          pricePerUnit: 17.5,
+          lineItemSubtotal: 87.5,
+        },
+      ],
+      nextPage: null,
+    });
+  });
+
+  it('does not let stale cached rows suppress newer current-year live Nabis orders', async () => {
+    const result = await getPreferredPartnerSavings({
+      orgId: 'org-1',
+      accountIdOrPageId: 'account-1',
+      year: 2026,
+    });
+
+    expect(mockedFetchNabisJson).toHaveBeenCalledWith('/v2/ny/order', {
+      searchParams: {
+        page: '0',
+        limit: '500',
+        action: 'DELIVERY_TO_RETAILER',
+      },
+    });
+    expect(result.orders.map((order) => order.orderNumber)).toEqual(['NY-OLD', 'NY-TODAY']);
+    expect(result.summary.orderCount).toBe(2);
+    expect(result.summary.totalSavings).toBe(27.5);
+  });
+});

--- a/lib/server/preferred-partner-savings.ts
+++ b/lib/server/preferred-partner-savings.ts
@@ -235,12 +235,71 @@ function rowDate(row: NabisRawOrderRow) {
   return parseDate(readString(row, ['createdTimestamp', 'createdDate', 'deliveryDate', 'paidAt']));
 }
 
+function orderIdentityKeys(row: NabisRawOrderRow) {
+  return ['order', 'orderNumber', 'externalOrderId', 'id']
+    .map((field) => normalizeIdentifier(readString(row, [field])))
+    .filter((value, index, values): value is string => Boolean(value && values.indexOf(value) === index));
+}
+
+function mergeCachedAndLiveOrderRows(cachedRows: NabisRawOrderRow[], liveRows: NabisRawOrderRow[]) {
+  if (cachedRows.length === 0) {
+    return liveRows;
+  }
+  if (liveRows.length === 0) {
+    return cachedRows;
+  }
+
+  const cachedOrderKeys = new Set<string>();
+  for (const row of cachedRows) {
+    for (const key of orderIdentityKeys(row)) {
+      cachedOrderKeys.add(key);
+    }
+  }
+
+  const liveGroups = new Map<string, { keys: Set<string>; rows: NabisRawOrderRow[] }>();
+  liveRows.forEach((row, index) => {
+    const keys = orderIdentityKeys(row);
+    const groupKey = keys.find((key) => liveGroups.has(key)) ?? keys[0] ?? `__missing_order_key_${index}`;
+    const group = liveGroups.get(groupKey) ?? { keys: new Set<string>(), rows: [] };
+    for (const key of keys) {
+      group.keys.add(key);
+    }
+    group.rows.push(row);
+    liveGroups.set(groupKey, group);
+    for (const key of keys) {
+      liveGroups.set(key, group);
+    }
+  });
+
+  const merged = [...cachedRows];
+  const appendedGroups = new Set<{ keys: Set<string>; rows: NabisRawOrderRow[] }>();
+  for (const group of liveGroups.values()) {
+    if (appendedGroups.has(group)) {
+      continue;
+    }
+    appendedGroups.add(group);
+    if ([...group.keys].some((key) => cachedOrderKeys.has(key))) {
+      continue;
+    }
+    merged.push(...group.rows);
+    for (const key of group.keys) {
+      cachedOrderKeys.add(key);
+    }
+  }
+
+  return merged;
+}
+
 function dateKey(date: Date | null) {
   return date ? date.toISOString().slice(0, 10) : null;
 }
 
 function currentYear() {
   return new Date().getFullYear();
+}
+
+function shouldRefreshLiveRowsForYear(year: number) {
+  return year >= currentYear();
 }
 
 function resolveSavingsYears(input: { year?: number | null; historical?: boolean | null }) {
@@ -892,12 +951,16 @@ export async function getPreferredPartnerSavings(input: {
     try {
       const cachedOrders = await loadCachedOrdersForAccount(context, year);
       const cachedRows = cachedNabisOrdersToPreferredPartnerRows(cachedOrders);
-      const rows =
-        cachedRows.length > 0
-          ? cachedRows
-          : cachedOrders.length > 0
-            ? await loadNabisRowsFromCachedOrderHeaders(cachedOrders)
-            : await loadNabisRowsForAccount(context, year);
+      let rows =
+        cachedRows.length > 0 ? cachedRows : cachedOrders.length > 0 ? await loadNabisRowsFromCachedOrderHeaders(cachedOrders) : [];
+
+      if (shouldRefreshLiveRowsForYear(year)) {
+        const liveRows = await loadNabisRowsForAccount(context, year);
+        rows = rows.length > 0 ? mergeCachedAndLiveOrderRows(rows, liveRows) : liveRows;
+      } else if (rows.length === 0) {
+        rows = await loadNabisRowsForAccount(context, year);
+      }
+
       const yearOrders = calculatePreferredPartnerOrdersFromRows(rows);
       orders.push(...yearOrders);
       if (rows.length > 0 && yearOrders.length === 0) {


### PR DESCRIPTION
## Summary
- Closes #136.
- Fixes the PPP savings calculator path that could miss newer current-year Nabis orders when older cached order lines already existed for the same account.
- Keeps cached rows preferred for already-cached invoices and appends only live Nabis order groups whose order identity is not represented in cache.
- Adds a regression test proving stale cached rows no longer suppress a newer live order.

## Root Cause
The calculator selected cached rows for a year whenever `cachedRows.length > 0`. That meant a store with any cached current-year order skipped the live Nabis order scan entirely, so a same-day order could be invisible until a separate sync populated the local cache.

## Scope
- Current-year PPP savings now asks live Nabis for matching order rows even when cached rows exist.
- Cached rows still win for overlapping order identities (`order`, `orderNumber`, `externalOrderId`, `id`).
- Past-year calculations keep the old cache-first behavior unless no cached/detail rows are available.

## Out of Scope
- No production data writes or backfills.
- No schema migration.
- No Nabis sync cadence changes.
- No pricing-table changes.
- No public customer-specific details.

## Owned Path Globs
- `lib/server/preferred-partner-savings.ts`
- `lib/server/preferred-partner-savings*.test.ts`
- `SESSION.md`

## Coordination
- Checked open PR #135: Nabis exception workflow, no owned path overlap.
- Checked open PR #82: docs-only project boundary, no owned path overlap.
- Classification: `parallel:exclusive` because this touches Nabis-backed calculation behavior.

## Validation
- RED before fix: `PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run lib/server/preferred-partner-savings-source.test.ts` failed because live Nabis fetch was not called when cached rows existed.
- `PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run lib/server/preferred-partner-savings-source.test.ts`
- `PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run lib/server/preferred-partner-savings.test.ts lib/server/preferred-partner-savings-source.test.ts`
- `rm -f tsconfig.tsbuildinfo && PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc -p tsconfig.typecheck.json --noEmit`
- `PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/eslint app components lib prisma --ext .ts,.tsx`
- `PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run` - 22 files, 98 tests passed
- `PATH=/Users/brycejohnson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/next build`
- Local HTTP proof: branch server on `http://127.0.0.1:3011`; `curl -I /accounts` returned 200. Browser screenshot proof was blocked because the MCP browser profile is already in use by another session.

## Remaining Risk
- Production verification still needs a deployed build and read-only proof against production/Nabis data. No production writes are required for this fix.