### PR TITLE
Remove personal workbook path defaults

### DIFF
--- a/app/api/integrations/sheets/schema/route.ts
+++ b/app/api/integrations/sheets/schema/route.ts
@@ -7,7 +7,22 @@ export async function GET() {
   const ctx = await guard(['ADMIN', 'OPS_TEAM', 'FINANCE']);
   if ('error' in ctx) return ctx.error;
 
-  const path = process.env.NABIS_MASTER_SHEET_PATH || '/Users/brycejohnson/Downloads/Nabis Notion Master Sheet.xlsx';
+  const path = process.env.NABIS_MASTER_SHEET_PATH?.trim();
+
+  if (!path) {
+    return NextResponse.json({
+      path: null,
+      fallback: true,
+      warning: 'NABIS_MASTER_SHEET_PATH is not configured. Returning mapped schema only.',
+      tabs: [],
+      requiredCoverage: REQUIRED_NABIS_TABS.map((tab) => ({
+        tab,
+        present: false,
+        mapping: NABIS_SCHEMA_MAPPING[tab as keyof typeof NABIS_SCHEMA_MAPPING] || null,
+      })),
+      sample: [],
+    });
+  }
 
   try {
     const data = inspectNabisWorkbook(path);

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -393,7 +393,7 @@ async function main() {
       provider: 'GOOGLE_SHEETS',
       name: 'Nabis Master Sheet',
       config: {
-        workbookPath: '/Users/brycejohnson/Downloads/Nabis Notion Master Sheet.xlsx',
+        workbookPath: process.env.NABIS_MASTER_SHEET_PATH || '/path/to/local/nabis-export.xlsx',
         requiredTabs: [
           'orders',
           'details',


### PR DESCRIPTION
Closes #147

## Why
Public source should not include a developer-specific local filesystem path as a default workbook location. It is not a secret, but it is unnecessary personal metadata and looks unpolished in public code review.

## What changed
- The sheets schema API now returns mapped schema fallback data when NABIS_MASTER_SHEET_PATH is unset instead of using a laptop-local path.
- Seed data now uses NABIS_MASTER_SHEET_PATH when provided, otherwise a generic local placeholder path.

## What did not change
- No production env values.
- No schema changes.
- No external data access or data writes.

## Validation
- Manual diff review.
- Protected PR CI expected for lint/type/build/migration checks.

## Remaining risk
- Historical commits may still contain the old path unless history rewrite is explicitly approved.