### PR TITLE
Add verified contact creation to Accounts

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,53 +1,63 @@
-# Session: Micro Bar buyer-facing copy and CTA correction
+# Session: Verified contact creation and Contacts navigation
 
 ## Issue
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/153
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/155
 
 ## Branch
 
-- `codex/microbar-buyer-copy`
+- `codex/155-contacts`
 
 ## Scope
 
-- Revise `/microbar` copy for educated New York dispensary buyers.
-- Replace invented product one-liners with real Micro Bar product descriptions from supplied brand/menu materials.
-- Remove on-page ordering language and keep buyer CTAs focused on:
-  - live Micro Bar Nabis marketplace profile
-  - direct Bryce email contact
-- Preserve the current visual direction and Micro Bar brand assets.
-
-## Domain Constraint
-
-- Keep `piccnewyork.org/microbar` as the live app route for now.
-- Do not change the root `piccnewyork.com` redirect; it should continue going to `piccnewyork.notion.site`.
-- Future work may add a path-only redirect from `piccnewyork.com/microbar` to this page, but this session does not mutate DNS or domain routing.
+- Make Contacts directly reachable as a section tab inside Accounts.
+- Keep Home, Map, Accounts, Route, and Dashboard in persistent navigation.
+- Keep Home accessible from the Profile/tools menu.
+- Add one reusable contact-creation experience to the Contacts page.
+- Create contacts through the existing external CRM boundary.
+- Prevent account-scoped duplicates, preserve existing relationships, and verify the completed relationship before reporting success.
+- Provide honest, retryable partial-failure behavior.
 
 ## Out Of Scope
 
-- On-page cart, checkout, order builder, or marketplace ordering flow.
-- Authenticated PICC app shell changes.
-- Territory, account, calendar, Nabis, Notion, Supabase, Clerk, or production data changes.
-- Backend writes, schema migrations, DNS edits, or redirect configuration changes.
-- Private PICC operating intelligence in public copy.
+- Task creation UI, which remains tracked by issue #36.
+- Mobile bundle optimization, which remains tracked by issue #94.
+- Remote branch and stale PR cleanup, which remains tracked by issue #39.
+- Bulk imports, historical relation repair, CRM schema changes, production backfills, or destructive data operations.
+- Publishing private workspace IDs, tokens, or tenant-specific operating details.
 
 ## Owned Paths
 
-- `app/microbar/**`
+- `app/(main)/accounts/page.tsx`
+- `app/(main)/contacts/**`
+- `app/api/contacts/**`
+- `components/crm/accounts-section-tabs.tsx`
+- `components/crm/contact-create-flow.tsx`
+- `components/layout/app-shell.tsx`
+- `lib/contacts/contact-create-model*`
+- `lib/server/contact-creation*`
+- `lib/server/notion-contact-creation*`
+- `lib/server/notion-live-crm.ts`
+- `lib/validation/schemas.ts`
+- focused tests and browser artifacts for the above paths
+- `docs/superpowers/specs/2026-08-12-contact-creation-design.md`
+- `docs/superpowers/plans/2026-08-12-contact-creation.md`
 - `SESSION.md`
 
 ## Active PR Overlap Check
 
-- Checked open PRs #144, #135, and #82.
-- No overlapping owned path globs found.
+- PR #135 overlaps `components/mobile/account-detail-sheet.tsx`; this branch does not edit that path.
+- PRs #144 and #82 were checked and do not own the implemented paths.
 
 ## Validation Plan
 
-- Run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
-- Use Browser for rendered validation.
-- Verify `/microbar` loads publicly, is nonblank, has no framework overlay, and responds to product/filter/CTA interactions.
-- Capture desktop and mobile screenshots.
+- Use RED-first unit and route tests for duplicate prevention, relationship preservation, verification, partial failure, retry, validation, and authorization.
+- Run focused tests after each behavior slice.
+- Run `npm run verify` under Node 22.
+- Run browser tests for the Contacts page, Accounts tabs, persistent navigation, Profile menu, form states, and 390x844 mobile viewport.
+- Use fakes or route interception for external writes during automated/browser validation. Do not create production contacts as test data.
 
-## TDD Note
+## Production Boundary
 
-This is a static public marketing-copy and CTA correction using existing Next.js patterns and supplied product descriptions. A RED unit test is not practical for visual copy/layout; browser validation is the primary behavior proof.
+- Live schema inspection was read-only and explicitly approved.
+- No production CRM writes, schema changes, backfills, or destructive actions are authorized for validation.

--- a/app/(main)/accounts/page.tsx
+++ b/app/(main)/accounts/page.tsx
@@ -1,5 +1,11 @@
 import { AccountsMobile } from '@/components/mobile/accounts-mobile';
+import { AccountsSectionTabs } from '@/components/crm/accounts-section-tabs';
 
 export default async function AccountsPage() {
-  return <AccountsMobile />;
+  return (
+    <>
+      <AccountsSectionTabs />
+      <AccountsMobile />
+    </>
+  );
 }

--- a/app/(main)/contacts/page.tsx
+++ b/app/(main)/contacts/page.tsx
@@ -1,3 +1,5 @@
+import { AccountsSectionTabs } from '@/components/crm/accounts-section-tabs';
+import { ContactCreateFlow } from '@/components/crm/contact-create-flow';
 import { ContactsTable } from '@/components/crm/contacts-table';
 import { DataFreshnessBanner } from '@/components/shared/data-freshness';
 import { loadAccountContactRuntime } from '@/lib/server/account-contact-runtime';
@@ -6,16 +8,23 @@ export default async function ContactsPage() {
   const runtime = await loadAccountContactRuntime();
 
   return (
-    <div className="space-y-6">
-      <header>
-        <h1 className="text-3xl font-bold">Contacts</h1>
-        <p className="text-sm text-slate-500">High-turnover contact table. Mark inactive instantly while preserving account history.</p>
-      </header>
-      <section className="grid gap-3 lg:grid-cols-2" aria-label="Contact data freshness">
-        <DataFreshnessBanner freshness={runtime.freshness.contacts} compact />
-        <DataFreshnessBanner freshness={runtime.freshness.accounts} compact />
-      </section>
-      <ContactsTable rows={runtime.contacts} />
+    <div className="min-h-full bg-[linear-gradient(180deg,#f7f9fc_0%,#eef2f7_100%)]">
+      <AccountsSectionTabs />
+      <div className="mx-auto max-w-[var(--app-shell-max)] space-y-5 px-4 pb-28 pt-5 md:px-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#818a98]">Accounts</p>
+            <h1 className="mt-1 text-2xl font-semibold tracking-[-0.03em] text-[#18212d]">Contacts</h1>
+            <p className="mt-1 max-w-xl text-sm leading-6 text-[#657081]">People linked to each dispensary in the live CRM.</p>
+          </div>
+          <ContactCreateFlow accounts={runtime.accounts} />
+        </header>
+        <section className="grid gap-3 lg:grid-cols-2" aria-label="Contact data freshness">
+          <DataFreshnessBanner freshness={runtime.freshness.contacts} compact />
+          <DataFreshnessBanner freshness={runtime.freshness.accounts} compact />
+        </section>
+        <ContactsTable rows={runtime.contacts} />
+      </div>
     </div>
   );
 }

--- a/app/api/contacts/retry/route.ts
+++ b/app/api/contacts/retry/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { parseJsonBody, routeErrorResponse } from '@/lib/api/route-errors';
+import { guard } from '@/lib/auth/api-guard';
+import { retryVerifiedContactLink } from '@/lib/server/contact-creation';
+import { createNotionContactCreationAdapter } from '@/lib/server/notion-contact-creation';
+import { notionContactRetrySchema } from '@/lib/validation/schemas';
+
+export async function POST(req: Request) {
+  const ctx = await guard(['ADMIN', 'OPS_TEAM', 'SALES_REP', 'BRAND_AMBASSADOR']);
+  if ('error' in ctx) return ctx.error;
+
+  try {
+    const payload = await parseJsonBody(req, notionContactRetrySchema);
+    const result = await retryVerifiedContactLink(payload, createNotionContactCreationAdapter());
+    return NextResponse.json(result, { status: result.status === 'partial_relation' ? 202 : 200 });
+  } catch (error) {
+    return routeErrorResponse(error, {
+      fallbackMessage: 'Failed to verify contact relationship',
+      zodMessage: 'Invalid contact retry payload',
+      statusByMessage: {
+        'Contact account not found': 404,
+        'Contact not found': 404,
+      },
+    });
+  }
+}

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { ActivityType } from '@prisma/client';
 import { parseJsonBody, routeErrorResponse } from '@/lib/api/route-errors';
 import { guard } from '@/lib/auth/api-guard';
 import { prisma } from '@/lib/db/prisma';
-import { contactSchema } from '@/lib/validation/schemas';
-import { writeActivity } from '@/lib/activity-log/write';
+import { notionContactCreateSchema } from '@/lib/validation/schemas';
+import { createVerifiedContact } from '@/lib/server/contact-creation';
+import { createNotionContactCreationAdapter } from '@/lib/server/notion-contact-creation';
 
 export async function GET() {
   const ctx = await guard();
@@ -23,24 +23,15 @@ export async function POST(req: Request) {
   if ('error' in ctx) return ctx.error;
 
   try {
-    const payload = await parseJsonBody(req, contactSchema);
-    const contact = await prisma.contact.create({ data: { orgId: ctx.orgId, ...payload } });
-
-    await writeActivity({
-      orgId: ctx.orgId,
-      accountId: payload.accountId,
-      contactId: contact.id,
-      actorClerkUserId: ctx.userId,
-      type: ActivityType.CONTACT_UPDATED,
-      title: 'Contact added',
-      description: `${contact.firstName} ${contact.lastName}`,
-    });
-
-    return NextResponse.json(contact, { status: 201 });
+    const payload = await parseJsonBody(req, notionContactCreateSchema);
+    const result = await createVerifiedContact(payload, createNotionContactCreationAdapter());
+    const status = result.status === 'partial_relation' ? 202 : result.status === 'created_verified' ? 201 : 200;
+    return NextResponse.json(result, { status });
   } catch (error) {
     return routeErrorResponse(error, {
       fallbackMessage: 'Failed to create contact',
       zodMessage: 'Invalid contact payload',
+      statusByMessage: { 'Contact account not found': 404 },
     });
   }
 }

--- a/components/crm/accounts-section-tabs.tsx
+++ b/components/crm/accounts-section-tabs.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Building2, ContactRound } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const tabs = [
+  { href: '/accounts', label: 'Accounts', icon: Building2 },
+  { href: '/contacts', label: 'Contacts', icon: ContactRound },
+];
+
+export function AccountsSectionTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Accounts sections"
+      className="border-b border-[#d7dde7] bg-[#f7f9fc] px-3 py-2 md:px-5"
+    >
+      <div className="mx-auto grid max-w-md grid-cols-2 rounded-xl bg-[#e1e5eb] p-1">
+        {tabs.map((tab) => {
+          const active = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+          const Icon = tab.icon;
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              aria-current={active ? 'page' : undefined}
+              className={cn(
+                'flex min-h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition-colors',
+                active
+                  ? 'bg-white text-[#18212d] shadow-[0_1px_3px_rgba(31,35,43,0.12)]'
+                  : 'text-[#687384] hover:text-[#2f3947]',
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/crm/contact-create-flow.tsx
+++ b/components/crm/contact-create-flow.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { CheckCircle2, Loader2, Plus, RotateCw, Search, X } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  buildContactCreatePayload,
+  contactCreateMessage,
+  filterContactAccounts,
+  type ContactAccountOption,
+  type ContactCreateStatus,
+} from '@/lib/contacts/contact-create-model';
+import { cn } from '@/lib/utils';
+
+type ContactResponse = {
+  status: ContactCreateStatus;
+  contact: { id: string; name: string };
+  retry?: { accountPageId: string; contactPageId: string };
+};
+
+const emptyDraft = {
+  accountPageId: '',
+  name: '',
+  position: '',
+  email: '',
+  phone: '',
+};
+
+export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption[] }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const requestedOpen = searchParams.get('new') === '1';
+  const requestedAccount = searchParams.get('account') ?? '';
+  const [open, setOpen] = useState(requestedOpen);
+  const [draft, setDraft] = useState({ ...emptyDraft, accountPageId: requestedAccount });
+  const [accountSearch, setAccountSearch] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ContactResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (requestedOpen) setOpen(true);
+  }, [requestedOpen]);
+
+  const filteredAccounts = useMemo(
+    () => filterContactAccounts(accounts, accountSearch).slice(0, 60),
+    [accountSearch, accounts],
+  );
+  const selectedAccount = accounts.find((account) => account.notionPageId === draft.accountPageId);
+
+  function changeOpen(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setResult(null);
+      setError(null);
+      setSubmitting(false);
+      setDraft(emptyDraft);
+      setAccountSearch('');
+      if (requestedOpen) router.replace('/contacts', { scroll: false });
+    }
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/contacts', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(buildContactCreatePayload(draft)),
+      });
+      const payload = (await response.json().catch(() => ({}))) as ContactResponse & { error?: string };
+      if (!response.ok && response.status !== 202) {
+        throw new Error(payload.error || 'Contact could not be saved.');
+      }
+      setResult(payload);
+      toast[payload.status === 'partial_relation' ? 'warning' : 'success'](
+        contactCreateMessage(payload.status),
+      );
+      if (payload.status !== 'partial_relation') router.refresh();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Contact could not be saved.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function retryRelationship() {
+    if (!result?.retry) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/contacts/retry', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(result.retry),
+      });
+      const payload = (await response.json().catch(() => ({}))) as ContactResponse & { error?: string };
+      if (!response.ok && response.status !== 202) throw new Error(payload.error || 'Link verification failed.');
+      setResult(payload);
+      if (payload.status !== 'partial_relation') {
+        toast.success(contactCreateMessage(payload.status));
+        router.refresh();
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Link verification failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={changeOpen}>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[#c93412] px-4 text-sm font-semibold text-white shadow-[0_8px_18px_rgba(201,52,18,0.22)] transition hover:bg-[#ad2d0e] active:scale-[0.98]"
+        >
+          <Plus className="h-4 w-4" />
+          Add contact
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[5000] bg-[#111722]/55 backdrop-blur-[2px]" />
+        <Dialog.Content className="fixed inset-x-0 bottom-0 z-[5001] max-h-[92dvh] overflow-y-auto rounded-t-[24px] border border-[#d7dde7] bg-[#f8fafc] shadow-[0_-20px_60px_rgba(17,23,34,0.24)] md:bottom-auto md:left-1/2 md:top-1/2 md:max-h-[88dvh] md:w-[min(620px,calc(100vw-32px))] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[24px]">
+          <div className="sticky top-0 z-10 flex items-start justify-between gap-4 border-b border-[#dce2eb] bg-[#f8fafc]/95 px-5 py-4 backdrop-blur">
+            <div>
+              <Dialog.Title className="text-xl font-semibold tracking-[-0.02em] text-[#18212d]">Add contact</Dialog.Title>
+              <Dialog.Description className="mt-1 text-sm text-[#667183]">
+                Save once, then verify the contact on both sides of the account relationship.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close className="grid h-10 w-10 shrink-0 place-items-center rounded-full text-[#5f6978] hover:bg-[#e9edf3]" aria-label="Close add contact">
+              <X className="h-5 w-5" />
+            </Dialog.Close>
+          </div>
+
+          {result ? (
+            <div className="space-y-5 p-5">
+              <div className={cn('rounded-2xl border p-5', result.status === 'partial_relation' ? 'border-amber-300 bg-amber-50' : 'border-emerald-300 bg-emerald-50')}>
+                <CheckCircle2 className={cn('h-7 w-7', result.status === 'partial_relation' ? 'text-amber-700' : 'text-emerald-700')} />
+                <h2 className="mt-3 text-lg font-semibold text-[#18212d]">{result.contact.name}</h2>
+                <p className="mt-1 text-sm leading-6 text-[#536071]">{contactCreateMessage(result.status)}</p>
+              </div>
+              {error ? <p role="alert" className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">{error}</p> : null}
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <button type="button" onClick={() => changeOpen(false)} className="min-h-11 rounded-xl border border-[#cfd6e1] bg-white px-4 text-sm font-semibold text-[#263242]">Done</button>
+                {result.status === 'partial_relation' ? (
+                  <button type="button" disabled={submitting} onClick={() => void retryRelationship()} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[#c93412] px-4 text-sm font-semibold text-white disabled:opacity-60">
+                    {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
+                    Retry link verification
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ) : (
+            <form className="space-y-5 p-5" onSubmit={submit}>
+              <fieldset>
+                <legend className="text-sm font-semibold text-[#263242]">Account <span className="text-[#c93412]">*</span></legend>
+                {selectedAccount ? (
+                  <div className="mt-2 flex items-center justify-between gap-3 rounded-xl border border-[#b8c5d7] bg-white p-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-[#18212d]">{selectedAccount.name}</p>
+                      <p className="text-xs text-[#6a7483]">{[selectedAccount.city, selectedAccount.state].filter(Boolean).join(', ') || 'Location unavailable'}</p>
+                    </div>
+                    <button type="button" onClick={() => setDraft((current) => ({ ...current, accountPageId: '' }))} className="text-sm font-semibold text-[#c93412]">Change</button>
+                  </div>
+                ) : (
+                  <div className="mt-2 overflow-hidden rounded-xl border border-[#cfd6e1] bg-white">
+                    <label className="flex items-center gap-2 border-b border-[#e0e5ed] px-3">
+                      <Search className="h-4 w-4 text-[#7b8491]" />
+                      <span className="sr-only">Search accounts</span>
+                      <input value={accountSearch} onChange={(event) => setAccountSearch(event.target.value)} placeholder="Search dispensary or city" className="h-11 min-w-0 flex-1 bg-transparent text-base outline-none placeholder:text-[#9aa2ad]" />
+                    </label>
+                    <div className="max-h-44 overflow-y-auto p-1.5">
+                      {filteredAccounts.length ? filteredAccounts.map((account) => (
+                        <button key={account.notionPageId} type="button" onClick={() => setDraft((current) => ({ ...current, accountPageId: account.notionPageId }))} className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-[#f1f4f8]">
+                          <span className="truncate text-sm font-medium text-[#253142]">{account.name}</span>
+                          <span className="shrink-0 text-xs text-[#7a8492]">{[account.city, account.state].filter(Boolean).join(', ')}</span>
+                        </button>
+                      )) : <p className="px-3 py-6 text-center text-sm text-[#77818f]">No matching accounts</p>}
+                    </div>
+                  </div>
+                )}
+              </fieldset>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <ContactField label="Full name" required value={draft.name} onChange={(value) => setDraft((current) => ({ ...current, name: value }))} autoComplete="name" />
+                <ContactField label="Role / position" required value={draft.position} onChange={(value) => setDraft((current) => ({ ...current, position: value }))} autoComplete="organization-title" />
+                <ContactField label="Email" type="email" value={draft.email} onChange={(value) => setDraft((current) => ({ ...current, email: value }))} autoComplete="email" />
+                <ContactField label="Phone" type="tel" value={draft.phone} onChange={(value) => setDraft((current) => ({ ...current, phone: value }))} autoComplete="tel" />
+              </div>
+
+              {error ? <p role="alert" className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">{error}</p> : null}
+              <div className="flex flex-col-reverse gap-2 border-t border-[#e0e5ed] pt-4 sm:flex-row sm:justify-end">
+                <Dialog.Close className="min-h-11 rounded-xl border border-[#cfd6e1] bg-white px-4 text-sm font-semibold text-[#263242]">Cancel</Dialog.Close>
+                <button type="submit" disabled={submitting || !draft.accountPageId || !draft.name.trim() || !draft.position.trim()} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[#c93412] px-5 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50">
+                  {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  {submitting ? 'Saving and verifying…' : 'Save contact'}
+                </button>
+              </div>
+            </form>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function ContactField({ label, required, type = 'text', value, onChange, autoComplete }: { label: string; required?: boolean; type?: string; value: string; onChange: (value: string) => void; autoComplete?: string }) {
+  return (
+    <label className="block text-sm font-semibold text-[#263242]">
+      {label} {required ? <span className="text-[#c93412]">*</span> : null}
+      <input required={required} type={type} value={value} onChange={(event) => onChange(event.target.value)} autoComplete={autoComplete} className="mt-2 h-12 w-full rounded-xl border border-[#cfd6e1] bg-white px-3 text-base font-normal text-[#18212d] outline-none transition focus:border-[#c93412] focus:ring-2 focus:ring-[#c93412]/15" />
+    </label>
+  );
+}

--- a/components/crm/contact-create-flow.tsx
+++ b/components/crm/contact-create-flow.tsx
@@ -35,6 +35,9 @@ export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption
   const requestedAccount = searchParams.get('account') ?? '';
   const [open, setOpen] = useState(requestedOpen);
   const [draft, setDraft] = useState({ ...emptyDraft, accountPageId: requestedAccount });
+  const [availableAccounts, setAvailableAccounts] = useState(accounts);
+  const [loadingAccounts, setLoadingAccounts] = useState(false);
+  const [accountsRequested, setAccountsRequested] = useState(false);
   const [accountSearch, setAccountSearch] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<ContactResponse | null>(null);
@@ -44,11 +47,33 @@ export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption
     if (requestedOpen) setOpen(true);
   }, [requestedOpen]);
 
+  async function loadAccountsIfNeeded() {
+    if (availableAccounts.length > 0 || loadingAccounts || accountsRequested) return;
+    setAccountsRequested(true);
+    setLoadingAccounts(true);
+    try {
+      const response = await fetch('/api/runtime/account-contact');
+      if (!response.ok) throw new Error('Accounts could not be loaded.');
+      const payload = (await response.json()) as { accounts?: ContactAccountOption[] };
+      setAvailableAccounts(payload.accounts ?? []);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Accounts could not be loaded.');
+    } finally {
+      setLoadingAccounts(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadAccountsIfNeeded();
+    // This only runs when the server-rendered runtime could not provide accounts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountsRequested, availableAccounts.length, loadingAccounts]);
+
   const filteredAccounts = useMemo(
-    () => filterContactAccounts(accounts, accountSearch).slice(0, 60),
-    [accountSearch, accounts],
+    () => filterContactAccounts(availableAccounts, accountSearch).slice(0, 60),
+    [accountSearch, availableAccounts],
   );
-  const selectedAccount = accounts.find((account) => account.notionPageId === draft.accountPageId);
+  const selectedAccount = availableAccounts.find((account) => account.notionPageId === draft.accountPageId);
 
   function changeOpen(nextOpen: boolean) {
     setOpen(nextOpen);
@@ -118,6 +143,7 @@ export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption
       <Dialog.Trigger asChild>
         <button
           type="button"
+          onClick={() => void loadAccountsIfNeeded()}
           className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[#c93412] px-4 text-sm font-semibold text-white shadow-[0_8px_18px_rgba(201,52,18,0.22)] transition hover:bg-[#ad2d0e] active:scale-[0.98]"
         >
           <Plus className="h-4 w-4" />
@@ -177,7 +203,9 @@ export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption
                       <input value={accountSearch} onChange={(event) => setAccountSearch(event.target.value)} placeholder="Search dispensary or city" className="h-11 min-w-0 flex-1 bg-transparent text-base outline-none placeholder:text-[#9aa2ad]" />
                     </label>
                     <div className="max-h-44 overflow-y-auto p-1.5">
-                      {filteredAccounts.length ? filteredAccounts.map((account) => (
+                      {loadingAccounts ? (
+                        <p className="flex items-center justify-center gap-2 px-3 py-6 text-sm text-[#77818f]"><Loader2 className="h-4 w-4 animate-spin" /> Loading accounts…</p>
+                      ) : filteredAccounts.length ? filteredAccounts.map((account) => (
                         <button key={account.notionPageId} type="button" onClick={() => setDraft((current) => ({ ...current, accountPageId: account.notionPageId }))} className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-[#f1f4f8]">
                           <span className="truncate text-sm font-medium text-[#253142]">{account.name}</span>
                           <span className="shrink-0 text-xs text-[#7a8492]">{[account.city, account.state].filter(Boolean).join(', ')}</span>

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -34,6 +34,9 @@ const defaultTabs: NavTab[] = [
 ];
 
 function isActive(pathname: string, href: string) {
+  if (href === '/accounts' && (pathname === '/contacts' || pathname.startsWith('/contacts/'))) {
+    return true;
+  }
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
@@ -101,6 +104,10 @@ export function AppShell({
                     Current Role
                     <div className="mt-1 text-sm font-semibold text-[#18212d]">{roleLabel(access.role)}</div>
                   </div>
+                  <Link href="/home" className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-[#243040] hover:bg-[#f3f6fb]">
+                    <House className="h-4 w-4" />
+                    Home
+                  </Link>
                   <Link href="/settings" className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-[#243040] hover:bg-[#f3f6fb]">
                     <Settings className="h-4 w-4" />
                     Settings

--- a/docs/superpowers/plans/2026-08-12-contact-creation.md
+++ b/docs/superpowers/plans/2026-08-12-contact-creation.md
@@ -1,0 +1,415 @@
+# Verified Contact Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Contacts a clear tab inside the Accounts section and provide an account-scoped, duplicate-safe contact form whose external CRM relationship is freshly verified before success.
+
+**Architecture:** A pure orchestration service owns contact dedupe, creation, relationship repair, and verification through a narrow adapter interface. A current-version Notion adapter implements that interface behind the server boundary. Route handlers map typed outcomes to HTTP, while one reusable client flow serves the Contacts page and account-detail entry points.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript strict, Tailwind CSS 4, Zod, Vitest, Playwright, Notion API `2026-03-11`.
+
+## Global Constraints
+
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/155
+- Work only on `codex/155-contacts`; never edit `main` or the user's Microbar branch.
+- Do not create production contacts during tests or browser verification.
+- Do not publish workspace IDs, tokens, raw external payloads, or tenant-specific operating intelligence.
+- No external CRM schema changes, bulk imports, historical repairs, production backfills, or destructive writes.
+- Keep Home, Map, Accounts, Route, and Dashboard in persistent navigation; also expose Home in Profile/tools.
+- Add Accounts and Contacts as section tabs, and keep the persistent Accounts destination active on both routes.
+- Use RED-first tests for every new behavior and run under Node 22.
+- Preserve unrelated files and the user's untracked screenshot in the original checkout.
+
+---
+
+### Task 1: Contact creation domain orchestration
+
+**Files:**
+- Create: `lib/server/contact-creation.ts`
+- Test: `lib/server/contact-creation.test.ts`
+
+**Interfaces:**
+- Produces: `CreateContactInput`, `ContactRecord`, `ContactCreationOutcome`, `ContactCreationAdapter`, `createVerifiedContact(input, adapter)`, and `retryVerifiedContactLink(input, adapter)`.
+- Consumes: no framework or HTTP types; this unit stays deterministic and adapter-driven.
+
+- [ ] **Step 1: Write failing tests for duplicate prevention and verified creation**
+
+```ts
+it('returns an existing verified contact for the same normalized name and account', async () => {
+  const adapter = fakeAdapter({ existing: contact({ name: 'Maya  Chen' }) });
+  const result = await createVerifiedContact(input({ name: ' maya chen ' }), adapter);
+  expect(result.status).toBe('existing_verified');
+  expect(adapter.createContact).not.toHaveBeenCalled();
+});
+
+it('creates and verifies a contact when the account has no normalized-name match', async () => {
+  const adapter = fakeAdapter({ existing: null, verify: true });
+  const result = await createVerifiedContact(input(), adapter);
+  expect(result.status).toBe('created_verified');
+  expect(adapter.createContact).toHaveBeenCalledTimes(1);
+  expect(adapter.ensureAccountContact).toHaveBeenCalledWith('account-page', 'contact-page');
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run lib/server/contact-creation.test.ts`
+
+Expected: FAIL because `contact-creation.ts` does not exist.
+
+- [ ] **Step 3: Implement the minimal typed orchestration**
+
+```ts
+export type ContactCreationOutcome =
+  | { status: 'created_verified' | 'existing_verified'; contact: ContactRecord; accountPageId: string }
+  | { status: 'partial_relation'; contact: ContactRecord; accountPageId: string; retry: { contactPageId: string; accountPageId: string } };
+
+export interface ContactCreationAdapter {
+  requireAccount(accountPageId: string): Promise<void>;
+  findContact(accountPageId: string, normalizedName: string): Promise<ContactRecord | null>;
+  createContact(input: CreateContactInput): Promise<ContactRecord>;
+  ensureAccountContact(accountPageId: string, contactPageId: string): Promise<void>;
+  verifyBothSides(accountPageId: string, contactPageId: string): Promise<boolean>;
+  refreshContacts(): Promise<void>;
+}
+```
+
+Normalize names with Unicode NFKC, trimmed lowercase text, and collapsed whitespace. Require the account first, find before create, append/verify idempotently, refresh only after verification, and return `partial_relation` after a contact exists but verification remains false or throws.
+
+- [ ] **Step 4: Add failing tests for account scoping, partial completion, and retry idempotency**
+
+```ts
+it('allows the same normalized name at a different account', async () => {
+  const adapter = fakeAdapter({ existing: null, verify: true });
+  const result = await createVerifiedContact(input({ accountPageId: 'second-account' }), adapter);
+  expect(result.status).toBe('created_verified');
+  expect(adapter.createContact).toHaveBeenCalledTimes(1);
+});
+
+it('returns partial_relation when the created contact cannot be verified', async () => {
+  const adapter = fakeAdapter({ existing: null, verify: false });
+  const result = await createVerifiedContact(input(), adapter);
+  expect(result).toMatchObject({ status: 'partial_relation', retry: { accountPageId: 'account-page', contactPageId: 'contact-page' } });
+});
+
+it('retries only relationship repair for an existing contact id', async () => {
+  const adapter = fakeAdapter({ verify: true });
+  const result = await retryVerifiedContactLink({ accountPageId: 'account-page', contactPageId: 'contact-page' }, adapter);
+  expect(result.status).toBe('existing_verified');
+  expect(adapter.createContact).not.toHaveBeenCalled();
+  expect(adapter.ensureAccountContact).toHaveBeenCalledTimes(1);
+});
+```
+
+- [ ] **Step 5: Run focused tests to GREEN and commit**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run lib/server/contact-creation.test.ts`
+
+Commit: `git commit -m "feat: orchestrate verified contact creation"`
+
+---
+
+### Task 2: Current Notion data-source adapter
+
+**Files:**
+- Create: `lib/server/notion-contact-creation.ts`
+- Test: `lib/server/notion-contact-creation.test.ts`
+- Modify: `lib/server/notion-live-crm.ts`
+
+**Interfaces:**
+- Produces: `notionContactCreationAdapter: ContactCreationAdapter` and `refreshLiveNotionContactsCache(): Promise<void>`.
+- Consumes: the Task 1 domain types and existing Notion environment boundaries.
+
+- [ ] **Step 1: Write failing adapter tests around current data-source endpoints**
+
+```ts
+it('resolves the database data source and paginates account-scoped contacts', async () => {
+  const result = await notionContactCreationAdapter.findContact('account-page', 'maya chen');
+  expect(result?.id).toBe('matching-contact');
+  expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+    'https://api.notion.com/v1/databases/contacts-db',
+    'https://api.notion.com/v1/data_sources/contacts-source/query',
+    'https://api.notion.com/v1/data_sources/contacts-source/query',
+  ]);
+  expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({ start_cursor: 'opaque-next-cursor' });
+  expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({ 'Notion-Version': '2026-03-11' });
+});
+
+it('creates a page beneath the resolved contacts data source', async () => {
+  await notionContactCreationAdapter.createContact(input());
+  const body = JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body));
+  expect(body.parent).toEqual({ type: 'data_source_id', data_source_id: 'contacts-source' });
+  expect(Object.keys(body.properties).sort()).toEqual([
+    'Contact Name', 'Contact Position', 'Dispensary', 'Email', 'Phone Number', 'Where Contact Info Came From',
+  ].sort());
+});
+```
+
+- [ ] **Step 2: Run the adapter test and confirm RED**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run lib/server/notion-contact-creation.test.ts`
+
+Expected: FAIL because the adapter module does not exist.
+
+- [ ] **Step 3: Implement the current-version request boundary**
+
+Implement a private `notionRequest<T>()` with:
+
+- `Notion-Version: 2026-03-11`;
+- `cache: 'no-store'`;
+- at most three bounded retries for 429 and 5xx;
+- `Retry-After` support when present;
+- sanitized thrown messages that include status/code but not authorization or full request payloads.
+
+Resolve database IDs to their first configured data-source ID through database retrieval, then query `/data_sources/{dataSourceId}/query` with `page_size: 100` and opaque cursor pagination.
+
+- [ ] **Step 4: Write failing relationship-preservation and verification tests**
+
+```ts
+it('appends the new contact without removing existing account contacts', async () => {
+  await notionContactCreationAdapter.ensureAccountContact('account-page', 'contact-c');
+  const body = JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body));
+  expect(body.properties['Associated Contacts'].relation).toEqual([
+    { id: 'contact-a' }, { id: 'contact-b' }, { id: 'contact-c' },
+  ]);
+});
+
+it('requires the contact and account pages to contain the relationship on fresh readback', async () => {
+  // Contact side true, account side false => false.
+});
+```
+
+- [ ] **Step 5: Implement account validation, dedupe reads, creation, append, and readback**
+
+Validate the account page belongs to the configured master data source and is not trashed. Read property values by a small ordered candidate map already consistent with the existing contact reader. Use the existing app contact-source classification. Never overwrite unrelated properties or replace the account's existing contact identifiers.
+
+- [ ] **Step 6: Expose a focused cache refresh and run tests to GREEN**
+
+Add `refreshLiveNotionContactsCache()` in `notion-live-crm.ts` as a narrow wrapper around the existing refresh path. The adapter calls it only after verified success.
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run lib/server/contact-creation.test.ts lib/server/notion-contact-creation.test.ts`
+
+Commit: `git commit -m "feat: add verified Notion contact adapter"`
+
+---
+
+### Task 3: Contact routes and validation
+
+**Files:**
+- Modify: `lib/validation/schemas.ts`
+- Modify: `app/api/contacts/route.ts`
+- Create: `app/api/contacts/retry-link/route.ts`
+- Create: `lib/server/contact-routes.test.ts`
+
+**Interfaces:**
+- Produces: browser contracts for `POST /api/contacts` and `POST /api/contacts/retry-link`.
+- Consumes: `createVerifiedContact`, `retryVerifiedContactLink`, and `notionContactCreationAdapter`.
+
+- [ ] **Step 1: Write route tests that fail before route changes**
+
+```ts
+it('maps created_verified to 201 and partial_relation to 202', async () => {
+  createVerifiedContact.mockResolvedValueOnce(createdOutcome()).mockResolvedValueOnce(partialOutcome());
+  expect((await POST(contactRequest(validPayload()))).status).toBe(201);
+  expect((await POST(contactRequest(validPayload()))).status).toBe(202);
+});
+
+it('rejects malformed page identifiers and invalid email with 400', async () => {
+  const response = await POST(contactRequest({ ...validPayload(), accountPageId: 'wrong', email: 'not-email' }));
+  expect(response.status).toBe(400);
+  expect(createVerifiedContact).not.toHaveBeenCalled();
+});
+
+it('returns the guard response before invoking the service', async () => {
+  guard.mockResolvedValueOnce({ error: new Response(null, { status: 403 }) });
+  expect((await POST(contactRequest(validPayload()))).status).toBe(403);
+  expect(createVerifiedContact).not.toHaveBeenCalled();
+});
+
+it('retry rejects mismatched identifiers and never accepts property payloads', async () => {
+  const response = await RETRY_POST(contactRequest({ ...validRetryPayload(), properties: { unsafe: true } }));
+  expect(response.status).toBe(400);
+  expect(retryVerifiedContactLink).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run route tests and confirm RED**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run lib/server/contact-routes.test.ts`
+
+- [ ] **Step 3: Add the exact schemas and route mappings**
+
+Create schemas for:
+
+```ts
+{ accountPageId, name, position, email?: string | null, phone?: string | null }
+{ accountPageId, contactPageId }
+```
+
+Accept hyphenated or compact UUID page identifiers, trim text, convert blank optional values to null, cap lengths, and keep the existing allowed write roles. Return 201/200/202 according to the typed outcome. Preserve the existing generic error envelope and map missing/foreign account errors to 404.
+
+- [ ] **Step 4: Run route tests to GREEN and commit**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run lib/server/contact-routes.test.ts lib/server/contact-creation.test.ts lib/server/notion-contact-creation.test.ts`
+
+Commit: `git commit -m "feat: expose verified contact routes"`
+
+---
+
+### Task 4: Reusable browser contact flow
+
+**Files:**
+- Create: `components/crm/contact-create-model.ts`
+- Test: `components/crm/contact-create-model.test.ts`
+- Create: `components/crm/contact-create-flow.tsx`
+- Modify: `app/(main)/contacts/page.tsx`
+- Modify: `components/crm/contacts-table.tsx`
+
+**Interfaces:**
+- Produces: `ContactCreateFlow`, `filterContactAccounts()`, `validateContactDraft()`, and `buildContactCreateHref()`.
+- Consumes: `RuntimeAccountSummary[]`, the Task 3 routes, and router query parameters `new=1` and optional `accountPageId`.
+
+- [ ] **Step 1: Write failing pure-model tests**
+
+```ts
+it('filters accounts by name, city, and license without case sensitivity', () => {
+  expect(filterContactAccounts(accounts, 'brooklyn').map((account) => account.name)).toEqual(['Juniper House']);
+  expect(filterContactAccounts(accounts, 'OCM-CAURD-24-000321').map((account) => account.name)).toEqual(['North Fork Cannabis']);
+});
+
+it('requires account, name, and position and validates a present email', () => {
+  expect(validateContactDraft({ accountPageId: '', name: '', position: '', email: 'wrong', phone: '' })).toEqual({
+    accountPageId: 'Choose an account.',
+    name: 'Enter the contact name.',
+    position: 'Enter the contact position.',
+    email: 'Enter a valid email address.',
+  });
+});
+
+it('builds a quick-create URL without leaking unrelated query parameters', () => {
+  expect(buildContactCreateHref('account-page')).toBe('/contacts?new=1&accountPageId=account-page');
+  expect(buildContactCreateHref()).toBe('/contacts?new=1');
+});
+```
+
+- [ ] **Step 2: Run model tests and confirm RED**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run components/crm/contact-create-model.test.ts`
+
+- [ ] **Step 3: Implement the pure model and reusable flow**
+
+The flow renders inline at the top of Contacts when `new=1`. On mobile it occupies the usable viewport above the persistent menu; on desktop it becomes a two-column form/account-search surface. Implement:
+
+- searchable account results with keyboard-accessible buttons;
+- account lock when `accountPageId` is supplied and found;
+- labeled fields with adjacent errors;
+- loading, empty search, submitting, duplicate, verified, partial, and failure states;
+- retry by calling `/api/contacts/retry-link` with server-returned identifiers only;
+- cancel by removing only the creation query parameters;
+- `router.refresh()` after verified results;
+- focus movement to the result heading and an `aria-live="polite"` status region.
+
+- [ ] **Step 4: Add visible entry points on Contacts**
+
+Add an Add contact button beside the Contacts heading and a toolbar action in `ContactsTable`. Both use `buildContactCreateHref()`. Remove or replace unsupported toolbar copy only where necessary for this flow; do not broaden into table redesign.
+
+- [ ] **Step 5: Run model and existing tests to GREEN and commit**
+
+Run: `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run components/crm/contact-create-model.test.ts && PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test`
+
+Commit: `git commit -m "feat: add mobile-first contact form"`
+
+---
+
+### Task 5: Persistent navigation and account entry point
+
+**Files:**
+- Modify: `components/layout/app-shell.tsx`
+- Create: `components/crm/accounts-section-tabs.tsx`
+- Modify: `app/(main)/accounts/page.tsx`
+- Modify: `app/(main)/contacts/page.tsx`
+- Modify: `components/mobile/account-detail-sheet.tsx`
+- Modify: `tests/e2e/smoke.spec.ts`
+
+**Interfaces:**
+- Consumes: `buildContactCreateHref()` and the account page identifier already present on `TerritoryStorePin`.
+- Produces: persistent Home, Map, Accounts, Route, Dashboard navigation; shared Accounts/Contacts section tabs; Profile/tools Home link; global Add contact/Add task links; account-detail Add contact link.
+
+- [ ] **Step 1: Add failing browser assertions for exact navigation**
+
+```ts
+await expect(page.getByRole('navigation', { name: 'Primary navigation' }).getByText('Contacts')).toHaveCount(0);
+await expect(page.getByRole('navigation', { name: 'Primary navigation' }).getByText('Dashboard')).toBeVisible();
+await expect(page.getByRole('navigation', { name: 'Primary navigation' }).getByText('Home')).toBeVisible();
+await page.getByRole('link', { name: 'Accounts' }).click();
+await expect(page.getByRole('navigation', { name: 'Account directory' }).getByRole('link', { name: 'Contacts' })).toBeVisible();
+await page.getByText('Profile').click();
+await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+```
+
+- [ ] **Step 2: Implement the Accounts/Contacts section tabs and Profile/tools link**
+
+Keep the existing five equal-width persistent tabs. Add Home to Profile/tools and a compact header quick-action details menu with Add contact and Add task. Create `AccountsSectionTabs` with accessible `aria-label="Account directory"` navigation and links to Accounts and Contacts. Render it near the top of both pages. Extend the Accounts persistent-tab matching so it remains active on `/contacts` without changing the link destination.
+
+- [ ] **Step 3: Resolve PR #135 overlap before editing account detail**
+
+Recheck PR #135 status and changed paths. If it remains stale/conflicting, release its stale path claim according to repo policy with a public-safe comment before this branch edits `account-detail-sheet.tsx`. Add an Add contact action next to Associated Contacts that links to the reusable form with the active account preselected. Do not import the form into the already-large sheet.
+
+- [ ] **Step 4: Run focused browser navigation checks and commit**
+
+Run the targeted Playwright tests under the agent dev environment, then:
+
+Commit: `git commit -m "feat: add contacts tab to accounts"`
+
+---
+
+### Task 6: Browser states, screenshots, and full verification
+
+**Files:**
+- Create or modify: `tests/e2e/contact-create.spec.ts`
+- Create: `.agents/issue-155-contacts-mobile.png`
+- Create: `.agents/issue-155-contacts-desktop.png`
+- Modify: `SESSION.md` only if validation evidence or owned paths changed.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: repeatable user-visible proof without a production CRM write.
+
+- [ ] **Step 1: Add a Playwright contact flow using network interception**
+
+Intercept the runtime account endpoint with one realistic account and intercept contact POST responses for verified, duplicate, partial, retry, and error cases. Do not add mock application data paths to production code. Test normal user input, cancel, field validation, focus behavior, and response states.
+
+- [ ] **Step 2: Run the QA inventory on desktop and 390x844 mobile**
+
+Cover:
+
+- persistent navigation, Accounts/Contacts section tabs, and Profile Home;
+- Contacts page Add contact;
+- account search and selection;
+- locked account query state;
+- validation, duplicate, verified, partial/retry, and hard error;
+- no horizontal overflow or controls behind bottom navigation;
+- keyboard reachability and visible focus;
+- exploratory double-submit protection;
+- exploratory retry after a simulated timeout.
+
+- [ ] **Step 3: Capture screenshots and a short interaction recording**
+
+Capture final desktop and mobile form/result states under `.agents/`. The recording must show opening Contacts, creating through intercepted routes, and reaching verified success. Label all proof as local/intercepted, not production.
+
+- [ ] **Step 4: Run fresh complete verification**
+
+Run:
+
+```bash
+PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run verify
+PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run test:e2e
+```
+
+Expected: both commands exit 0. Record exact test counts, build result, and any existing audit warnings separately.
+
+- [ ] **Step 5: Self-review and update the draft PR**
+
+Review the complete diff for private data, unrelated edits, accidental local files, path overlap, accessibility, and honest integration claims. Update the PR with commands, screenshots, local/intercepted proof, remaining production-write boundary, and rollback risk.
+
+Commit: `git commit -m "test: verify contact creation in the browser"`

--- a/docs/superpowers/specs/2026-08-12-contact-creation-design.md
+++ b/docs/superpowers/specs/2026-08-12-contact-creation-design.md
@@ -12,7 +12,7 @@ This slice changes contact creation and navigation only. Task creation, general 
 
 ### Navigation
 
-The persistent five-item navigation becomes Home, Map, Accounts, Contacts, and Route. Contacts is reachable in one tap on mobile and desktop. Dashboard remains available from the Profile/tools menu so the field workflow stays compact without losing access.
+The persistent five-item navigation becomes Map, Accounts, Contacts, Route, and Dashboard. Contacts and Dashboard are each reachable in one tap on mobile and desktop. Home moves into the Profile/tools menu and remains directly accessible there.
 
 The app shell also exposes a compact quick-action control containing Add contact and Add task. Add task can continue routing to its existing quick-create URL until issue #36 supplies its form.
 
@@ -131,7 +131,8 @@ The account-detail sheet only supplies the account identifier and opens the reus
 
 ### Browser tests
 
-- Contacts is reachable in one tap from primary navigation;
+- Contacts and Dashboard are reachable in one tap from primary navigation;
+- Home is reachable from the Profile/tools menu;
 - Add contact opens from Contacts and account detail;
 - account detail locks the correct account;
 - required-field and email errors are visible and accessible;

--- a/docs/superpowers/specs/2026-08-12-contact-creation-design.md
+++ b/docs/superpowers/specs/2026-08-12-contact-creation-design.md
@@ -1,0 +1,146 @@
+# Verified Contact Creation Design
+
+## Objective
+
+Make Contacts a first-class field workflow and let an authorized user add a contact without leaving the PICC app. A successful result means the contact exists in the connected CRM, belongs to the selected account, appears in the account's related-contact collection, and has been verified through a fresh server read.
+
+## Product Boundary
+
+This slice changes contact creation and navigation only. Task creation, general mobile performance work, and stale engineering cleanup remain separate issues and pull requests. It does not change the external CRM schema, bulk-import contacts, repair historical relationships, or perform a production backfill.
+
+## User Experience
+
+### Navigation
+
+The persistent five-item navigation becomes Home, Map, Accounts, Contacts, and Route. Contacts is reachable in one tap on mobile and desktop. Dashboard remains available from the Profile/tools menu so the field workflow stays compact without losing access.
+
+The app shell also exposes a compact quick-action control containing Add contact and Add task. Add task can continue routing to its existing quick-create URL until issue #36 supplies its form.
+
+### Entry points
+
+The same reusable creation experience opens from:
+
+- the Contacts page through a visible Add contact button;
+- the quick-create URL;
+- an account-detail sheet, with that account preselected and locked;
+- the global quick-action control.
+
+On mobile it uses a focused full-height workflow above the persistent navigation. On wider screens it uses a constrained side panel. Both render the same form component and state model.
+
+### Form
+
+The form contains:
+
+- Account, required and searchable unless preselected by account detail;
+- Contact name, required;
+- Position, required;
+- Email, optional but validated when present;
+- Phone, optional;
+- Save and Cancel actions.
+
+Labels remain above fields. Save is disabled only while submitting or when required client validation fails. Server validation remains authoritative. The form does not expose internal integration property names.
+
+### States
+
+- Loading: account search and submission use layout-matched skeleton or inline progress states.
+- Empty: account search explains how to broaden the query.
+- Validation: field-specific messages remain adjacent to their inputs.
+- Duplicate: show the existing contact and offer View contact; do not create a second record.
+- Verified success: show the contact name and linked account, then refresh the contact directory and account detail.
+- Partial completion: explain that the contact exists but the account relationship could not be fully verified; provide Retry link and View contact. Never label this state successful.
+- Failure: preserve entered values and provide a retry action with a safe, human-readable message.
+
+## Server Architecture
+
+### Boundary
+
+A focused contact-creation service owns all external CRM operations. UI components and the route handler do not construct external property payloads.
+
+The service accepts a normalized request containing the selected account page identifier, contact name, position, email, and phone. It returns one of four explicit outcomes:
+
+- `created_verified`;
+- `existing_verified`;
+- `partial_relation`;
+- `failed` through a typed error.
+
+### Idempotent workflow
+
+1. Validate the authenticated user's write role.
+2. Resolve and freshly read the selected account through the configured CRM boundary.
+3. Query contacts scoped to the exact account and compare normalized names.
+4. If a matching contact exists, verify the account relationship and return `existing_verified` or repair only the missing relationship through the same retry-safe path.
+5. If no match exists, create the contact with its account relationship and the existing app-appropriate source classification.
+6. Freshly read the account's related-contact collection, append the new identifier without removing existing identifiers, and update only when missing.
+7. Freshly read both records and require the relationship to be present from both directions.
+8. Invalidate or refresh the app's contact snapshot only after the verified outcome.
+
+The external system does not provide a cross-record transaction. Every step is therefore idempotent. Retrying after a timeout or partial update must find the existing account-scoped contact before attempting creation.
+
+### Partial completion
+
+If contact creation succeeds but the account-side relationship or final readback fails, return `partial_relation` with the existing contact identifier and a retry token derived from stable record identifiers. The retry endpoint repeats relationship verification and append behavior without creating a new contact.
+
+Logs and activity records contain stable internal identifiers and outcome codes, never tokens, full external payloads, or sensitive contact values.
+
+## API Contract
+
+`POST /api/contacts` accepts the browser form payload and returns HTTP 201 for `created_verified`, HTTP 200 for `existing_verified`, and HTTP 202 for `partial_relation`. Invalid input is HTTP 400, missing/foreign accounts are HTTP 404, and unauthorized roles remain HTTP 403.
+
+The route preserves the existing generic error envelope. The response includes only the display fields and identifiers needed by the UI.
+
+`POST /api/contacts/retry-link` accepts the partial outcome identifiers and returns `created_verified` or `existing_verified` after fresh verification. It never accepts arbitrary external property payloads from the client.
+
+## Component Boundaries
+
+- `ContactCreateFlow`: owns query-string visibility, form state, outcome rendering, cancel behavior, and router refresh.
+- `ContactForm`: renders accessible fields and client validation; it knows nothing about external CRM payloads.
+- `AccountContactPicker`: searches the existing account runtime with keyboard and touch support.
+- `contact-create-service`: performs dedupe, create, relationship append, readback, and cache invalidation.
+- route handlers: authenticate, parse, call the service, and map typed outcomes to HTTP.
+
+The account-detail sheet only supplies the account identifier and opens the reusable flow. It does not duplicate form or write logic.
+
+## Accessibility And Mobile Behavior
+
+- Meet WCAG 2.1 AA contrast and focus visibility using the existing design system.
+- All controls have accessible labels, 44px minimum mobile touch targets, logical tab order, and focus restoration on close.
+- Validation and result messages use an appropriate live region without moving focus unexpectedly.
+- The mobile workflow fits a 390x844 viewport, respects safe areas, and never sits behind the bottom navigation.
+- Motion is limited to 150-240ms state transitions and honors reduced-motion preferences.
+
+## Testing
+
+### Unit and service tests
+
+- account-scoped normalized-name duplicate returns the existing contact;
+- the same name at a different account can be created;
+- create payload contains only supported contact fields;
+- account relationship append preserves existing contact identifiers;
+- verified success requires fresh two-sided readback;
+- partial completion returns the existing contact identifier;
+- retry is idempotent and never creates a second contact;
+- external rate-limit and transient failures use bounded retry behavior;
+- secrets and raw payloads do not enter logs.
+
+### Route tests
+
+- role enforcement;
+- valid created, existing, and partial status mappings;
+- malformed input, missing account, and foreign account responses;
+- retry endpoint rejects arbitrary or mismatched identifiers.
+
+### Browser tests
+
+- Contacts is reachable in one tap from primary navigation;
+- Add contact opens from Contacts and account detail;
+- account detail locks the correct account;
+- required-field and email errors are visible and accessible;
+- duplicate, verified success, partial, and retry states render correctly;
+- cancel returns to the prior surface without data loss elsewhere;
+- desktop and 390x844 mobile layouts have no clipped controls or horizontal overflow.
+
+Browser tests intercept external writes or use a local adapter. They do not create production contacts.
+
+## Delivery And Proof
+
+The pull request must link issue #155, list overlapping pull requests reviewed, and remain scoped to owned paths. Required proof is a clean repository verification run, focused browser tests, before/after navigation screenshots, form screenshots on mobile and desktop, and a short interaction recording. Production behavior may be claimed only after an explicitly approved real write followed by live readback; local and intercepted-browser verification must be labeled as such.

--- a/docs/superpowers/specs/2026-08-12-contact-creation-design.md
+++ b/docs/superpowers/specs/2026-08-12-contact-creation-design.md
@@ -12,7 +12,7 @@ This slice changes contact creation and navigation only. Task creation, general 
 
 ### Navigation
 
-The persistent five-item navigation becomes Map, Accounts, Contacts, Route, and Dashboard. Contacts and Dashboard are each reachable in one tap on mobile and desktop. Home moves into the Profile/tools menu and remains directly accessible there.
+The persistent five-item navigation remains Home, Map, Accounts, Route, and Dashboard. Home is also available from the Profile/tools menu. The Accounts section gains a clear two-tab switcher for Accounts and Contacts; the persistent Accounts destination remains active while either tab is open.
 
 The app shell also exposes a compact quick-action control containing Add contact and Add task. Add task can continue routing to its existing quick-create URL until issue #36 supplies its form.
 
@@ -131,8 +131,9 @@ The account-detail sheet only supplies the account identifier and opens the reus
 
 ### Browser tests
 
-- Contacts and Dashboard are reachable in one tap from primary navigation;
-- Home is reachable from the Profile/tools menu;
+- Dashboard remains reachable in one tap from primary navigation;
+- Contacts is reachable from the Accounts section tab switcher;
+- Home remains persistent and is also reachable from the Profile/tools menu;
 - Add contact opens from Contacts and account detail;
 - account detail locks the correct account;
 - required-field and email errors are visible and accessible;

--- a/lib/contacts/contact-create-model.test.ts
+++ b/lib/contacts/contact-create-model.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildContactCreatePayload,
+  contactCreateMessage,
+  filterContactAccounts,
+} from '@/lib/contacts/contact-create-model';
+
+const accounts = [
+  { notionPageId: 'a', name: 'Gotham Buds', city: 'New York', state: 'NY' },
+  { notionPageId: 'b', name: 'Alta Dispensary', city: 'Astoria', state: 'NY' },
+];
+
+describe('contact create UI model', () => {
+  it('finds accounts by name and location without changing source order', () => {
+    expect(filterContactAccounts(accounts, 'astoria').map((account) => account.notionPageId)).toEqual(['b']);
+    expect(filterContactAccounts(accounts, '')).toEqual(accounts);
+  });
+
+  it('trims required fields and converts blank optional fields to null', () => {
+    expect(
+      buildContactCreatePayload({
+        accountPageId: ' account-id ',
+        name: ' Maya Chen ',
+        position: ' Buyer ',
+        email: ' ',
+        phone: ' 212-555-0187 ',
+      }),
+    ).toEqual({
+      accountPageId: 'account-id',
+      name: 'Maya Chen',
+      position: 'Buyer',
+      email: null,
+      phone: '212-555-0187',
+    });
+  });
+
+  it('uses honest confirmation copy for verified, duplicate, and partial outcomes', () => {
+    expect(contactCreateMessage('created_verified')).toContain('created and linked');
+    expect(contactCreateMessage('existing_verified')).toContain('already existed');
+    expect(contactCreateMessage('partial_relation')).toContain('could not verify');
+  });
+});

--- a/lib/contacts/contact-create-model.ts
+++ b/lib/contacts/contact-create-model.ts
@@ -1,0 +1,49 @@
+export type ContactAccountOption = {
+  notionPageId: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+};
+
+export type ContactCreateDraft = {
+  accountPageId: string;
+  name: string;
+  position: string;
+  email: string;
+  phone: string;
+};
+
+export type ContactCreateStatus = 'created_verified' | 'existing_verified' | 'partial_relation';
+
+export function filterContactAccounts<T extends ContactAccountOption>(accounts: T[], query: string) {
+  const normalized = query.trim().toLocaleLowerCase('en-US');
+  if (!normalized) return accounts;
+  return accounts.filter((account) =>
+    [account.name, account.city, account.state]
+      .filter(Boolean)
+      .join(' ')
+      .toLocaleLowerCase('en-US')
+      .includes(normalized),
+  );
+}
+
+export function buildContactCreatePayload(draft: ContactCreateDraft) {
+  const optional = (value: string) => value.trim() || null;
+  return {
+    accountPageId: draft.accountPageId.trim(),
+    name: draft.name.trim(),
+    position: draft.position.trim(),
+    email: optional(draft.email),
+    phone: optional(draft.phone),
+  };
+}
+
+export function contactCreateMessage(status: ContactCreateStatus) {
+  if (status === 'created_verified') {
+    return 'Contact created and linked to the account in Notion.';
+  }
+  if (status === 'existing_verified') {
+    return 'This contact already existed. Its account link is verified.';
+  }
+  return 'The contact was saved, but we could not verify both relationship links yet.';
+}

--- a/lib/server/contact-creation.test.ts
+++ b/lib/server/contact-creation.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createVerifiedContact,
+  retryVerifiedContactLink,
+  type ContactCreationAdapter,
+  type ContactRecord,
+  type CreateContactInput,
+} from '@/lib/server/contact-creation';
+
+function contact(overrides: Partial<ContactRecord> = {}): ContactRecord {
+  return {
+    id: 'contact-page',
+    name: 'Maya Chen',
+    position: 'Buyer',
+    email: 'maya@example.com',
+    phone: '212-555-0187',
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<CreateContactInput> = {}): CreateContactInput {
+  return {
+    accountPageId: 'account-page',
+    name: 'Maya Chen',
+    position: 'Buyer',
+    email: 'maya@example.com',
+    phone: '212-555-0187',
+    ...overrides,
+  };
+}
+
+function fakeAdapter(options: {
+  existing?: ContactRecord | null;
+  verify?: boolean;
+  ensureError?: Error;
+} = {}) {
+  const created = contact();
+  const adapter = {
+    requireAccount: vi.fn().mockResolvedValue(undefined),
+    findContact: vi.fn().mockResolvedValue(options.existing ?? null),
+    getContact: vi.fn().mockResolvedValue(created),
+    createContact: vi.fn().mockResolvedValue(created),
+    ensureAccountContact: options.ensureError
+      ? vi.fn().mockRejectedValue(options.ensureError)
+      : vi.fn().mockResolvedValue(undefined),
+    verifyBothSides: vi.fn().mockResolvedValue(options.verify ?? true),
+    refreshContacts: vi.fn().mockResolvedValue(undefined),
+  } satisfies ContactCreationAdapter;
+
+  return adapter;
+}
+
+describe('verified contact creation', () => {
+  it('returns an existing verified contact for the same normalized name and account', async () => {
+    const existing = contact({ name: 'Maya  Chen' });
+    const adapter = fakeAdapter({ existing });
+
+    const result = await createVerifiedContact(input({ name: '  MAYA chen  ' }), adapter);
+
+    expect(result).toEqual({
+      status: 'existing_verified',
+      contact: existing,
+      accountPageId: 'account-page',
+    });
+    expect(adapter.findContact).toHaveBeenCalledWith('account-page', 'maya chen');
+    expect(adapter.createContact).not.toHaveBeenCalled();
+    expect(adapter.ensureAccountContact).toHaveBeenCalledWith('account-page', 'contact-page');
+    expect(adapter.refreshContacts).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates and verifies a contact when the account has no normalized-name match', async () => {
+    const adapter = fakeAdapter({ existing: null });
+
+    const result = await createVerifiedContact(input(), adapter);
+
+    expect(result.status).toBe('created_verified');
+    expect(adapter.requireAccount).toHaveBeenCalledWith('account-page');
+    expect(adapter.createContact).toHaveBeenCalledWith(input());
+    expect(adapter.ensureAccountContact).toHaveBeenCalledWith('account-page', 'contact-page');
+    expect(adapter.verifyBothSides).toHaveBeenCalledWith('account-page', 'contact-page');
+    expect(adapter.refreshContacts).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the same normalized name at a different account', async () => {
+    const adapter = fakeAdapter({ existing: null });
+
+    const result = await createVerifiedContact(input({ accountPageId: 'second-account' }), adapter);
+
+    expect(result.status).toBe('created_verified');
+    expect(adapter.findContact).toHaveBeenCalledWith('second-account', 'maya chen');
+    expect(adapter.createContact).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns partial_relation when a created contact cannot be verified', async () => {
+    const adapter = fakeAdapter({ existing: null, verify: false });
+
+    const result = await createVerifiedContact(input(), adapter);
+
+    expect(result).toEqual({
+      status: 'partial_relation',
+      contact: contact(),
+      accountPageId: 'account-page',
+      retry: {
+        accountPageId: 'account-page',
+        contactPageId: 'contact-page',
+      },
+    });
+    expect(adapter.refreshContacts).not.toHaveBeenCalled();
+  });
+
+  it('returns partial_relation when relation append fails after contact creation', async () => {
+    const adapter = fakeAdapter({ existing: null, ensureError: new Error('temporary integration failure') });
+
+    const result = await createVerifiedContact(input(), adapter);
+
+    expect(result.status).toBe('partial_relation');
+    expect(adapter.createContact).toHaveBeenCalledTimes(1);
+    expect(adapter.refreshContacts).not.toHaveBeenCalled();
+  });
+
+  it('retries relationship repair without creating another contact', async () => {
+    const adapter = fakeAdapter({ verify: true });
+
+    const result = await retryVerifiedContactLink(
+      { accountPageId: 'account-page', contactPageId: 'contact-page' },
+      adapter,
+    );
+
+    expect(result.status).toBe('existing_verified');
+    expect(adapter.requireAccount).toHaveBeenCalledWith('account-page');
+    expect(adapter.getContact).toHaveBeenCalledWith('contact-page');
+    expect(adapter.createContact).not.toHaveBeenCalled();
+    expect(adapter.ensureAccountContact).toHaveBeenCalledTimes(1);
+    expect(adapter.refreshContacts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/server/contact-creation.ts
+++ b/lib/server/contact-creation.ts
@@ -1,0 +1,116 @@
+export type CreateContactInput = {
+  accountPageId: string;
+  name: string;
+  position: string;
+  email: string | null;
+  phone: string | null;
+};
+
+export type ContactRecord = {
+  id: string;
+  name: string;
+  position: string;
+  email: string | null;
+  phone: string | null;
+};
+
+export type ContactCreationOutcome =
+  | {
+      status: 'created_verified' | 'existing_verified';
+      contact: ContactRecord;
+      accountPageId: string;
+    }
+  | {
+      status: 'partial_relation';
+      contact: ContactRecord;
+      accountPageId: string;
+      retry: {
+        accountPageId: string;
+        contactPageId: string;
+      };
+    };
+
+export type RetryContactLinkInput = {
+  accountPageId: string;
+  contactPageId: string;
+};
+
+export interface ContactCreationAdapter {
+  requireAccount(accountPageId: string): Promise<void>;
+  findContact(accountPageId: string, normalizedName: string): Promise<ContactRecord | null>;
+  getContact(contactPageId: string): Promise<ContactRecord>;
+  createContact(input: CreateContactInput): Promise<ContactRecord>;
+  ensureAccountContact(accountPageId: string, contactPageId: string): Promise<void>;
+  verifyBothSides(accountPageId: string, contactPageId: string): Promise<boolean>;
+  refreshContacts(): Promise<void>;
+}
+
+export function normalizeContactName(value: string) {
+  return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase('en-US');
+}
+
+function partialOutcome(
+  accountPageId: string,
+  contact: ContactRecord,
+): ContactCreationOutcome {
+  return {
+    status: 'partial_relation',
+    contact,
+    accountPageId,
+    retry: {
+      accountPageId,
+      contactPageId: contact.id,
+    },
+  };
+}
+
+async function finishRelationship(
+  accountPageId: string,
+  contact: ContactRecord,
+  adapter: ContactCreationAdapter,
+  verifiedStatus: 'created_verified' | 'existing_verified',
+): Promise<ContactCreationOutcome> {
+  try {
+    await adapter.ensureAccountContact(accountPageId, contact.id);
+    const verified = await adapter.verifyBothSides(accountPageId, contact.id);
+    if (!verified) {
+      return partialOutcome(accountPageId, contact);
+    }
+
+    await adapter.refreshContacts().catch(() => undefined);
+    return {
+      status: verifiedStatus,
+      contact,
+      accountPageId,
+    };
+  } catch {
+    return partialOutcome(accountPageId, contact);
+  }
+}
+
+export async function createVerifiedContact(
+  input: CreateContactInput,
+  adapter: ContactCreationAdapter,
+): Promise<ContactCreationOutcome> {
+  await adapter.requireAccount(input.accountPageId);
+
+  const existing = await adapter.findContact(
+    input.accountPageId,
+    normalizeContactName(input.name),
+  );
+  if (existing) {
+    return finishRelationship(input.accountPageId, existing, adapter, 'existing_verified');
+  }
+
+  const created = await adapter.createContact(input);
+  return finishRelationship(input.accountPageId, created, adapter, 'created_verified');
+}
+
+export async function retryVerifiedContactLink(
+  input: RetryContactLinkInput,
+  adapter: ContactCreationAdapter,
+): Promise<ContactCreationOutcome> {
+  await adapter.requireAccount(input.accountPageId);
+  const contact = await adapter.getContact(input.contactPageId);
+  return finishRelationship(input.accountPageId, contact, adapter, 'existing_verified');
+}

--- a/lib/server/contact-routes.test.ts
+++ b/lib/server/contact-routes.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const accountPageId = '11111111-1111-4111-8111-111111111111';
+const contactPageId = '22222222-2222-4222-8222-222222222222';
+
+const verified = {
+  status: 'created_verified' as const,
+  accountPageId,
+  contact: {
+    id: contactPageId,
+    name: 'Maya Chen',
+    position: 'Buyer',
+    email: 'maya@example.com',
+    phone: null,
+  },
+};
+
+function request(path: string, body: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockDependencies(input?: {
+  guardResult?: unknown;
+  createResult?: unknown;
+  retryResult?: unknown;
+}) {
+  vi.doMock('@/lib/auth/api-guard', () => ({
+    guard: vi.fn().mockResolvedValue(input?.guardResult ?? { orgId: 'org', userId: 'user' }),
+  }));
+  vi.doMock('@/lib/server/notion-contact-creation', () => ({
+    createNotionContactCreationAdapter: vi.fn(() => ({ boundary: 'notion' })),
+  }));
+  vi.doMock('@/lib/server/contact-creation', () => ({
+    createVerifiedContact: vi.fn().mockResolvedValue(input?.createResult ?? verified),
+    retryVerifiedContactLink: vi.fn().mockResolvedValue(
+      input?.retryResult ?? { ...verified, status: 'existing_verified' },
+    ),
+  }));
+}
+
+describe('contact write routes', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates and verifies a Notion contact for an authorized user', async () => {
+    await mockDependencies();
+    const { POST } = await import('@/app/api/contacts/route');
+
+    const response = (await POST(
+      request('/api/contacts', {
+        accountPageId,
+        name: 'Maya Chen',
+        position: 'Buyer',
+        email: 'maya@example.com',
+        phone: null,
+      }),
+    )) as Response;
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual(verified);
+  });
+
+  it('returns accepted with retry context when only one relation side is confirmed', async () => {
+    const partial = {
+      ...verified,
+      status: 'partial_relation' as const,
+      retry: { accountPageId, contactPageId },
+    };
+    await mockDependencies({ createResult: partial });
+    const { POST } = await import('@/app/api/contacts/route');
+
+    const response = (await POST(
+      request('/api/contacts', {
+        accountPageId,
+        name: 'Maya Chen',
+        position: 'Buyer',
+        email: null,
+        phone: null,
+      }),
+    )) as Response;
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual(partial);
+  });
+
+  it('rejects malformed contact payloads before calling the external boundary', async () => {
+    await mockDependencies();
+    const domain = await import('@/lib/server/contact-creation');
+    const { POST } = await import('@/app/api/contacts/route');
+
+    const response = (await POST(request('/api/contacts', { accountPageId, name: '' }))) as Response;
+
+    expect(response.status).toBe(400);
+    expect(vi.mocked(domain.createVerifiedContact)).not.toHaveBeenCalled();
+  });
+
+  it('returns the auth guard response without attempting creation', async () => {
+    await mockDependencies({
+      guardResult: { error: Response.json({ error: 'Forbidden' }, { status: 403 }) },
+    });
+    const domain = await import('@/lib/server/contact-creation');
+    const { POST } = await import('@/app/api/contacts/route');
+
+    const response = (await POST(request('/api/contacts', {}))) as Response;
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(domain.createVerifiedContact)).not.toHaveBeenCalled();
+  });
+
+  it('retries a partial relationship without creating another contact', async () => {
+    await mockDependencies();
+    const domain = await import('@/lib/server/contact-creation');
+    const { POST } = await import('@/app/api/contacts/retry/route');
+
+    const response = (await POST(
+      request('/api/contacts/retry', { accountPageId, contactPageId }),
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(domain.retryVerifiedContactLink)).toHaveBeenCalledWith(
+      { accountPageId, contactPageId },
+      { boundary: 'notion' },
+    );
+  });
+});

--- a/lib/server/notion-contact-creation.test.ts
+++ b/lib/server/notion-contact-creation.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CreateContactInput } from '@/lib/server/contact-creation';
+import { createNotionContactCreationAdapter } from '@/lib/server/notion-contact-creation';
+
+const originalEnv = process.env;
+
+function jsonResponse(payload: unknown, status = 200, headers?: HeadersInit) {
+  return Promise.resolve(
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: {
+        'content-type': 'application/json',
+        ...headers,
+      },
+    }),
+  );
+}
+
+function createInput(): CreateContactInput {
+  return {
+    accountPageId: '11111111-1111-4111-8111-111111111111',
+    name: 'Maya Chen',
+    position: 'Buyer',
+    email: 'maya@example.com',
+    phone: '212-555-0187',
+  };
+}
+
+function contactPage(id: string, accountId = createInput().accountPageId) {
+  return {
+    object: 'page',
+    id,
+    in_trash: false,
+    parent: { type: 'data_source_id', data_source_id: 'contacts-source' },
+    properties: {
+      'Contact Name': { type: 'title', title: [{ plain_text: 'Maya Chen' }] },
+      'Contact Position': { type: 'rich_text', rich_text: [{ plain_text: 'Buyer' }] },
+      Email: { type: 'email', email: 'maya@example.com' },
+      'Phone Number': { type: 'phone_number', phone_number: '212-555-0187' },
+      Dispensary: { type: 'relation', relation: [{ id: accountId }] },
+    },
+  };
+}
+
+describe('Notion contact creation adapter', () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NOTION_API_KEY: 'test-notion-key',
+      NOTION_CONTACTS_DATABASE_ID: 'contacts-db',
+      NOTION_MASTER_LIST_DATABASE_ID: 'accounts-db',
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('resolves the contacts data source and paginates account-scoped contacts', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ data_sources: [{ id: 'contacts-source' }] }))
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          results: [contactPage('nonmatching-contact', 'different-account')],
+          has_more: true,
+          next_cursor: 'opaque-next-cursor',
+        }),
+      )
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          results: [contactPage('matching-contact')],
+          has_more: false,
+          next_cursor: null,
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    const result = await adapter.findContact(createInput().accountPageId, 'maya chen');
+
+    expect(result?.id).toBe('matching-contact');
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://api.notion.com/v1/databases/contacts-db',
+      'https://api.notion.com/v1/data_sources/contacts-source/query',
+      'https://api.notion.com/v1/data_sources/contacts-source/query',
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      start_cursor: 'opaque-next-cursor',
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({
+      'Notion-Version': '2026-03-11',
+    });
+  });
+
+  it('creates a page beneath the resolved contacts data source with supported fields', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ data_sources: [{ id: 'contacts-source' }] }))
+      .mockImplementationOnce(() => jsonResponse(contactPage('created-contact')));
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    const result = await adapter.createContact(createInput());
+
+    expect(result.id).toBe('created-contact');
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.parent).toEqual({ type: 'data_source_id', data_source_id: 'contacts-source' });
+    expect(Object.keys(body.properties).sort()).toEqual(
+      [
+        'Contact Name',
+        'Contact Position',
+        'Dispensary',
+        'Email',
+        'Phone Number',
+        'Where Contact Info Came From',
+      ].sort(),
+    );
+  });
+
+  it('appends the new contact without removing existing account contacts', async () => {
+    const accountId = createInput().accountPageId;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          id: accountId,
+          in_trash: false,
+          properties: {
+            'Associated Contacts': {
+              type: 'relation',
+              relation: [{ id: 'contact-a' }, { id: 'contact-b' }],
+            },
+          },
+        }),
+      )
+      .mockImplementationOnce(() => jsonResponse({ id: accountId }));
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    await adapter.ensureAccountContact(accountId, 'contact-c');
+
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.properties['Associated Contacts'].relation).toEqual([
+      { id: 'contact-a' },
+      { id: 'contact-b' },
+      { id: 'contact-c' },
+    ]);
+  });
+
+  it('does not patch an account that already contains the contact', async () => {
+    const accountId = createInput().accountPageId;
+    const fetchMock = vi.fn().mockImplementationOnce(() =>
+      jsonResponse({
+        id: accountId,
+        in_trash: false,
+        properties: {
+          'Associated Contacts': { type: 'relation', relation: [{ id: 'contact-c' }] },
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    await adapter.ensureAccountContact(accountId, 'contact-c');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires both contact and account pages to contain the relationship', async () => {
+    const accountId = createInput().accountPageId;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse(contactPage('contact-page', accountId)))
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          id: accountId,
+          properties: {
+            'Associated Contacts': { type: 'relation', relation: [] },
+          },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    await expect(adapter.verifyBothSides(accountId, 'contact-page')).resolves.toBe(false);
+  });
+
+  it('rejects an account outside the configured master data source', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ data_sources: [{ id: 'accounts-source' }] }))
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          id: createInput().accountPageId,
+          in_trash: false,
+          parent: { type: 'data_source_id', data_source_id: 'different-source' },
+          properties: {},
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    await expect(adapter.requireAccount(createInput().accountPageId)).rejects.toThrow(
+      'Contact account not found',
+    );
+  });
+
+  it('retries rate-limited requests using Retry-After without exposing payloads', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        jsonResponse({ code: 'rate_limited', message: 'slow down' }, 429, { 'retry-after': '0' }),
+      )
+      .mockImplementationOnce(() => jsonResponse({ data_sources: [{ id: 'accounts-source' }] }))
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          id: createInput().accountPageId,
+          in_trash: false,
+          parent: { type: 'data_source_id', data_source_id: 'accounts-source' },
+          properties: {},
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = createNotionContactCreationAdapter();
+
+    await expect(adapter.requireAccount(createInput().accountPageId)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/lib/server/notion-contact-creation.ts
+++ b/lib/server/notion-contact-creation.ts
@@ -1,0 +1,231 @@
+import 'server-only';
+
+import type {
+  ContactCreationAdapter,
+  ContactRecord,
+  CreateContactInput,
+} from '@/lib/server/contact-creation';
+import { normalizeContactName } from '@/lib/server/contact-creation';
+import { refreshLiveNotionContactsCache } from '@/lib/server/notion-live-crm';
+
+const NOTION_API_BASE = 'https://api.notion.com/v1';
+const NOTION_VERSION = '2026-03-11';
+const MAX_ATTEMPTS = 3;
+
+type NotionPage = {
+  id: string;
+  in_trash?: boolean;
+  parent?: { type?: string; data_source_id?: string };
+  properties?: Record<string, unknown>;
+};
+
+type RelationProperty = {
+  type?: string;
+  relation?: Array<{ id?: string }>;
+};
+
+type TextProperty = {
+  type?: string;
+  title?: Array<{ plain_text?: string }>;
+  rich_text?: Array<{ plain_text?: string }>;
+  email?: string | null;
+  phone_number?: string | null;
+};
+
+function requiredEnv(name: 'NOTION_API_KEY' | 'NOTION_CONTACTS_DATABASE_ID' | 'NOTION_MASTER_LIST_DATABASE_ID') {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function normalizeId(value: string | undefined) {
+  return (value ?? '').replace(/-/g, '').toLowerCase();
+}
+
+function relationIds(property: unknown) {
+  const relation = property as RelationProperty | undefined;
+  return (relation?.relation ?? []).flatMap((item) => (item.id ? [item.id] : []));
+}
+
+function plainText(items: Array<{ plain_text?: string }> | undefined) {
+  return (items ?? []).map((item) => item.plain_text ?? '').join('').trim();
+}
+
+function mapContact(page: NotionPage): ContactRecord {
+  if (!page.id || page.in_trash) throw new Error('Contact not found');
+  const properties = page.properties ?? {};
+  const name = properties['Contact Name'] as TextProperty | undefined;
+  const position = properties['Contact Position'] as TextProperty | undefined;
+  const email = properties.Email as TextProperty | undefined;
+  const phone = properties['Phone Number'] as TextProperty | undefined;
+
+  return {
+    id: page.id,
+    name: plainText(name?.title),
+    position: plainText(position?.rich_text),
+    email: email?.email?.trim() || null,
+    phone: phone?.phone_number?.trim() || null,
+  };
+}
+
+async function delay(milliseconds: number) {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function notionRequest<T>(path: string, init?: RequestInit, attempt = 1): Promise<T> {
+  const response = await fetch(`${NOTION_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${requiredEnv('NOTION_API_KEY')}`,
+      'Notion-Version': NOTION_VERSION,
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    cache: 'no-store',
+  });
+
+  if ((response.status === 429 || response.status >= 500) && attempt < MAX_ATTEMPTS) {
+    const retryAfter = Number(response.headers.get('retry-after'));
+    const waitMs = Number.isFinite(retryAfter) ? Math.max(0, retryAfter * 1_000) : attempt * 500;
+    await delay(waitMs);
+    return notionRequest<T>(path, init, attempt + 1);
+  }
+
+  const payload = (await response.json().catch(() => ({}))) as T & { code?: string };
+  if (!response.ok) {
+    const code = typeof payload?.code === 'string' ? payload.code : 'unknown_error';
+    throw new Error(`Notion request failed (${response.status}:${code})`);
+  }
+  return payload;
+}
+
+export function createNotionContactCreationAdapter(): ContactCreationAdapter {
+  const dataSourceCache = new Map<string, Promise<string>>();
+
+  function resolveDataSource(databaseId: string) {
+    let pending = dataSourceCache.get(databaseId);
+    if (!pending) {
+      pending = notionRequest<{ data_sources?: Array<{ id?: string }> }>(`/databases/${databaseId}`).then(
+        (database) => {
+          const id = database.data_sources?.find((item) => item.id)?.id;
+          if (!id) throw new Error('Notion data source is unavailable');
+          return id;
+        },
+      );
+      dataSourceCache.set(databaseId, pending);
+    }
+    return pending;
+  }
+
+  async function getAccount(accountPageId: string) {
+    return notionRequest<NotionPage>(`/pages/${accountPageId}`);
+  }
+
+  return {
+    async requireAccount(accountPageId) {
+      const expectedSource = await resolveDataSource(requiredEnv('NOTION_MASTER_LIST_DATABASE_ID'));
+      const page = await getAccount(accountPageId);
+      if (
+        page.in_trash ||
+        page.parent?.type !== 'data_source_id' ||
+        normalizeId(page.parent.data_source_id) !== normalizeId(expectedSource)
+      ) {
+        throw new Error('Contact account not found');
+      }
+    },
+
+    async findContact(accountPageId, normalizedName) {
+      const sourceId = await resolveDataSource(requiredEnv('NOTION_CONTACTS_DATABASE_ID'));
+      let cursor: string | undefined;
+
+      do {
+        const response = await notionRequest<{
+          results?: NotionPage[];
+          has_more?: boolean;
+          next_cursor?: string | null;
+        }>(`/data_sources/${sourceId}/query`, {
+          method: 'POST',
+          body: JSON.stringify({
+            page_size: 100,
+            filter: { property: 'Dispensary', relation: { contains: accountPageId } },
+            ...(cursor ? { start_cursor: cursor } : {}),
+          }),
+        });
+
+        for (const page of response.results ?? []) {
+          const accountIds = relationIds(page.properties?.Dispensary);
+          const belongsToAccount = accountIds.some(
+            (candidate) => normalizeId(candidate) === normalizeId(accountPageId),
+          );
+          if (!belongsToAccount) continue;
+          const contact = mapContact(page);
+          if (normalizeContactName(contact.name) === normalizedName) return contact;
+        }
+
+        cursor = response.has_more && response.next_cursor ? response.next_cursor : undefined;
+      } while (cursor);
+
+      return null;
+    },
+
+    async getContact(contactPageId) {
+      return mapContact(await notionRequest<NotionPage>(`/pages/${contactPageId}`));
+    },
+
+    async createContact(input: CreateContactInput) {
+      const sourceId = await resolveDataSource(requiredEnv('NOTION_CONTACTS_DATABASE_ID'));
+      const properties: Record<string, unknown> = {
+        'Contact Name': { title: [{ text: { content: input.name } }] },
+        'Contact Position': { rich_text: [{ text: { content: input.position } }] },
+        Dispensary: { relation: [{ id: input.accountPageId }] },
+        'Where Contact Info Came From': { multi_select: [{ name: 'CRM Contact' }] },
+      };
+      if (input.email) properties.Email = { email: input.email };
+      if (input.phone) properties['Phone Number'] = { phone_number: input.phone };
+
+      const page = await notionRequest<NotionPage>('/pages', {
+        method: 'POST',
+        body: JSON.stringify({
+          parent: { type: 'data_source_id', data_source_id: sourceId },
+          properties,
+        }),
+      });
+      return mapContact(page);
+    },
+
+    async ensureAccountContact(accountPageId, contactPageId) {
+      const account = await getAccount(accountPageId);
+      const existing = relationIds(account.properties?.['Associated Contacts']);
+      if (existing.some((id) => normalizeId(id) === normalizeId(contactPageId))) return;
+
+      await notionRequest(`/pages/${accountPageId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          properties: {
+            'Associated Contacts': {
+              relation: [...existing.map((id) => ({ id })), { id: contactPageId }],
+            },
+          },
+        }),
+      });
+    },
+
+    async verifyBothSides(accountPageId, contactPageId) {
+      const [contact, account] = await Promise.all([
+        notionRequest<NotionPage>(`/pages/${contactPageId}`),
+        getAccount(accountPageId),
+      ]);
+      const contactHasAccount = relationIds(contact.properties?.Dispensary).some(
+        (id) => normalizeId(id) === normalizeId(accountPageId),
+      );
+      const accountHasContact = relationIds(account.properties?.['Associated Contacts']).some(
+        (id) => normalizeId(id) === normalizeId(contactPageId),
+      );
+      return contactHasAccount && accountHasContact;
+    },
+
+    async refreshContacts() {
+      await refreshLiveNotionContactsCache();
+    },
+  };
+}

--- a/lib/server/notion-live-crm.ts
+++ b/lib/server/notion-live-crm.ts
@@ -479,6 +479,10 @@ export async function loadLiveNotionContacts(): Promise<ContactTableRow[]> {
   return contacts.rows.map(toContactTableRow);
 }
 
+export async function refreshLiveNotionContactsCache() {
+  await getCachedContacts({ refresh: true });
+}
+
 export async function loadLiveNotionContactsWithMeta(): Promise<{
   rows: RuntimeContactSummary[];
   meta: ContactsFreshnessMeta;

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -21,6 +21,27 @@ export const contactSchema = z.object({
   status: z.enum(['ACTIVE', 'INACTIVE']).default('ACTIVE'),
 });
 
+const notionPageIdSchema = z
+  .string()
+  .trim()
+  .regex(
+    /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i,
+    'Invalid Notion page ID',
+  );
+
+export const notionContactCreateSchema = z.object({
+  accountPageId: notionPageIdSchema,
+  name: z.string().trim().min(1).max(160),
+  position: z.string().trim().min(1).max(160),
+  email: z.string().trim().email().max(320).nullable(),
+  phone: z.string().trim().max(40).nullable(),
+});
+
+export const notionContactRetrySchema = z.object({
+  accountPageId: notionPageIdSchema,
+  contactPageId: notionPageIdSchema,
+});
+
 export const quickLogSchema = z.object({
   accountId: z.string().cuid(),
   title: z.string().min(2).max(200),


### PR DESCRIPTION
## Why
The app exposes contact data but lacks a complete browser workflow for adding an account contact and verifying the external relationship.

Closes #155

## Scope
- Add a Contacts tab inside the Accounts section.
- Add a reusable mobile-first contact form.
- Prevent account-scoped duplicates.
- Verify the external account relationship before reporting success.
- Surface retryable partial completion.
- Keep the existing persistent Home, Map, Accounts, Route, and Dashboard menu.
- Add Home to Profile/tools.

## Out of scope
- Bulk import, schema changes, historical repairs, production backfills, and destructive writes.
- Task creation, general mobile performance work, and stale-work cleanup, which remain separate issues.

## Validation plan
- RED-first service, adapter, route, and UI-model tests.
- Repository verification and browser tests under Node 22.
- Desktop/mobile screenshots and intercepted browser flow.
- No production contact creation during automated validation.

## Coordination
Reviewed open PRs #144, #135, and #82. Account-detail integration remains blocked on explicit disposition of the stale #135 overlap; other implementation paths are isolated.