### PR TITLE
Add subway lines toggle to territory map

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,63 +1,33 @@
-# Session: Verified contact creation and Contacts navigation
+# Session: Issue 157 Subway Toggle
 
-## Issue
+## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/155
-
-## Branch
-
-- `codex/155-contacts`
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/157
+- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/158
+- Branch: `codex/157-subway-toggle`
 
 ## Scope
 
-- Make Contacts directly reachable as a section tab inside Accounts.
-- Keep Home, Map, Accounts, Route, and Dashboard in persistent navigation.
-- Keep Home accessible from the Profile/tools menu.
-- Add one reusable contact-creation experience to the Contacts page.
-- Create contacts through the existing external CRM boundary.
-- Prevent account-scoped duplicates, preserve existing relationships, and verify the completed relationship before reporting success.
-- Provide honest, retryable partial-failure behavior.
+- Add a polished, accessible subway-lines toggle to the territory map toolbar.
+- Render the native Google Maps transit layer without disturbing PICC overlays.
+- Remember the setting on the current device.
+- Verify the interaction at desktop and mobile viewports.
 
-## Out Of Scope
+## Out of scope
 
-- Task creation UI, which remains tracked by issue #36.
-- Mobile bundle optimization, which remains tracked by issue #94.
-- Remote branch and stale PR cleanup, which remains tracked by issue #39.
-- Bulk imports, historical relation repair, CRM schema changes, production backfills, or destructive data operations.
-- Publishing private workspace IDs, tokens, or tenant-specific operating details.
+- Custom MTA geometry, station, schedule, or service-alert ingestion.
+- Route optimization or Google Directions changes.
+- Database, schema, authentication, authorization, environment, or production-data changes.
+- Any change to `/Users/brycejohnson/Code/map-app`.
 
-## Owned Paths
+## Constraints
 
-- `app/(main)/accounts/page.tsx`
-- `app/(main)/contacts/**`
-- `app/api/contacts/**`
-- `components/crm/accounts-section-tabs.tsx`
-- `components/crm/contact-create-flow.tsx`
-- `components/layout/app-shell.tsx`
-- `lib/contacts/contact-create-model*`
-- `lib/server/contact-creation*`
-- `lib/server/notion-contact-creation*`
-- `lib/server/notion-live-crm.ts`
-- `lib/validation/schemas.ts`
-- focused tests and browser artifacts for the above paths
-- `docs/superpowers/specs/2026-08-12-contact-creation-design.md`
-- `docs/superpowers/plans/2026-08-12-contact-creation.md`
-- `SESSION.md`
+- Keep Google Maps as the only map provider.
+- Preserve existing account pins, route geometry, territory boundaries, markers, lasso, search, filters, and map gestures.
+- Use a failing behavior test before implementation.
+- Run `npm run verify` and browser tests before completion.
+- Capture user-visible desktop and mobile evidence.
 
-## Active PR Overlap Check
+## Ownership and overlap
 
-- PR #135 overlaps `components/mobile/account-detail-sheet.tsx`; this branch does not edit that path.
-- PRs #144 and #82 were checked and do not own the implemented paths.
-
-## Validation Plan
-
-- Use RED-first unit and route tests for duplicate prevention, relationship preservation, verification, partial failure, retry, validation, and authorization.
-- Run focused tests after each behavior slice.
-- Run `npm run verify` under Node 22.
-- Run browser tests for the Contacts page, Accounts tabs, persistent navigation, Profile menu, form states, and 390x844 mobile viewport.
-- Use fakes or route interception for external writes during automated/browser validation. Do not create production contacts as test data.
-
-## Production Boundary
-
-- Live schema inspection was read-only and explicitly approved.
-- No production CRM writes, schema changes, backfills, or destructive actions are authorized for validation.
+Owned paths are documented in PR #158. Active PRs #144, #135, and #82 were reviewed. PRs #135 and #82 do not overlap. PR #144 is a broad legacy monorepo migration that conflicts with the current canonical architecture and declares no path ownership.

--- a/SESSION.md
+++ b/SESSION.md
@@ -31,3 +31,17 @@
 ## Ownership and overlap
 
 Owned paths are documented in PR #158. Active PRs #144, #135, and #82 were reviewed. PRs #135 and #82 do not overlap. PR #144 is a broad legacy monorepo migration that conflicts with the current canonical architecture and declares no path ownership.
+
+## Validation evidence
+
+- RED unit proof: `lib/territory/subway-lines.test.ts` initially failed because the subway utility did not exist.
+- RED browser proof: the focused Playwright test initially failed because no `Show subway lines` control existed.
+- `npm run verify`: passed lint, typecheck, 27 Vitest files with 125 tests, Prisma validation, and the Next.js production build.
+- `npm run test:e2e`: 18 Playwright tests passed.
+- Focused subway suite: toggle on/off, `aria-pressed`, device-local reload persistence, route visualization coexistence, and 390x844 mobile reachability passed.
+- Desktop control-state screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-desktop.png`.
+- Mobile control-state screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-mobile.png`.
+
+## Remaining verification boundary
+
+The isolated local environment has no Google Maps API key, so screenshots prove the polished active control and responsive fit, while unit tests prove native `TransitLayer` attachment and cleanup. Actual subway geometry must be verified after deployment on the authenticated production map, where Google Maps configuration is present.

--- a/SESSION.md
+++ b/SESSION.md
@@ -36,9 +36,10 @@ Owned paths are documented in PR #158. Active PRs #144, #135, and #82 were revie
 
 - RED unit proof: `lib/territory/subway-lines.test.ts` initially failed because the subway utility did not exist.
 - RED browser proof: the focused Playwright test initially failed because no `Show subway lines` control existed.
-- `npm run verify`: passed lint, typecheck, 27 Vitest files with 125 tests, Prisma validation, and the Next.js production build.
+- `npm run verify`: passed lint, typecheck, 27 Vitest files with 126 tests, Prisma validation, and the Next.js production build.
 - `npm run test:e2e`: 18 Playwright tests passed.
 - Focused subway suite: toggle on/off, `aria-pressed`, device-local reload persistence, route visualization coexistence, and 390x844 mobile reachability passed.
+- Independent review found and then verified the fix for blocked `localStorage` property access; no Critical or Important findings remain.
 - Desktop control-state screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-desktop.png`.
 - Mobile control-state screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-mobile.png`.
 

--- a/components/mobile/territory-map-mobile.tsx
+++ b/components/mobile/territory-map-mobile.tsx
@@ -28,6 +28,8 @@ interface TerritoryMapMobileProps {
   focusRequestToken: number;
   routeCoordinates: [number, number][];
   pinColorMode: PinColorMode;
+  showSubwayLines?: boolean;
+  onSubwayLinesUnavailable?: () => void;
   onSelectStore: (id: string | null) => void;
   onDraftBoundaryChange?: (coordinates: [number, number][]) => void;
   onSelectionBoundaryChange?: (coordinates: [number, number][]) => void;
@@ -56,6 +58,8 @@ export function TerritoryMapMobile({
   focusRequestToken,
   routeCoordinates,
   pinColorMode,
+  showSubwayLines = false,
+  onSubwayLinesUnavailable,
   onSelectStore,
   onDraftBoundaryChange,
   onSelectionBoundaryChange,
@@ -83,6 +87,8 @@ export function TerritoryMapMobile({
       locationRequestToken={locationRequestToken}
       routeCoordinates={routeCoordinates}
       pinColorMode={pinColorMode}
+      showSubwayLines={showSubwayLines}
+      onSubwayLinesUnavailable={onSubwayLinesUnavailable}
       cameraMode="manual-focus"
       focusRequestToken={focusRequestToken}
       fitPadding={24}

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Crosshair, Download, Filter, Layers3, RefreshCw, Search } from 'lucide-react';
+import { Crosshair, Download, Filter, Layers3, RefreshCw, Search, TrainFront } from 'lucide-react';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
@@ -37,6 +37,8 @@ interface TerritoryMapOverlayControlsProps {
   onCenterCurrentLocation: () => void;
   onRefreshData: () => void;
   onToggleMapSearch: () => void;
+  showSubwayLines: boolean;
+  onToggleSubwayLines: () => void;
   onOpenBoundarySheet: () => void;
   onOpenMyMapsExport: () => void;
   showBoundaries: boolean;
@@ -69,6 +71,8 @@ export function TerritoryMapOverlayControls({
   onCenterCurrentLocation,
   onRefreshData,
   onToggleMapSearch,
+  showSubwayLines,
+  onToggleSubwayLines,
   onOpenBoundarySheet,
   onOpenMyMapsExport,
   showBoundaries,
@@ -292,6 +296,19 @@ export function TerritoryMapOverlayControls({
           onClick={onToggleMapSearch}
         >
           <Search className={cn('h-5 w-5', showMapSearch || mapSearch.trim().length > 0 ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
+        </button>
+        <button
+          type="button"
+          aria-label={showSubwayLines ? 'Hide subway lines' : 'Show subway lines'}
+          title={showSubwayLines ? 'Hide subway lines' : 'Show subway lines'}
+          aria-pressed={showSubwayLines}
+          className={cn(
+            'picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]',
+            showSubwayLines ? 'ring-2 ring-[#cd3814]' : '',
+          )}
+          onClick={onToggleSubwayLines}
+        >
+          <TrainFront className={cn('h-5 w-5', showSubwayLines ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
         </button>
         <button
           type="button"

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAppAccess } from '@/components/auth/app-access-provider';
@@ -30,6 +30,7 @@ import type { TerritoryStorePin } from '@/lib/territory/types';
 import { getTerritoryMapSearchSuggestions } from '@/lib/territory/map-search-suggestions';
 import { clearSavedTerritoryFilters, countActiveTerritoryFilters, loadSavedTerritoryFilters, persistSavedTerritoryFilters, type TerritorySavedFiltersPayload } from '@/lib/territory/filter-storage';
 import { useRoutePlan } from '@/lib/territory/route-plan-client';
+import { loadSubwayLinesPreference, persistSubwayLinesPreference } from '@/lib/territory/subway-lines';
 
 const TerritoryMapMobile = dynamic(
   () => import('@/components/mobile/territory-map-mobile').then((module) => module.TerritoryMapMobile),
@@ -103,6 +104,7 @@ export function TerritoryMobile() {
   const [lastOrderDateFilter, setLastOrderDateFilter] = useState<'all' | 'last_month' | 'last_2_months' | 'three_plus_months'>('all');
   const [showFilters, setShowFilters] = useState(false);
   const [showMapSearch, setShowMapSearch] = useState(false);
+  const [showSubwayLines, setShowSubwayLines] = useState(false);
   const [pinColorMode, setPinColorMode] = useState<PinColorMode>('status');
   const [draftStatuses, setDraftStatuses] = useState<string[]>([]);
   const [draftReps, setDraftReps] = useState<string[]>([]);
@@ -129,6 +131,24 @@ export function TerritoryMobile() {
   const [lassoDrawingMode, setLassoDrawingMode] = useState(false);
   const [lassoSelectedIds, setLassoSelectedIds] = useState<string[]>([]);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  useEffect(() => {
+    setShowSubwayLines(loadSubwayLinesPreference(window.localStorage));
+  }, []);
+
+  const toggleSubwayLines = useCallback(() => {
+    setShowSubwayLines((current) => {
+      const next = !current;
+      persistSubwayLinesPreference(window.localStorage, next);
+      return next;
+    });
+  }, []);
+
+  const handleSubwayLinesUnavailable = useCallback(() => {
+    setShowSubwayLines(false);
+    persistSubwayLinesPreference(window.localStorage, false);
+    toast.error('Subway lines are unavailable in Google Maps right now.');
+  }, []);
 
   useEffect(() => {
     try {
@@ -730,6 +750,8 @@ export function TerritoryMobile() {
               focusRequestToken={focusRequestToken}
               routeCoordinates={routeCoordinates}
               pinColorMode={pinColorMode}
+              showSubwayLines={showSubwayLines}
+              onSubwayLinesUnavailable={handleSubwayLinesUnavailable}
               repColorMap={repColorMap}
               onSelectStore={setFocusedId}
               onDraftBoundaryChange={(coordinates) =>
@@ -787,6 +809,8 @@ export function TerritoryMobile() {
             onCenterCurrentLocation={centerOnCurrentLocation}
             onRefreshData={() => setRefreshNonce((value) => value + 1)}
             onToggleMapSearch={() => setShowMapSearch((current) => !current)}
+            showSubwayLines={showSubwayLines}
+            onToggleSubwayLines={toggleSubwayLines}
             onOpenBoundarySheet={() => setShowBoundarySheet(true)}
             onOpenMyMapsExport={() => setShowMyMapsExport(true)}
             showBoundaries={showBoundaries}

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -30,7 +30,7 @@ import type { TerritoryStorePin } from '@/lib/territory/types';
 import { getTerritoryMapSearchSuggestions } from '@/lib/territory/map-search-suggestions';
 import { clearSavedTerritoryFilters, countActiveTerritoryFilters, loadSavedTerritoryFilters, persistSavedTerritoryFilters, type TerritorySavedFiltersPayload } from '@/lib/territory/filter-storage';
 import { useRoutePlan } from '@/lib/territory/route-plan-client';
-import { loadSubwayLinesPreference, persistSubwayLinesPreference } from '@/lib/territory/subway-lines';
+import { getBrowserLocalStorage, loadSubwayLinesPreference, persistSubwayLinesPreference } from '@/lib/territory/subway-lines';
 
 const TerritoryMapMobile = dynamic(
   () => import('@/components/mobile/territory-map-mobile').then((module) => module.TerritoryMapMobile),
@@ -133,20 +133,20 @@ export function TerritoryMobile() {
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
 
   useEffect(() => {
-    setShowSubwayLines(loadSubwayLinesPreference(window.localStorage));
+    setShowSubwayLines(loadSubwayLinesPreference(getBrowserLocalStorage(window)));
   }, []);
 
   const toggleSubwayLines = useCallback(() => {
     setShowSubwayLines((current) => {
       const next = !current;
-      persistSubwayLinesPreference(window.localStorage, next);
+      persistSubwayLinesPreference(getBrowserLocalStorage(window), next);
       return next;
     });
   }, []);
 
   const handleSubwayLinesUnavailable = useCallback(() => {
     setShowSubwayLines(false);
-    persistSubwayLinesPreference(window.localStorage, false);
+    persistSubwayLinesPreference(getBrowserLocalStorage(window), false);
     toast.error('Subway lines are unavailable in Google Maps right now.');
   }, []);
 

--- a/components/territory/google-territory-map.tsx
+++ b/components/territory/google-territory-map.tsx
@@ -8,6 +8,7 @@ import { GoogleTerritoryMarkers, GoogleTerritoryMarkersFallback } from '@/compon
 import { pinColorForStore, pinGlyphColorForStore, pinGlyphForStore, type PinColorMode } from '@/lib/territory/pin-colors';
 import type { GoogleMyMapsViewportBounds } from '@/lib/territory/google-my-maps-export';
 import type { TerritoryBoundary, TerritoryMarker, TerritoryStorePin } from '@/lib/territory/types';
+import { attachTransitLayer, createTransitLayer, type TransitMapsApi } from '@/lib/territory/subway-lines';
 import { cn } from '@/lib/utils';
 
 export type MapCameraMode = 'follow-selection' | 'manual-focus';
@@ -33,6 +34,8 @@ interface GoogleTerritoryMapProps {
   locationRequestToken?: number;
   routeCoordinates: [number, number][];
   pinColorMode?: PinColorMode;
+  showSubwayLines?: boolean;
+  onSubwayLinesUnavailable?: () => void;
   onSelectStore: (storeId: string | null) => void;
   onDraftBoundaryChange?: (coordinates: [number, number][]) => void;
   onSelectionBoundaryChange?: (coordinates: [number, number][]) => void;
@@ -63,7 +66,7 @@ type GooglePolyline = {
   setMap: (map: null) => void;
 };
 
-type GoogleMapsApi = {
+type GoogleMapsApi = TransitMapsApi & {
   Polyline: new (options: {
     map: unknown;
     geodesic: boolean;
@@ -169,6 +172,22 @@ function RouteLine({ routeCoordinates }: { routeCoordinates: [number, number][] 
       }
     };
   }, [map, routeCoordinates]);
+
+  return null;
+}
+
+function SubwayLayer({ enabled, onUnavailable }: { enabled: boolean; onUnavailable?: () => void }) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!enabled || !map) return;
+    const layer = createTransitLayer(getGoogleMapsApi());
+    if (!layer) {
+      onUnavailable?.();
+      return;
+    }
+    return attachTransitLayer(layer, map);
+  }, [enabled, map, onUnavailable]);
 
   return null;
 }
@@ -410,6 +429,8 @@ export function GoogleTerritoryMap({
   locationRequestToken,
   routeCoordinates,
   pinColorMode = 'status',
+  showSubwayLines = false,
+  onSubwayLinesUnavailable,
   onSelectStore,
   onDraftBoundaryChange,
   onSelectionBoundaryChange,
@@ -643,6 +664,7 @@ export function GoogleTerritoryMap({
           <CurrentLocationController currentLocation={currentLocation} locationRequestToken={locationRequestToken} />
           <ViewportBoundsController onViewportBoundsChange={onViewportBoundsChange} />
           <RouteLine routeCoordinates={routeCoordinates} />
+          <SubwayLayer enabled={showSubwayLines} onUnavailable={onSubwayLinesUnavailable} />
           <GoogleTerritoryBoundaries
             boundaries={boundaries}
             showBoundaries={showBoundaries}

--- a/docs/superpowers/plans/2026-08-12-subway-lines-toggle.md
+++ b/docs/superpowers/plans/2026-08-12-subway-lines-toggle.md
@@ -1,0 +1,478 @@
+# Subway Lines Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an accessible territory-map control that shows Google transit routes and stations and remembers the choice on the current device.
+
+**Architecture:** Keep preference parsing and Google overlay lifecycle in a focused, testable territory utility. `TerritoryMobile` owns the UI state, passes it through `TerritoryMapMobile` to `GoogleTerritoryMap`, and renders the toggle through `TerritoryMapOverlayControls`. A map child attaches one native `google.maps.TransitLayer` while enabled and detaches it on disable or unmount.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript strict, `@vis.gl/react-google-maps`, Google Maps JavaScript API, Tailwind CSS v4, Lucide React, Vitest, Playwright.
+
+## Global Constraints
+
+- Keep Google Maps as the only supported map provider.
+- Default subway lines to off on first use.
+- Persist only on the current browser/device with `localStorage`; add no backend or database state.
+- Preserve account pins, route geometry, territory boundaries, markers, lasso, search, filters, camera state, and map gestures.
+- Use the existing 40px right-side toolbar control treatment and PICC-red `#cd3814` active state.
+- Use exact accessible copy: `Show subway lines` when off and `Hide subway lines` when on.
+- Do not add custom MTA geometry, schedules, service alerts, route-planning changes, schema changes, auth changes, or production-data writes.
+- Do not change `/Users/brycejohnson/Code/map-app`.
+- Use RED tests before non-test behavior edits.
+
+## File Structure
+
+- Create `lib/territory/subway-lines.ts`: storage key, safe preference I/O, transit-layer factory, and attach/cleanup adapter.
+- Create `lib/territory/subway-lines.test.ts`: deterministic storage and Google overlay lifecycle tests.
+- Modify `components/territory/google-territory-map.tsx`: typed `TransitLayer` access and a small `SubwayLayer` map child.
+- Modify `components/mobile/territory-map-mobile.tsx`: pass subway visibility and unavailable callback through the mobile map boundary.
+- Modify `components/mobile/territory-map-overlay-controls.tsx`: train-icon toggle with state-specific styling and accessible semantics.
+- Modify `components/mobile/territory-mobile.tsx`: load, toggle, persist, and recover subway preference.
+- Create `tests/e2e/territory-subway-lines.spec.ts`: browser-visible toggle, persistence, route compatibility, and responsive checks.
+- Update `SESSION.md`: record final validation and proof without changing scope.
+
+---
+
+### Task 1: Safe preference and transit-layer adapters
+
+**Files:**
+- Create: `lib/territory/subway-lines.test.ts`
+- Create: `lib/territory/subway-lines.ts`
+
+**Interfaces:**
+- Produces: `SUBWAY_LINES_STORAGE_KEY: 'picc:territory:subway-lines'`
+- Produces: `loadSubwayLinesPreference(storage: StorageReader | null | undefined): boolean`
+- Produces: `persistSubwayLinesPreference(storage: StorageWriter | null | undefined, enabled: boolean): boolean`
+- Produces: `createTransitLayer(mapsApi: TransitMapsApi | null | undefined): TransitLayerHandle | null`
+- Produces: `attachTransitLayer(layer: TransitLayerHandle, map: unknown): () => void`
+
+- [ ] **Step 1: Write failing preference and lifecycle tests**
+
+Create `lib/territory/subway-lines.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SUBWAY_LINES_STORAGE_KEY,
+  attachTransitLayer,
+  createTransitLayer,
+  loadSubwayLinesPreference,
+  persistSubwayLinesPreference,
+} from '@/lib/territory/subway-lines';
+
+describe('subway lines preference', () => {
+  it('defaults to off for missing, malformed, or inaccessible storage', () => {
+    expect(loadSubwayLinesPreference(null)).toBe(false);
+    expect(loadSubwayLinesPreference({ getItem: () => null })).toBe(false);
+    expect(loadSubwayLinesPreference({ getItem: () => 'yes' })).toBe(false);
+    expect(loadSubwayLinesPreference({ getItem: () => { throw new Error('blocked'); } })).toBe(false);
+  });
+
+  it('loads and persists exact boolean values', () => {
+    expect(loadSubwayLinesPreference({ getItem: () => 'true' })).toBe(true);
+    expect(loadSubwayLinesPreference({ getItem: () => 'false' })).toBe(false);
+
+    const setItem = vi.fn();
+    expect(persistSubwayLinesPreference({ setItem }, true)).toBe(true);
+    expect(setItem).toHaveBeenCalledWith(SUBWAY_LINES_STORAGE_KEY, 'true');
+  });
+
+  it('reports a failed write without throwing', () => {
+    expect(persistSubwayLinesPreference({ setItem: () => { throw new Error('quota'); } }, true)).toBe(false);
+  });
+});
+
+describe('Google transit layer adapter', () => {
+  it('returns null when the optional Google API is unavailable', () => {
+    expect(createTransitLayer(null)).toBeNull();
+    expect(createTransitLayer({})).toBeNull();
+  });
+
+  it('attaches once and detaches during cleanup', () => {
+    const setMap = vi.fn();
+    class TransitLayer {
+      setMap = setMap;
+    }
+    const layer = createTransitLayer({ TransitLayer });
+    expect(layer).not.toBeNull();
+
+    const map = { id: 'territory-map' };
+    const cleanup = attachTransitLayer(layer!, map);
+    expect(setMap).toHaveBeenCalledWith(map);
+    cleanup();
+    expect(setMap).toHaveBeenLastCalledWith(null);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `npm test -- lib/territory/subway-lines.test.ts`
+
+Expected: FAIL because `@/lib/territory/subway-lines` does not exist.
+
+- [ ] **Step 3: Implement the minimal utility**
+
+Create `lib/territory/subway-lines.ts`:
+
+```ts
+export const SUBWAY_LINES_STORAGE_KEY = 'picc:territory:subway-lines';
+
+export type StorageReader = { getItem: (key: string) => string | null };
+export type StorageWriter = { setItem: (key: string, value: string) => void };
+
+export type TransitLayerHandle = {
+  setMap: (map: unknown | null) => void;
+};
+
+export type TransitMapsApi = {
+  TransitLayer?: new () => TransitLayerHandle;
+};
+
+export function loadSubwayLinesPreference(storage: StorageReader | null | undefined): boolean {
+  try {
+    return storage?.getItem(SUBWAY_LINES_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function persistSubwayLinesPreference(
+  storage: StorageWriter | null | undefined,
+  enabled: boolean,
+): boolean {
+  try {
+    if (!storage) return false;
+    storage.setItem(SUBWAY_LINES_STORAGE_KEY, String(enabled));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createTransitLayer(mapsApi: TransitMapsApi | null | undefined): TransitLayerHandle | null {
+  return mapsApi?.TransitLayer ? new mapsApi.TransitLayer() : null;
+}
+
+export function attachTransitLayer(layer: TransitLayerHandle, map: unknown): () => void {
+  layer.setMap(map);
+  return () => layer.setMap(null);
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm GREEN**
+
+Run: `npm test -- lib/territory/subway-lines.test.ts`
+
+Expected: PASS with 5 tests.
+
+- [ ] **Step 5: Commit the adapter slice**
+
+```bash
+git add lib/territory/subway-lines.ts lib/territory/subway-lines.test.ts
+git commit -m "feat: add subway layer preference adapter"
+```
+
+---
+
+### Task 2: Complete browser-visible subway toggle
+
+**Files:**
+- Create: `tests/e2e/territory-subway-lines.spec.ts`
+- Modify: `components/mobile/territory-map-overlay-controls.tsx:3-44,283-321`
+- Modify: `components/mobile/territory-mobile.tsx:3-26,88-176,709-806`
+- Modify: `components/mobile/territory-map-mobile.tsx:9-96`
+- Modify: `components/territory/google-territory-map.tsx:15-91,139-175,604-725`
+
+**Interfaces:**
+- Consumes: `loadSubwayLinesPreference(window.localStorage): boolean`
+- Consumes: `persistSubwayLinesPreference(window.localStorage, enabled): boolean`
+- Adds control props: `showSubwayLines: boolean`, `onToggleSubwayLines: () => void`
+- Produces state for the map boundary: `showSubwayLines: boolean`, `onSubwayLinesUnavailable: () => void`
+- Consumes: `createTransitLayer(mapsApi)` and `attachTransitLayer(layer, map)` from Task 1.
+- Adds map props: `showSubwayLines?: boolean`, `onSubwayLinesUnavailable?: () => void`.
+
+- [ ] **Step 1: Write the failing Playwright behavior test**
+
+Create `tests/e2e/territory-subway-lines.spec.ts` with deterministic route interception:
+
+```ts
+import { expect, test, type Page } from '@playwright/test';
+
+const preferenceKey = 'picc:territory:subway-lines';
+
+async function mockTerritory(page: Page) {
+  await page.route('**/api/territory/stores**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      stores: [
+        { id: 'one', notionPageId: 'one', name: 'Downtown One', status: 'Lead - Hot', statusKey: 'lead-hot', statusColor: 'red', pinKind: 'lead', repNames: [], repEmails: [], lat: 40.7128, lng: -74.006, locationLabel: 'New York', locationAddress: 'New York, NY', locationSource: 'google-address-cache', locationPrecision: 'address', isApproximate: false, lastEditedTime: '2026-08-12T00:00:00.000Z', city: 'New York', state: 'NY', referralSource: null },
+        { id: 'two', notionPageId: 'two', name: 'Brooklyn Two', status: 'Lead - Hot', statusKey: 'lead-hot', statusColor: 'red', pinKind: 'lead', repNames: [], repEmails: [], lat: 40.6943, lng: -73.9918, locationLabel: 'Brooklyn', locationAddress: 'Brooklyn, NY', locationSource: 'google-address-cache', locationPrecision: 'address', isApproximate: false, lastEditedTime: '2026-08-12T00:00:00.000Z', city: 'Brooklyn', state: 'NY', referralSource: null },
+      ],
+      filters: { statuses: [], reps: [], pppStatuses: [], headsetConnectionStatuses: [], preferredPartners: [], referralSources: [], locationAvailability: [], vendorDayStatuses: [] },
+      meta: { dataSource: 'notion-live-cache', lastEditedMax: null, recordsRead: 2, unresolvedLocationCount: 0, geocodedThisRequest: 0, syncedAt: null, stale: false, syncing: false, syncError: null },
+    }),
+  }));
+  await page.route('**/api/territory/boundaries', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ boundaries: [] }) }));
+  await page.route('**/api/territory/markers', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ markers: [] }) }));
+  await page.route('**/api/territory/saved-routes', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ routes: [] }) }));
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockTerritory(page);
+  await page.addInitScript((key) => localStorage.removeItem(key), preferenceKey);
+});
+
+test('toggles subway lines and remembers the device preference', async ({ page }) => {
+  await page.goto('/territory');
+  const toggle = page.getByRole('button', { name: 'Show subway lines' });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+  await toggle.click();
+  const enabled = page.getByRole('button', { name: 'Hide subway lines' });
+  await expect(enabled).toHaveAttribute('aria-pressed', 'true');
+  await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), preferenceKey)).toBe('true');
+
+  await page.reload();
+  await expect(page.getByRole('button', { name: 'Hide subway lines' })).toHaveAttribute('aria-pressed', 'true');
+
+  await page.getByRole('button', { name: 'Hide subway lines' }).click();
+  await expect(page.getByRole('button', { name: 'Show subway lines' })).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('keeps subway context enabled while route visualization changes', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('picc_route_plan_v1', JSON.stringify({ selectedStopIds: ['one', 'two'], orderedStopIds: ['one', 'two'], savedRoutes: [], optimizedRoute: null, updatedAt: new Date().toISOString() })));
+  await page.goto('/territory');
+  await page.getByRole('button', { name: 'Show subway lines' }).click();
+  await page.getByRole('button', { name: 'Visualize Route' }).click();
+  await expect(page.getByRole('button', { name: 'Hide subway lines' })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('button', { name: 'Hide Route' })).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run the new browser test and confirm RED**
+
+Run: `npx playwright test tests/e2e/territory-subway-lines.spec.ts --project=chromium`
+
+Expected: FAIL because the `Show subway lines` control does not exist.
+
+- [ ] **Step 3: Add the train-icon control**
+
+In `components/mobile/territory-map-overlay-controls.tsx`:
+
+- Import `TrainFront` from `lucide-react`.
+- Add required props `showSubwayLines` and `onToggleSubwayLines`.
+- Insert the button directly after Search with:
+
+```tsx
+<button
+  type="button"
+  aria-label={showSubwayLines ? 'Hide subway lines' : 'Show subway lines'}
+  title={showSubwayLines ? 'Hide subway lines' : 'Show subway lines'}
+  aria-pressed={showSubwayLines}
+  className={cn(
+    'picc-soft-transition grid h-10 w-10 place-items-center rounded-lg bg-white/90 shadow hover:bg-white active:scale-[0.94]',
+    showSubwayLines ? 'ring-2 ring-[#cd3814]' : '',
+  )}
+  onClick={onToggleSubwayLines}
+>
+  <TrainFront className={cn('h-5 w-5', showSubwayLines ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
+</button>
+```
+
+- [ ] **Step 4: Own and persist state in `TerritoryMobile`**
+
+In `components/mobile/territory-mobile.tsx`:
+
+- Import `useCallback` plus the preference functions.
+- Add `const [showSubwayLines, setShowSubwayLines] = useState(false);`.
+- Load once after mount without writing a false value first:
+
+```tsx
+useEffect(() => {
+  setShowSubwayLines(loadSubwayLinesPreference(window.localStorage));
+}, []);
+```
+
+- Add explicit user and fallback handlers:
+
+```tsx
+const toggleSubwayLines = useCallback(() => {
+  setShowSubwayLines((current) => {
+    const next = !current;
+    persistSubwayLinesPreference(window.localStorage, next);
+    return next;
+  });
+}, []);
+
+const handleSubwayLinesUnavailable = useCallback(() => {
+  setShowSubwayLines(false);
+  persistSubwayLinesPreference(window.localStorage, false);
+  toast.error('Subway lines are unavailable in Google Maps right now.');
+}, []);
+```
+
+- Pass `showSubwayLines` and `onSubwayLinesUnavailable={handleSubwayLinesUnavailable}` to `TerritoryMapMobile`.
+- Pass `showSubwayLines` and `onToggleSubwayLines={toggleSubwayLines}` to `TerritoryMapOverlayControls`.
+
+- [ ] **Step 5: Pass the state through `TerritoryMapMobile`**
+
+Add both props to `TerritoryMapMobileProps`, destructure them with `showSubwayLines = false`, and forward them to `GoogleTerritoryMap`:
+
+```tsx
+showSubwayLines={showSubwayLines}
+onSubwayLinesUnavailable={onSubwayLinesUnavailable}
+```
+
+- [ ] **Step 6: Extend the Google API boundary and implement the map child**
+
+In `components/territory/google-territory-map.tsx`:
+
+- Import `attachTransitLayer`, `createTransitLayer`, and `TransitMapsApi`.
+- Define `GoogleMapsApi` as the existing map types intersected with `TransitMapsApi`.
+- Add optional props to `GoogleTerritoryMapProps`.
+- Add the focused map child:
+
+```tsx
+function SubwayLayer({
+  enabled,
+  onUnavailable,
+}: {
+  enabled: boolean;
+  onUnavailable?: () => void;
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!enabled || !map) return;
+    const layer = createTransitLayer(getGoogleMapsApi());
+    if (!layer) {
+      onUnavailable?.();
+      return;
+    }
+    return attachTransitLayer(layer, map);
+  }, [enabled, map, onUnavailable]);
+
+  return null;
+}
+```
+
+- Render `<SubwayLayer enabled={showSubwayLines} onUnavailable={onSubwayLinesUnavailable} />` next to `RouteLine` inside `GoogleMap`.
+
+- [ ] **Step 7: Run focused unit and browser tests**
+
+Run: `npm test -- lib/territory/subway-lines.test.ts`
+
+Expected: PASS.
+
+Run: `npx playwright test tests/e2e/territory-subway-lines.spec.ts --project=chromium`
+
+Expected: PASS for toggle, persistence, and route compatibility.
+
+- [ ] **Step 8: Run lint and typecheck**
+
+Run: `npm run lint -- --no-cache && npm run typecheck`
+
+Expected: PASS with no missing prop or Google Maps type errors.
+
+- [ ] **Step 9: Commit the complete interactive feature**
+
+```bash
+git add components/mobile/territory-mobile.tsx components/mobile/territory-map-mobile.tsx components/mobile/territory-map-overlay-controls.tsx components/territory/google-territory-map.tsx tests/e2e/territory-subway-lines.spec.ts
+git commit -m "feat: add persistent subway lines toggle"
+```
+
+---
+
+### Task 3: Responsive browser QA, visual evidence, and final verification
+
+**Files:**
+- Modify: `tests/e2e/territory-subway-lines.spec.ts`
+- Modify: `SESSION.md`
+- Evidence only: `/tmp/picc-subway-desktop.png`, `/tmp/picc-subway-mobile.png`
+
+**Interfaces:**
+- Verifies the complete feature without creating production data.
+
+- [ ] **Step 1: Add viewport-fit assertions**
+
+Append a test that runs at `{ width: 390, height: 844 }`, enables the control, and asserts its bounding box stays within the viewport and does not overlap the bottom navigation:
+
+```ts
+test('keeps the subway control reachable on a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/territory');
+  const toggle = page.getByRole('button', { name: 'Show subway lines' });
+  await toggle.click();
+  const box = await page.getByRole('button', { name: 'Hide subway lines' }).boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(390);
+  expect(box!.y + box!.height).toBeLessThan(768);
+});
+```
+
+- [ ] **Step 2: Write the QA inventory before browser signoff**
+
+Record these checks in the working notes before running the browser:
+
+- Default off and exact accessible copy.
+- Toggle on/off and local preference value.
+- Reload persistence.
+- Native overlay adapter attachment and cleanup.
+- Route visualization remains independently usable.
+- Search, layers, and filters remain reachable.
+- Desktop 1440x900 and mobile 390x844 layout fit.
+- Exploratory: blocked local storage.
+- Exploratory: missing `TransitLayer` API fallback.
+
+- [ ] **Step 3: Run the complete automated validation**
+
+Run: `npm run verify`
+
+Expected: lint, typecheck, all Vitest files, Prisma validation, and production build PASS.
+
+Run: `npm run test:e2e`
+
+Expected: all Playwright smoke and subway tests PASS.
+
+- [ ] **Step 4: Run headed desktop and mobile interaction passes**
+
+Start the isolated server with `npm run dev:agent`. Use the available browser-testing workflow to exercise the QA inventory at 1440x900 and 390x844. Use intercepted/fake territory responses; do not create records or mutate production data.
+
+Capture:
+
+```txt
+/tmp/picc-subway-desktop.png
+/tmp/picc-subway-mobile.png
+```
+
+Each screenshot must show the map view, the active train control, and unobstructed surrounding controls. If a configured Google API key is available, center on NYC and capture visible transit routes; otherwise label the screenshots as local control-state proof and reserve transit rendering for authenticated production verification.
+
+- [ ] **Step 5: Update session proof and run diff review**
+
+Add the exact commands, pass counts, screenshot paths, and any remaining Google-rendering risk to `SESSION.md`.
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- components lib/territory tests/e2e SESSION.md
+```
+
+Expected: no whitespace errors, no unrelated files, no secrets, no production data, and no Map-APP changes.
+
+- [ ] **Step 6: Commit verification notes**
+
+```bash
+git add tests/e2e/territory-subway-lines.spec.ts SESSION.md
+git commit -m "test: verify subway toggle browser behavior"
+```
+
+- [ ] **Step 7: Publish and update draft PR #158**
+
+Push the branch. Update PR #158 with validation commands, screenshots, remaining risk, and changed-file scope. Do not mark it ready or merge until the required review and verification-before-completion checks pass.

--- a/docs/superpowers/specs/2026-08-12-subway-lines-toggle-design.md
+++ b/docs/superpowers/specs/2026-08-12-subway-lines-toggle-design.md
@@ -1,0 +1,65 @@
+# Subway Lines Toggle Design
+
+## Goal
+
+Give PICC field reps optional subway context while they inspect accounts and plan visits on the territory map. The feature must be immediately usable from the map UI and remember each device's preference.
+
+## User experience
+
+The existing right-side map toolbar gains a train-icon button directly below Search. The button uses the same 40px operational control shape, neutral off state, and PICC-red active ring as adjacent map controls.
+
+- Off: accessible label and title read `Show subway lines`; the current map remains unchanged.
+- On: accessible label and title read `Hide subway lines`; the icon and focus ring use the existing PICC-red active treatment.
+- Activation updates the map immediately without closing sheets, moving the camera, changing filters, or altering selected accounts.
+- The chosen state survives reloads in the same browser on the same device.
+- First use defaults to off so the existing map presentation does not change unexpectedly.
+
+Google controls the precise route colors, station labels, and visibility thresholds. The result should provide the same kind of subway context as the supplied reference, not attempt to copy Apple Maps styling.
+
+## Architecture
+
+Use the Google Maps JavaScript API `TransitLayer` inside the existing `GoogleTerritoryMap` provider boundary. A small map-child component owns the Google overlay lifecycle: create the layer when enabled, attach it to the current map, and detach it during disable or unmount.
+
+The territory mobile page owns the boolean UI preference. A focused territory utility defines the storage key and safely reads and writes the value. The state flows through `TerritoryMapMobile` into `GoogleTerritoryMap`, and into `TerritoryMapOverlayControls` for the button state.
+
+This is additive. It introduces no API route, database field, external dataset, map provider, or account-data mutation.
+
+## Data flow
+
+1. On client initialization, read the device-local preference. Missing, malformed, or inaccessible storage resolves to `false`.
+2. Render the map and toolbar from the resolved state.
+3. On button activation, invert the state and persist the new boolean.
+4. The map child attaches or detaches `google.maps.TransitLayer` based on that state.
+5. Account pins, routes, boundaries, markers, selection state, and camera state remain independent.
+
+## Failure behavior
+
+- If local storage is unavailable, the toggle still works for the current page session.
+- If Google Maps does not expose `TransitLayer`, do not break the map. Leave all PICC overlays interactive and return the visible toggle state to off with a concise toast explaining that subway lines are unavailable.
+- Detach the overlay during component cleanup to prevent stale map references.
+
+## Accessibility and responsive behavior
+
+- The button is a native `button` with state-specific `aria-label`, `title`, and `aria-pressed`.
+- Active styling is not the only state signal; accessible properties and tooltips state the action.
+- The 40px control follows the existing toolbar density and remains reachable at mobile and desktop viewports.
+- The new control must not obscure Google attribution, zoom controls, focused account cards, or the bottom navigation safe area.
+
+## Testing
+
+1. Add a failing unit test for preference parsing, fallback, and persistence.
+2. Add a failing unit test around the overlay adapter for map attachment, detachment, cleanup, and unavailable-API behavior.
+3. Use Playwright to verify state-specific button text, `aria-pressed`, activation, persistence after reload, and compatibility with route visualization.
+4. Run `npm run verify`.
+5. Run targeted Playwright coverage and `npm run test:e2e`.
+6. Test default-off, enable, disable, reload persistence, route visualization compatibility, and unavailable-layer fallback.
+7. Capture desktop and mobile screenshots with subway lines enabled.
+
+## Acceptance criteria
+
+- A train-icon subway control is visible directly on the territory map.
+- Tapping it immediately shows or hides Google transit routes and stations.
+- The button exposes correct visible and accessible active state.
+- The choice persists across reloads on the same device.
+- Existing territory interactions and overlays continue working.
+- Failure to load the optional transit overlay cannot make the map unusable.

--- a/lib/territory/subway-lines.test.ts
+++ b/lib/territory/subway-lines.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SUBWAY_LINES_STORAGE_KEY,
+  attachTransitLayer,
+  createTransitLayer,
+  loadSubwayLinesPreference,
+  persistSubwayLinesPreference,
+} from '@/lib/territory/subway-lines';
+
+describe('subway lines preference', () => {
+  it('defaults to off for missing, malformed, or inaccessible storage', () => {
+    expect(loadSubwayLinesPreference(null)).toBe(false);
+    expect(loadSubwayLinesPreference({ getItem: () => null })).toBe(false);
+    expect(loadSubwayLinesPreference({ getItem: () => 'yes' })).toBe(false);
+    expect(
+      loadSubwayLinesPreference({
+        getItem: () => {
+          throw new Error('blocked');
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('loads and persists exact boolean values', () => {
+    expect(loadSubwayLinesPreference({ getItem: () => 'true' })).toBe(true);
+    expect(loadSubwayLinesPreference({ getItem: () => 'false' })).toBe(false);
+
+    const setItem = vi.fn();
+    expect(persistSubwayLinesPreference({ setItem }, true)).toBe(true);
+    expect(setItem).toHaveBeenCalledWith(SUBWAY_LINES_STORAGE_KEY, 'true');
+  });
+
+  it('reports a failed write without throwing', () => {
+    expect(
+      persistSubwayLinesPreference(
+        {
+          setItem: () => {
+            throw new Error('quota');
+          },
+        },
+        true,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('Google transit layer adapter', () => {
+  it('returns null when the optional Google API is unavailable', () => {
+    expect(createTransitLayer(null)).toBeNull();
+    expect(createTransitLayer({})).toBeNull();
+  });
+
+  it('attaches once and detaches during cleanup', () => {
+    const setMap = vi.fn();
+    class TransitLayer {
+      setMap = setMap;
+    }
+    const layer = createTransitLayer({ TransitLayer });
+    expect(layer).not.toBeNull();
+
+    const map = { id: 'territory-map' };
+    const cleanup = attachTransitLayer(layer!, map);
+    expect(setMap).toHaveBeenCalledWith(map);
+    cleanup();
+    expect(setMap).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/lib/territory/subway-lines.test.ts
+++ b/lib/territory/subway-lines.test.ts
@@ -3,11 +3,22 @@ import {
   SUBWAY_LINES_STORAGE_KEY,
   attachTransitLayer,
   createTransitLayer,
+  getBrowserLocalStorage,
   loadSubwayLinesPreference,
   persistSubwayLinesPreference,
 } from '@/lib/territory/subway-lines';
 
 describe('subway lines preference', () => {
+  it('returns null when the browser blocks access to the localStorage property', () => {
+    const browser = Object.defineProperty({}, 'localStorage', {
+      get() {
+        throw new DOMException('Blocked', 'SecurityError');
+      },
+    });
+
+    expect(getBrowserLocalStorage(browser)).toBeNull();
+  });
+
   it('defaults to off for missing, malformed, or inaccessible storage', () => {
     expect(loadSubwayLinesPreference(null)).toBe(false);
     expect(loadSubwayLinesPreference({ getItem: () => null })).toBe(false);

--- a/lib/territory/subway-lines.ts
+++ b/lib/territory/subway-lines.ts
@@ -2,6 +2,7 @@ export const SUBWAY_LINES_STORAGE_KEY = 'picc:territory:subway-lines';
 
 export type StorageReader = { getItem: (key: string) => string | null };
 export type StorageWriter = { setItem: (key: string, value: string) => void };
+export type BrowserStorage = StorageReader & StorageWriter;
 
 export type TransitLayerHandle = {
   setMap: (map: unknown | null) => void;
@@ -10,6 +11,14 @@ export type TransitLayerHandle = {
 export type TransitMapsApi = {
   TransitLayer?: new () => TransitLayerHandle;
 };
+
+export function getBrowserLocalStorage(browser: unknown): BrowserStorage | null {
+  try {
+    return (browser as { localStorage?: BrowserStorage } | null | undefined)?.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export function loadSubwayLinesPreference(storage: StorageReader | null | undefined): boolean {
   try {

--- a/lib/territory/subway-lines.ts
+++ b/lib/territory/subway-lines.ts
@@ -1,0 +1,42 @@
+export const SUBWAY_LINES_STORAGE_KEY = 'picc:territory:subway-lines';
+
+export type StorageReader = { getItem: (key: string) => string | null };
+export type StorageWriter = { setItem: (key: string, value: string) => void };
+
+export type TransitLayerHandle = {
+  setMap: (map: unknown | null) => void;
+};
+
+export type TransitMapsApi = {
+  TransitLayer?: new () => TransitLayerHandle;
+};
+
+export function loadSubwayLinesPreference(storage: StorageReader | null | undefined): boolean {
+  try {
+    return storage?.getItem(SUBWAY_LINES_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function persistSubwayLinesPreference(
+  storage: StorageWriter | null | undefined,
+  enabled: boolean,
+): boolean {
+  try {
+    if (!storage) return false;
+    storage.setItem(SUBWAY_LINES_STORAGE_KEY, String(enabled));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createTransitLayer(mapsApi: TransitMapsApi | null | undefined): TransitLayerHandle | null {
+  return mapsApi?.TransitLayer ? new mapsApi.TransitLayer() : null;
+}
+
+export function attachTransitLayer(layer: TransitLayerHandle, map: unknown): () => void {
+  layer.setMap(map);
+  return () => layer.setMap(null);
+}

--- a/tests/e2e/territory-subway-lines.spec.ts
+++ b/tests/e2e/territory-subway-lines.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const preferenceKey = 'picc:territory:subway-lines';
+
+async function mockTerritory(page: Page) {
+  await page.route('**/api/territory/stores**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        stores: [
+          {
+            id: 'one',
+            notionPageId: 'one',
+            name: 'Downtown One',
+            status: 'Lead - Hot',
+            statusKey: 'lead-hot',
+            statusColor: 'red',
+            pinKind: 'lead',
+            repNames: [],
+            repEmails: [],
+            lat: 40.7128,
+            lng: -74.006,
+            locationLabel: 'New York',
+            locationAddress: 'New York, NY',
+            locationSource: 'google-address-cache',
+            locationPrecision: 'address',
+            isApproximate: false,
+            lastEditedTime: '2026-08-12T00:00:00.000Z',
+            city: 'New York',
+            state: 'NY',
+            referralSource: null,
+          },
+          {
+            id: 'two',
+            notionPageId: 'two',
+            name: 'Brooklyn Two',
+            status: 'Lead - Hot',
+            statusKey: 'lead-hot',
+            statusColor: 'red',
+            pinKind: 'lead',
+            repNames: [],
+            repEmails: [],
+            lat: 40.6943,
+            lng: -73.9918,
+            locationLabel: 'Brooklyn',
+            locationAddress: 'Brooklyn, NY',
+            locationSource: 'google-address-cache',
+            locationPrecision: 'address',
+            isApproximate: false,
+            lastEditedTime: '2026-08-12T00:00:00.000Z',
+            city: 'Brooklyn',
+            state: 'NY',
+            referralSource: null,
+          },
+        ],
+        filters: {
+          statuses: [],
+          reps: [],
+          pppStatuses: [],
+          headsetConnectionStatuses: [],
+          preferredPartners: [],
+          referralSources: [],
+          locationAvailability: [],
+          vendorDayStatuses: [],
+        },
+        meta: {
+          dataSource: 'notion-live-cache',
+          lastEditedMax: null,
+          recordsRead: 2,
+          unresolvedLocationCount: 0,
+          geocodedThisRequest: 0,
+          syncedAt: null,
+          stale: false,
+          syncing: false,
+          syncError: null,
+        },
+      }),
+    }),
+  );
+  await page.route('**/api/territory/boundaries', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ boundaries: [] }) }),
+  );
+  await page.route('**/api/territory/markers', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ markers: [] }) }),
+  );
+  await page.route('**/api/territory/saved-routes', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ routes: [] }) }),
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockTerritory(page);
+  await page.addInitScript((key) => {
+    if (sessionStorage.getItem('picc-subway-test-ready')) return;
+    localStorage.removeItem(key);
+    sessionStorage.setItem('picc-subway-test-ready', 'true');
+  }, preferenceKey);
+});
+
+test('toggles subway lines and remembers the device preference', async ({ page }) => {
+  await page.goto('/territory');
+  const toggle = page.getByRole('button', { name: 'Show subway lines' });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+  await toggle.click();
+  const enabled = page.getByRole('button', { name: 'Hide subway lines' });
+  await expect(enabled).toHaveAttribute('aria-pressed', 'true');
+  await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), preferenceKey)).toBe('true');
+
+  await page.reload();
+  await expect(page.getByRole('button', { name: 'Hide subway lines' })).toHaveAttribute('aria-pressed', 'true');
+
+  await page.getByRole('button', { name: 'Hide subway lines' }).click();
+  await expect(page.getByRole('button', { name: 'Show subway lines' })).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('keeps subway context enabled while route visualization changes', async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem(
+      'picc_route_plan_v1',
+      JSON.stringify({
+        selectedStopIds: ['one', 'two'],
+        orderedStopIds: ['one', 'two'],
+        savedRoutes: [],
+        optimizedRoute: null,
+        updatedAt: new Date().toISOString(),
+      }),
+    ),
+  );
+  await page.goto('/territory');
+  await page.getByRole('button', { name: 'Show subway lines' }).click();
+  await page.getByRole('button', { name: 'Visualize Route' }).click();
+  await expect(page.getByRole('button', { name: 'Hide subway lines' })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('button', { name: 'Hide Route' })).toBeVisible();
+});
+
+test('keeps the subway control reachable on a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/territory');
+  await page.getByRole('button', { name: 'Show subway lines' }).click();
+
+  const toggle = page.getByRole('button', { name: 'Hide subway lines' });
+  const box = await toggle.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(390);
+  expect(box!.y + box!.height).toBeLessThan(768);
+  await expect(page.getByRole('button', { name: 'Search dispensaries on the map' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Open territory layers' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Open filters' })).toBeVisible();
+});


### PR DESCRIPTION
## Why
Field reps need subway context while planning NYC account visits on the territory map.

Closes #157

## What changed
- Added a train-icon toggle directly to the territory map toolbar.
- Mounted the native Google Maps `TransitLayer` when enabled and detached it on disable/unmount.
- Remembered the preference on the current browser/device.
- Added accurate `Show subway lines` / `Hide subway lines` labels and `aria-pressed` state.
- Kept route visualization, account pins, boundaries, search, layers, filters, and camera behavior independent.
- Guarded unavailable Google transit APIs and privacy modes that block local storage.

## Out of scope
- Custom MTA data ingestion.
- Route optimization changes.
- Schema, auth, environment, or production-data changes.
- Map-APP changes.

## Owned path globs
- components/mobile/territory-mobile.tsx
- components/mobile/territory-map-overlay-controls.tsx
- components/mobile/territory-map-mobile.tsx
- components/territory/google-territory-map.tsx
- lib/territory/subway-lines*
- tests/e2e/territory-subway-lines.spec.ts
- docs/superpowers/specs/*subway*
- docs/superpowers/plans/*subway*
- SESSION.md

## Active PR overlap review
Checked PRs #144, #135, and #82. PRs #135 and #82 do not overlap. PR #144 is a broad legacy monorepo migration with no declared owned globs and conflicts with the current canonical no-monorepo architecture; this branch remains a surgical change against current main.

## Validation
- RED unit test observed before the subway utility existed.
- RED browser test observed before the control existed.
- `npm run verify`: passed lint, typecheck, 27 Vitest files / 126 tests, Prisma validation, and production build.
- `npm run test:e2e`: 18/18 passed.
- Focused Playwright coverage verifies on/off state, accessibility, device persistence after reload, route coexistence, and 390x844 reachability.
- Independent review: no Critical or Important findings remain.

## Visual proof
- Desktop: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-desktop.png`
- Mobile: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-mobile.png`

Local screenshots prove active control state and responsive fit. The isolated environment lacks a Google Maps API key, so actual subway geometry remains a post-deploy authenticated production verification item.

## Risk
Low and additive. Google controls transit rendering, route colors, station labels, and zoom thresholds.