### PR TITLE
Keep territory save action above bottom navigation

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,62 +1,48 @@
-# Session: Issue 159 Subway Visibility
+# Session: Issue 161 Territory Save Clearance
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/159
-- Branch: `codex/159-subway-visibility`
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/161
+- Draft PR: pending initial branch publication
+- Branch: `codex/161-territory-save-clearance`
 
 ## Scope
 
-- Replace the faint native Google transit layer with a custom MTA subway overlay.
-- Match the supplied Apple Maps reference with thicker route-colored strokes, dark contrast casing, and readable route badges.
-- Move the subway toggle directly below the Filters control.
-- Preserve the device-local preference and all existing territory-map interactions.
+- Keep the territory boundary editor fully above the fixed bottom navigation.
+- Keep the editor body independently scrollable when its point list exceeds the available height.
+- Keep the `Save Boundary` footer visible, keyboard reachable, and clickable at short desktop and mobile viewports.
+- Add focused regression coverage for the reported overlap.
 
 ## Out of scope
 
-- Replacing Google Maps as the base map.
-- Copying Apple map tiles, proprietary typography, POI data, or trade dress.
-- Live arrival times, service alerts, trip planning, or schedule ingestion.
-- Database, schema, authentication, authorization, environment, or production-data changes.
-- Any change to `/Users/brycejohnson/Code/map-app`.
+- Boundary persistence, API, database, schema, authentication, authorization, or production-data changes.
+- Map-provider, map-control, or primary-navigation redesign.
+- Changes to `/Users/brycejohnson/Code/map-app`.
 
 ## Constraints
 
-- Keep Google Maps as the only map provider.
-- Use public official MTA route geometry and document its source/version.
-- Keep subway labels legible without blocking dispensary pins or map gestures.
-- Use failing tests before behavior edits.
+- Reuse the existing `--picc-bottom-nav-clearance` design token.
+- Preserve the current Google Maps boundary editing workflow and fixed primary navigation.
+- Use a failing browser behavior test before implementation.
 - Run `npm run verify` and `npm run test:e2e` before completion.
-- Capture desktop and mobile browser evidence.
+- Capture desktop and mobile user-visible evidence.
 
 ## Ownership and overlap
 
-- Planned owned paths: `components/mobile/territory-map-overlay-controls.tsx`, `components/territory/google-territory-map.tsx`, `lib/territory/subway-*`, `public/data/subway-*`, focused tests, this session file, and the issue-159 spec/plan.
-- Open PRs #144, #135, and #82 were checked. PRs #135 and #82 do not overlap. PR #144 is a stale broad monorepo migration that conflicts with the repository's current canonical architecture and declares no path ownership.
+- Owned paths: `components/mobile/territory-boundary-sheet.tsx`, focused territory editor tests, `SESSION.md`, and UI evidence.
+- Open PRs #160, #144, #135, and #82 were checked.
+- PR #160 owns subway/map-overlay paths but does not own the boundary sheet.
+- PRs #135 and #82 do not overlap.
+- PR #144 is a stale broad monorepo migration that conflicts with the canonical architecture and declares no owned paths.
 
 ## Validation plan
 
-- RED unit coverage for route styling, route grouping/offset behavior, zoom-based badge visibility, and invalid geometry.
-- RED Playwright coverage for Filters -> Subway control order, persistence, mobile reachability, and coexistence with route visualization.
-- Static checks, complete unit suite, production build, and complete E2E suite.
-- Browser screenshots at desktop and 390x844 mobile viewports.
+- RED: reproduce the footer/navigation intersection with a populated editor at the reported short viewport.
+- GREEN: verify the save footer stays above the primary navigation while the editor body scrolls.
+- Exercise the save control with mouse and keyboard.
+- Check mobile portrait, mobile landscape, short desktop, and standard desktop viewport fit.
+- Run `npm run verify` and the complete Playwright suite.
 
-## Validation evidence
+## Remaining verification boundary
 
-- Official source: MTA NYCT Subway static GTFS feed `20260807-H-rockaways-extension-removed`, published by MTA New York City Transit.
-- Generated asset: 327,700 bytes, 28 services, 98 route paths, and 475 parent stations. The raw 43 MB GTFS archive is not committed.
-- RED unit proof: `lib/territory/subway-overlay.test.ts` failed because the overlay module did not exist; `lib/territory/subway-lines.test.ts` then failed because the custom loader/controller exports did not exist.
-- RED browser proof: the control-order test failed with Subway at y=169.75 above Filters ending at y=306.88.
-- Focused overlay tests: 13 passed.
-- Focused subway Playwright suite: 4 passed after moving Subway below Filters.
-- `npm run verify`: passed lint, typecheck, 28 Vitest files with 133 tests, Prisma validation, and the Next.js production build.
-- `npm run test:e2e`: 19 Playwright tests passed.
-- Real Google Maps visual verification used mocked territory responses and the existing local browser Maps configuration; no production record was created or changed.
-- Desktop screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-bold-desktop.png`.
-- Mobile screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff8d5-e100-7570-ad57-fb48755260e4/picc-subway-bold-mobile.png`.
-
-## Browser verdict
-
-The map shows thick official-colored routes with dark casing and readable service badges at both desktop and 390x844. The right toolbar order is Search, Territory Layers, Filters, Subway. Account-map gestures remain available, and unit/browser coverage proves toggle cleanup, persistence, and route-visualization coexistence.
-
-The only browser console errors during visual capture were expected local database requests before interception and the unavailable local audit endpoint; the Google Maps scripts and `/data/nyc-subway-overlay.v1.json` returned HTTP 200.
+Implementation and deployment evidence pending.

--- a/SESSION.md
+++ b/SESSION.md
@@ -38,9 +38,10 @@
 ## Validation evidence
 
 - RED: at 1440x800, the primary navigation began at y=704 while `Save Boundary` ended at y=821.5.
-- GREEN: the focused Playwright suite passed all four checks covering internal scrolling, keyboard save, mobile portrait, mobile landscape, short desktop, and the reported 1800x1280 viewport.
+- GREEN: the focused Playwright suite passed all four checks covering real internal scroll movement with a stationary footer, tab-order keyboard save, mobile portrait, mobile landscape with at least a 44px usable form body, short desktop, and the reported 1800x1280 viewport.
 - `npm run verify`: passed lint, typecheck, 27 Vitest files with 126 tests, Prisma validation, and the Next.js production build.
 - `npm run test:e2e`: 22 Playwright tests passed.
+- Read-only review found the initial landscape test allowed a collapsed scroll body; the strengthened test failed at 0px, the height-aware inset was corrected, and the focused four-viewport suite passed again.
 - Desktop screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-desktop.png`.
 - Mobile screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-mobile.png`.
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -3,7 +3,7 @@
 ## Linked work
 
 - GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/161
-- Draft PR: pending initial branch publication
+- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/162
 - Branch: `codex/161-territory-save-clearance`
 
 ## Scope
@@ -35,14 +35,15 @@
 - PRs #135 and #82 do not overlap.
 - PR #144 is a stale broad monorepo migration that conflicts with the canonical architecture and declares no owned paths.
 
-## Validation plan
+## Validation evidence
 
-- RED: reproduce the footer/navigation intersection with a populated editor at the reported short viewport.
-- GREEN: verify the save footer stays above the primary navigation while the editor body scrolls.
-- Exercise the save control with mouse and keyboard.
-- Check mobile portrait, mobile landscape, short desktop, and standard desktop viewport fit.
-- Run `npm run verify` and the complete Playwright suite.
+- RED: at 1440x800, the primary navigation began at y=704 while `Save Boundary` ended at y=821.5.
+- GREEN: the focused Playwright suite passed all four checks covering internal scrolling, keyboard save, mobile portrait, mobile landscape, short desktop, and the reported 1800x1280 viewport.
+- `npm run verify`: passed lint, typecheck, 27 Vitest files with 126 tests, Prisma validation, and the Next.js production build.
+- `npm run test:e2e`: 22 Playwright tests passed.
+- Desktop screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-desktop.png`.
+- Mobile screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-mobile.png`.
 
 ## Remaining verification boundary
 
-Implementation and deployment evidence pending.
+The local UI uses intercepted read and save responses and does not mutate production data. Production proof remains pending merge and deployment.

--- a/components/mobile/territory-boundary-sheet.tsx
+++ b/components/mobile/territory-boundary-sheet.tsx
@@ -285,9 +285,9 @@ export function TerritoryBoundaryEditor({
   const isNewBoundary = !boundary.id;
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 top-[96px] z-[5300] px-3 md:inset-x-auto md:right-4 md:top-[106px] md:w-[380px] md:max-w-[calc(100vw-32px)] md:px-0 lg:w-[420px]">
-      <div className="pointer-events-auto mx-auto flex max-h-[calc(100dvh-112px)] max-w-[720px] flex-col rounded-2xl border border-[#d8b0a5] bg-[#fffaf8] shadow-[0_8px_28px_rgba(0,0,0,0.18)] md:max-h-[calc(100dvh-126px)]">
-        <div className="flex items-center justify-between border-b border-[#f0d6ce] px-4 py-3">
+    <div className="pointer-events-none fixed inset-x-0 bottom-[max(var(--picc-bottom-nav-clearance),calc(var(--picc-bottom-nav-height)_+_12px))] top-[clamp(12px,12dvh,96px)] z-[5300] px-3 md:inset-x-auto md:right-4 md:w-[380px] md:max-w-[calc(100vw-32px)] md:px-0 lg:w-[420px]">
+      <div className="pointer-events-auto mx-auto flex max-h-full max-w-[720px] flex-col rounded-2xl border border-[#d8b0a5] bg-[#fffaf8] shadow-[0_8px_28px_rgba(0,0,0,0.18)]">
+        <div className="flex shrink-0 items-center justify-between border-b border-[#f0d6ce] px-4 py-3">
           <div>
             <p className="text-[16px] font-semibold text-[#23262d]">{isNewBoundary ? 'Draw Territory Boundary' : 'Edit Territory Boundary'}</p>
             <p className="mt-1 text-[12px] text-[#7a5e56]">
@@ -301,7 +301,7 @@ export function TerritoryBoundaryEditor({
           </button>
         </div>
 
-        <div className="overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-y-auto" data-testid="territory-boundary-editor-scroll">
           <div className="grid gap-3 px-4 py-4 md:grid-cols-1">
             <label className="block">
             <span className="mb-1 block text-[12px] font-semibold uppercase tracking-wide text-[#7b7e87]">Name</span>
@@ -406,7 +406,7 @@ export function TerritoryBoundaryEditor({
           </div>
         </div>
 
-        <div className="border-t border-[#f0d6ce] px-4 py-3">
+        <div className="shrink-0 border-t border-[#f0d6ce] px-4 py-3">
           <div className="flex items-center justify-between gap-3">
             <p className="text-[12px] text-[#7b7e87]">{boundary.coordinates.length} point{boundary.coordinates.length === 1 ? '' : 's'} captured</p>
             <button

--- a/components/mobile/territory-boundary-sheet.tsx
+++ b/components/mobile/territory-boundary-sheet.tsx
@@ -285,7 +285,7 @@ export function TerritoryBoundaryEditor({
   const isNewBoundary = !boundary.id;
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-[max(var(--picc-bottom-nav-clearance),calc(var(--picc-bottom-nav-height)_+_12px))] top-[clamp(12px,12dvh,96px)] z-[5300] px-3 md:inset-x-auto md:right-4 md:w-[380px] md:max-w-[calc(100vw-32px)] md:px-0 lg:w-[420px]">
+    <div className="pointer-events-none fixed inset-x-0 bottom-[max(var(--picc-bottom-nav-clearance),calc(var(--picc-bottom-nav-height)_+_12px))] top-[clamp(0px,calc(30dvh_-_117px),96px)] z-[5300] px-3 md:inset-x-auto md:right-4 md:w-[380px] md:max-w-[calc(100vw-32px)] md:px-0 lg:w-[420px]">
       <div className="pointer-events-auto mx-auto flex max-h-full max-w-[720px] flex-col rounded-2xl border border-[#d8b0a5] bg-[#fffaf8] shadow-[0_8px_28px_rgba(0,0,0,0.18)]">
         <div className="flex shrink-0 items-center justify-between border-b border-[#f0d6ce] px-4 py-3">
           <div>

--- a/tests/e2e/territory-boundary-editor.spec.ts
+++ b/tests/e2e/territory-boundary-editor.spec.ts
@@ -118,7 +118,8 @@ test('keeps Save Boundary above the fixed primary navigation at a short viewport
     }),
   );
   const save = page.getByRole('button', { name: 'Save Boundary' });
-  await save.focus();
+  await page.getByRole('button', { name: 'Delete' }).last().focus();
+  await page.keyboard.press('Tab');
   await expect(save).toBeFocused();
   await save.press('Enter');
   await expect(page.getByText('Territory boundary updated')).toBeVisible();
@@ -133,6 +134,17 @@ for (const viewport of [
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await openPopulatedBoundaryEditor(page);
     await expectSaveAboveNavigation(page);
+    if (viewport.name === 'mobile landscape') {
+      const scrollBody = page.getByTestId('territory-boundary-editor-scroll');
+      const save = page.getByRole('button', { name: 'Save Boundary' });
+      const footerYBeforeScroll = (await save.boundingBox())!.y;
+      expect(await scrollBody.evaluate((element) => element.clientHeight)).toBeGreaterThanOrEqual(44);
+      await scrollBody.evaluate((element) => {
+        element.scrollTop = 100;
+      });
+      expect(await scrollBody.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+      expect((await save.boundingBox())!.y).toBe(footerYBeforeScroll);
+    }
     if (viewport.name === 'mobile portrait' || viewport.name === 'reported desktop') {
       await page.screenshot({ path: testInfo.outputPath(`${viewport.name.replaceAll(' ', '-')}.png`) });
     }

--- a/tests/e2e/territory-boundary-editor.spec.ts
+++ b/tests/e2e/territory-boundary-editor.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const coordinates: [number, number][] = [
+  [-73.96628, 40.73636],
+  [-73.93075, 40.73362],
+  [-73.94946, 40.71606],
+  [-73.95813, 40.70728],
+  [-73.97503, 40.71203],
+  [-73.98284, 40.72392],
+  [-73.97931, 40.73148],
+  [-73.97144, 40.73821],
+];
+
+async function mockTerritory(page: Page) {
+  await page.route('**/api/territory/stores**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        stores: [],
+        filters: {
+          statuses: [],
+          reps: [],
+          pppStatuses: [],
+          headsetConnectionStatuses: [],
+          preferredPartners: [],
+          referralSources: [],
+          locationAvailability: [],
+          vendorDayStatuses: [],
+        },
+        meta: {
+          dataSource: 'notion-live-cache',
+          lastEditedMax: null,
+          recordsRead: 0,
+          unresolvedLocationCount: 0,
+          geocodedThisRequest: 0,
+          syncedAt: null,
+          stale: false,
+          syncing: false,
+          syncError: null,
+        },
+      }),
+    }),
+  );
+  await page.route('**/api/territory/boundaries', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        boundaries: [
+          {
+            id: 'queens-east',
+            name: 'Queens East',
+            description: 'Reported short-viewport regression fixture',
+            color: '#1746ff',
+            borderWidth: 2,
+            isVisibleByDefault: true,
+            coordinates,
+            createdAt: '2026-08-12T00:00:00.000Z',
+            updatedAt: '2026-08-12T00:00:00.000Z',
+          },
+        ],
+      }),
+    }),
+  );
+  await page.route('**/api/territory/markers', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ markers: [] }) }),
+  );
+  await page.route('**/api/territory/saved-routes', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ routes: [] }) }),
+  );
+}
+
+async function openPopulatedBoundaryEditor(page: Page) {
+  await mockTerritory(page);
+  await page.goto('/territory');
+  await page.getByRole('button', { name: 'Open territory layers' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
+}
+
+async function expectSaveAboveNavigation(page: Page) {
+  const save = page.getByRole('button', { name: 'Save Boundary' });
+  const navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+  await expect(save).toBeVisible();
+
+  const [saveBox, navigationBox] = await Promise.all([save.boundingBox(), navigation.boundingBox()]);
+  expect(saveBox).not.toBeNull();
+  expect(navigationBox).not.toBeNull();
+  expect(saveBox!.y + saveBox!.height).toBeLessThanOrEqual(navigationBox!.y);
+}
+
+test('keeps Save Boundary above the fixed primary navigation at a short viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 800 });
+  await openPopulatedBoundaryEditor(page);
+  await expectSaveAboveNavigation(page);
+
+  const scrollBody = page.getByTestId('territory-boundary-editor-scroll');
+  const scrollMetrics = await scrollBody.evaluate((element) => ({ clientHeight: element.clientHeight, scrollHeight: element.scrollHeight }));
+  expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight);
+
+  await page.route('**/api/territory/boundaries/queens-east', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        boundary: {
+          id: 'queens-east',
+          name: 'Queens East',
+          description: 'Reported short-viewport regression fixture',
+          color: '#1746ff',
+          borderWidth: 2,
+          isVisibleByDefault: true,
+          coordinates,
+          createdAt: '2026-08-12T00:00:00.000Z',
+          updatedAt: '2026-08-12T00:05:00.000Z',
+        },
+      }),
+    }),
+  );
+  const save = page.getByRole('button', { name: 'Save Boundary' });
+  await save.focus();
+  await expect(save).toBeFocused();
+  await save.press('Enter');
+  await expect(page.getByText('Territory boundary updated')).toBeVisible();
+});
+
+for (const viewport of [
+  { name: 'mobile portrait', width: 390, height: 844 },
+  { name: 'mobile landscape', width: 844, height: 390 },
+  { name: 'reported desktop', width: 1800, height: 1280 },
+]) {
+  test(`keeps the boundary save action reachable at ${viewport.name}`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await openPopulatedBoundaryEditor(page);
+    await expectSaveAboveNavigation(page);
+    if (viewport.name === 'mobile portrait' || viewport.name === 'reported desktop') {
+      await page.screenshot({ path: testInfo.outputPath(`${viewport.name.replaceAll(' ', '-')}.png`) });
+    }
+  });
+}


### PR DESCRIPTION
## Why
The territory boundary editor extended behind the fixed primary navigation at shorter viewport heights, hiding the Save Boundary action and preventing users from completing the workflow.

Closes #161

## What changed
- Bound the boundary editor between a height-aware top inset and the existing bottom-navigation clearance
- Kept the header and Save footer fixed inside the panel while the form and point list scroll independently
- Preserved at least a 44px usable scrolling region in short mobile landscape
- Added regression coverage for the original overlap, real scroll movement, stationary footer, natural keyboard tab/Enter save, portrait, landscape, short desktop, and the reported 1800x1280 viewport

## Out of scope
- Boundary persistence, API, database, schema, auth, or production-data changes
- Map-provider, map-control, or primary-navigation redesign
- Changes to map-app

## Owned paths
- `components/mobile/territory-boundary-sheet.tsx`
- `tests/e2e/territory-boundary-editor.spec.ts`
- `SESSION.md`

## Overlap check
Open PRs #160, #144, #135, and #82 were checked. #160 owns subway and map-overlay paths but not the boundary sheet. #135 and #82 do not overlap. #144 is a stale broad monorepo migration that conflicts with the canonical architecture and declares no owned paths.

## Root cause
The editor max height subtracted only its top offset and did not reserve the fixed bottom-navigation clearance. Its scroll body also lacked the flex constraints required to shrink when a long point list was present.

## Validation
- RED: at 1440x800, primary navigation began at y=704 while Save Boundary ended at y=821.5
- Review-driven RED: the initial landscape layout produced a 0px scroll body
- GREEN focused suite: 4/4 responsive editor tests passed, including real scrolling and keyboard save
- `npm run verify`: passed lint, typecheck, 126 unit tests, Prisma validation, and production build before the review-driven test hardening
- `npm run test:e2e`: 22/22 passed before the review-driven test hardening
- Post-review focused suite: 4/4 passed
- `git diff --check`: passed

## Browser proof
- Desktop: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-desktop.png`
- Mobile: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-mobile.png`

## Remaining risk
Local browser tests intercept boundary reads and saves and do not mutate production data. Production proof remains pending deployment.