### PR TITLE
Fix Nabis identity review without blocking sales sync

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,50 +1,52 @@
-# Session: Issue 161 Territory Save Clearance
+# Session: Issue 164 Nabis Identity Review Continuity
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/161
-- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/162
-- Branch: `codex/161-territory-save-clearance`
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/164
+- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/165
+- Branch: `codex/164-nabis-identity-review`
+- Worktree: `/Users/brycejohnson/Code/PICC-Web-App-worktrees/issue-164-nabis-identity-review`
 
 ## Scope
 
-- Keep the territory boundary editor fully above the fixed bottom navigation.
-- Keep the editor body independently scrollable when its point list exceeds the available height.
-- Keep the `Save Boundary` footer visible, keyboard reachable, and clickable at short desktop and mobile viewports.
-- Add focused regression coverage for the reported overlap.
+- Preserve canonical Notion page ownership when Nabis identity matching is ambiguous.
+- Keep recent order ingestion independent from optional CRM mirroring failures.
+- Create deduplicated, auditable identity-review notifications.
+- Email the configured administrator once per newly opened conflict.
+- Add complete Settings UI for recipient configuration, open/resolved review items, and explicit resolution.
+- Correct last-success and failed-attempt status semantics.
 
 ## Out of scope
 
-- Boundary persistence, API, database, schema, authentication, authorization, or production-data changes.
-- Map-provider, map-control, or primary-navigation redesign.
+- Fuzzy automatic account merges.
+- Destructive Account or Notion page deletion.
+- Unreviewed production data repair.
 - Changes to `/Users/brycejohnson/Code/map-app`.
+- Unrelated Nabis exception workflows or application-shell refactors.
 
 ## Constraints
 
-- Reuse the existing `--picc-bottom-nav-clearance` design token.
-- Preserve the current Google Maps boundary editing workflow and fixed primary navigation.
-- Use a failing browser behavior test before implementation.
-- Run `npm run verify` and `npm run test:e2e` before completion.
-- Capture desktop and mobile user-visible evidence.
+- Use RED-first tests for every behavior change.
+- Keep Notion and email behind server adapters.
+- Reuse existing notification, preference, identity, and audit models unless tests prove a schema addition unavoidable.
+- All configuration and resolution actions must be usable from the authenticated browser UI.
+- Production email-provider or environment changes require approval-lane confirmation on PR #165.
+- Run `npm run verify` and browser E2E before completion.
 
 ## Ownership and overlap
 
-- Owned paths: `components/mobile/territory-boundary-sheet.tsx`, focused territory editor tests, `SESSION.md`, and UI evidence.
-- Open PRs #160, #144, #135, and #82 were checked.
-- PR #160 owns subway/map-overlay paths but does not own the boundary sheet.
-- PRs #135 and #82 do not overlap.
-- PR #144 is a stale broad monorepo migration that conflicts with the canonical architecture and declares no owned paths.
+- Owned paths: `lib/server/nabis-sync*`, `lib/server/notion-crm-sync*`, identity-conflict and email modules, `app/api/settings/nabis-*/**`, `components/settings/nabis-sync-admin-panel.tsx`, focused tests, `docs/superpowers/**`, and `SESSION.md`.
+- PR #135 was checked; this branch avoids its separate account-detail email workflow.
+- PR #144 was checked; this work follows the canonical current root-app architecture.
+- The branch is `parallel:exclusive` because sync sequencing and identity ownership are shared production behavior.
 
-## Validation evidence
+## Validation plan
 
-- RED: at 1440x800, the primary navigation began at y=704 while `Save Boundary` ended at y=821.5.
-- GREEN: the focused Playwright suite passed all four checks covering real internal scroll movement with a stationary footer, tab-order keyboard save, mobile portrait, mobile landscape with at least a 44px usable form body, short desktop, and the reported 1800x1280 viewport.
-- `npm run verify`: passed lint, typecheck, 27 Vitest files with 126 tests, Prisma validation, and the Next.js production build.
-- `npm run test:e2e`: 22 Playwright tests passed.
-- Read-only review found the initial landscape test allowed a collapsed scroll body; the strengthened test failed at 0px, the height-aware inset was corrected, and the focused four-viewport suite passed again.
-- Desktop screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-desktop.png`.
-- Mobile screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-mobile.png`.
+- Unit/domain: collision handling, exact matches, deduplication, email idempotency, order continuity, last-success semantics, resolution transaction.
+- API/component: authorization, validation, preference persistence, loading/error/empty/open/resolved states.
+- Browser: configure recipient, inspect a deterministic intercepted conflict, resolve it, and verify status/readback without creating production test data.
+- Static/full: `npm run verify` and `npm run test:e2e`.
 
-## Remaining verification boundary
+## Current state
 
-The local UI uses intercepted read and save responses and does not mutate production data. Production proof remains pending merge and deployment.
+Design approved in chat. Written specification is pending user review; implementation has not started.

--- a/app/api/settings/nabis-identity-conflicts/route.ts
+++ b/app/api/settings/nabis-identity-conflicts/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { guard } from '@/lib/auth/api-guard';
+import { parseJsonBody, routeErrorResponse } from '@/lib/api/route-errors';
+import {
+  getNabisIdentityReviewSettings,
+  resolveNabisIdentityConflict,
+  retryNabisIdentityConflictEmail,
+  saveNabisIdentityReviewPreference,
+} from '@/lib/server/nabis-identity-conflict-admin';
+
+export const dynamic = 'force-dynamic';
+
+const preferenceSchema = z.object({
+  email: z.string().trim().email().max(320),
+  emailEnabled: z.boolean(),
+  inAppEnabled: z.boolean(),
+});
+
+const actionSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('resolve'),
+    notificationId: z.string().cuid(),
+    decision: z.enum(['KEEP_CURRENT_OWNER', 'TRANSFER_TO_INCOMING']),
+  }),
+  z.object({
+    action: z.literal('retry-email'),
+    notificationId: z.string().cuid(),
+  }),
+]);
+
+export async function GET() {
+  const ctx = await guard(['ADMIN', 'OPS_TEAM']);
+  if ('error' in ctx) return ctx.error;
+  try {
+    return NextResponse.json(await getNabisIdentityReviewSettings(ctx.orgId));
+  } catch (error) {
+    return routeErrorResponse(error, { fallbackMessage: 'Failed to load Nabis identity reviews' });
+  }
+}
+
+export async function PATCH(request: Request) {
+  const ctx = await guard(['ADMIN']);
+  if ('error' in ctx) return ctx.error;
+  try {
+    const payload = await parseJsonBody(request, preferenceSchema);
+    await saveNabisIdentityReviewPreference({
+      orgId: ctx.orgId,
+      clerkUserId: ctx.userId,
+      ...payload,
+    });
+    return NextResponse.json(await getNabisIdentityReviewSettings(ctx.orgId));
+  } catch (error) {
+    return routeErrorResponse(error, { fallbackMessage: 'Failed to save Nabis review alerts' });
+  }
+}
+
+export async function POST(request: Request) {
+  const ctx = await guard(['ADMIN']);
+  if ('error' in ctx) return ctx.error;
+  try {
+    const payload = await parseJsonBody(request, actionSchema);
+    if (payload.action === 'retry-email') {
+      await retryNabisIdentityConflictEmail(ctx.orgId, payload.notificationId);
+    } else {
+      await resolveNabisIdentityConflict({
+        orgId: ctx.orgId,
+        notificationId: payload.notificationId,
+        decision: payload.decision,
+        actor: { clerkUserId: ctx.userId, email: ctx.email ?? null },
+      });
+    }
+    return NextResponse.json(await getNabisIdentityReviewSettings(ctx.orgId));
+  } catch (error) {
+    return routeErrorResponse(error, { fallbackMessage: 'Failed to update Nabis identity review' });
+  }
+}

--- a/components/settings/nabis-identity-review-panel.tsx
+++ b/components/settings/nabis-identity-review-panel.tsx
@@ -92,7 +92,7 @@ export function NabisIdentityReviewPanel() {
   }
 
   return (
-    <section id="nabis-identity-review" className="scroll-mt-24 rounded-2xl border border-[#d6dae2] bg-white px-4 py-5 sm:px-5">
+    <section id="nabis-identity-review" className="scroll-mt-24 rounded-2xl border border-[#d6dae2] bg-white px-4 py-5 [&_button]:min-h-11 sm:px-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -113,14 +113,14 @@ export function NabisIdentityReviewPanel() {
           <Badge variant={data?.emailProviderReady ? 'success' : 'warning'}>{data?.emailProviderReady ? 'email ready' : 'email setup required'}</Badge>
         </div>
         <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(220px,1fr)_auto_auto_auto] lg:items-end">
-          <label className="text-[13px] font-medium text-[#38404d]">Review email
+          <label className="text-sm font-medium text-[#38404d]">Review email
             <input type="email" value={email} onChange={(event) => setEmail(event.currentTarget.value)} className="mt-1 block h-11 w-full rounded-xl border border-[#cbd2dc] bg-white px-3 text-sm outline-none focus:border-[#5f86e8] focus:ring-2 focus:ring-[#dce7ff]" placeholder="admin@company.com" />
           </label>
           <Toggle label="Email" checked={emailEnabled} onChange={setEmailEnabled} />
           <Toggle label="In-app" checked={inAppEnabled} onChange={setInAppEnabled} />
-          <Button type="button" onClick={() => void savePreference()} disabled={saving || !email.trim()}>{saving ? 'Saving…' : 'Save alerts'}</Button>
+          <Button type="button" className="bg-[#24324f] text-white hover:bg-[#1c2840]" onClick={() => void savePreference()} disabled={saving || !email.trim()}>{saving ? 'Saving…' : 'Save alerts'}</Button>
         </div>
-        {!data?.emailProviderReady ? <p className="mt-3 text-[12px] text-[#9a5717]">In-app review remains active. Production email starts when the approved sender is connected.</p> : null}
+        {!data?.emailProviderReady ? <p className="mt-3 text-sm text-[#9a5717] sm:text-[12px]">In-app review remains active. Production email starts when the approved sender is connected.</p> : null}
       </div>
 
       <div className="mt-4 space-y-3">
@@ -134,18 +134,18 @@ export function NabisIdentityReviewPanel() {
               <div className="flex min-w-0 items-start gap-3"><AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-[#ae6114]" /><div>
                 <p className="font-semibold text-[#352818]">{conflict.metadata.incomingAccountName}</p>
                 <p className="mt-1 text-sm text-[#6c5537]">Current CRM owner: {conflict.metadata.currentOwnerAccountName ?? 'none'} · seen {conflict.metadata.occurrenceCount} time{conflict.metadata.occurrenceCount === 1 ? '' : 's'}</p>
-                <p className="mt-1 text-[12px] text-[#826846]">Last detected {dateTime(conflict.metadata.lastDetectedAt)}</p>
-                <p className="mt-2 text-[12px] text-[#6c5537]">Nabis retailer {conflict.metadata.sourceIdentifiers.nabisRetailerId ?? 'unknown'} · license {conflict.metadata.sourceIdentifiers.licenseNumber ?? 'unknown'}</p>
+                <p className="mt-1 text-sm text-[#826846] sm:text-[12px]">Last detected {dateTime(conflict.metadata.lastDetectedAt)}</p>
+                <p className="mt-2 text-sm text-[#6c5537] sm:text-[12px]">Nabis retailer {conflict.metadata.sourceIdentifiers.nabisRetailerId ?? 'unknown'} · license {conflict.metadata.sourceIdentifiers.licenseNumber ?? 'unknown'}</p>
               </div></div>
               <Badge variant={conflict.metadata.email.status === 'SENT' ? 'success' : 'warning'}>email {conflict.metadata.email.status.toLowerCase()}</Badge>
             </div>
             {isConfirming ? <div className="mt-4 rounded-xl border border-[#d8b477] bg-white p-3">
               <p className="text-sm font-semibold text-[#352818]">{confirm.decision === 'KEEP_CURRENT_OWNER' ? `Keep ${conflict.metadata.currentOwnerAccountName ?? 'the current CRM owner'}?` : `Transfer the CRM page to ${conflict.metadata.incomingAccountName}?`}</p>
-              <p className="mt-1 text-[12px] text-[#6c5537]">This records an explicit identity override and audit event. Future syncs follow your decision.</p>
-              <div className="mt-3 flex gap-2"><Button type="button" onClick={() => void runAction({ action: 'resolve', notificationId: conflict.id, decision: confirm.decision }, 'Identity conflict resolved.')} disabled={isActing}>{isActing ? 'Resolving…' : 'Confirm decision'}</Button><Button type="button" variant="secondary" onClick={() => setConfirm(null)} disabled={isActing}>Cancel</Button></div>
+              <p className="mt-1 text-sm text-[#6c5537] sm:text-[12px]">This records an explicit identity override and audit event. Future syncs follow your decision.</p>
+              <div className="mt-3 flex gap-2"><Button type="button" className="bg-[#24324f] text-white hover:bg-[#1c2840]" onClick={() => void runAction({ action: 'resolve', notificationId: conflict.id, decision: confirm.decision }, 'Identity conflict resolved.')} disabled={isActing}>{isActing ? 'Resolving…' : 'Confirm decision'}</Button><Button type="button" variant="secondary" onClick={() => setConfirm(null)} disabled={isActing}>Cancel</Button></div>
             </div> : <div className="mt-4 flex flex-wrap gap-2">
               {conflict.metadata.currentOwnerAccountName ? <Button type="button" variant="secondary" onClick={() => setConfirm({ id: conflict.id, decision: 'KEEP_CURRENT_OWNER' })}>Keep current owner</Button> : null}
-              <Button type="button" onClick={() => setConfirm({ id: conflict.id, decision: 'TRANSFER_TO_INCOMING' })}>Transfer to Nabis account</Button>
+              <Button type="button" className="bg-[#24324f] text-white hover:bg-[#1c2840]" onClick={() => setConfirm({ id: conflict.id, decision: 'TRANSFER_TO_INCOMING' })}>Transfer to Nabis account</Button>
               {conflict.metadata.email.status !== 'SENT' ? <Button type="button" variant="ghost" onClick={() => void runAction({ action: 'retry-email', notificationId: conflict.id }, 'Conflict email retried.')} disabled={isActing || !data?.emailProviderReady}>Retry email</Button> : null}
             </div>}
           </article>;

--- a/components/settings/nabis-identity-review-panel.tsx
+++ b/components/settings/nabis-identity-review-panel.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Mail, RefreshCw, ShieldCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { Badge, Button } from '@/components/ui';
+
+type Decision = 'KEEP_CURRENT_OWNER' | 'TRANSFER_TO_INCOMING';
+type Conflict = {
+  id: string;
+  metadata: {
+    status: 'OPEN' | 'RESOLVED'; occurrenceCount: number; lastDetectedAt: string;
+    incomingAccountName: string; currentOwnerAccountName: string | null;
+    sourceIdentifiers: { nabisRetailerId: string | null; licenseNumber: string | null };
+    email: { status: 'PENDING' | 'SENT' | 'FAILED' | 'UNAVAILABLE'; error?: string | null };
+    resolution?: { decision: Decision; resolvedAt: string };
+  };
+};
+type ReviewResponse = {
+  conflicts: Conflict[];
+  preference: { email: string; emailEnabled: boolean; inAppEnabled: boolean };
+  emailProviderReady: boolean;
+};
+
+function dateTime(value?: string | null) {
+  if (!value) return 'Not recorded';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Not recorded' : date.toLocaleString();
+}
+
+export function NabisIdentityReviewPanel() {
+  const [data, setData] = useState<ReviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [actingId, setActingId] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<{ id: string; decision: Decision } | null>(null);
+  const [email, setEmail] = useState('');
+  const [emailEnabled, setEmailEnabled] = useState(true);
+  const [inAppEnabled, setInAppEnabled] = useState(true);
+  const openConflicts = useMemo(() => data?.conflicts.filter((item) => item.metadata.status === 'OPEN') ?? [], [data]);
+  const resolvedConflicts = useMemo(() => data?.conflicts.filter((item) => item.metadata.status === 'RESOLVED').slice(0, 5) ?? [], [data]);
+
+  const applyData = useCallback((payload: ReviewResponse) => {
+    setData(payload);
+    setEmail(payload.preference.email);
+    setEmailEnabled(payload.preference.emailEnabled);
+    setInAppEnabled(payload.preference.inAppEnabled);
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/settings/nabis-identity-conflicts', { cache: 'no-store' });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(payload.error ?? 'Unable to load identity reviews');
+      applyData(payload as ReviewResponse);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to load identity reviews');
+    } finally {
+      setLoading(false);
+    }
+  }, [applyData]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function request(method: 'PATCH' | 'POST', body: Record<string, string | boolean>) {
+    const response = await fetch('/api/settings/nabis-identity-conflicts', {
+      method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(payload.error ?? 'Unable to update identity review');
+    applyData(payload as ReviewResponse);
+  }
+
+  async function savePreference() {
+    setSaving(true);
+    try {
+      await request('PATCH', { email, emailEnabled, inAppEnabled });
+      toast.success('Nabis conflict alerts saved.');
+    } catch (error) { toast.error(error instanceof Error ? error.message : 'Unable to save alert settings'); }
+    finally { setSaving(false); }
+  }
+
+  async function runAction(body: Record<string, string>, message: string) {
+    setActingId(body.notificationId);
+    try {
+      await request('POST', body);
+      setConfirm(null);
+      toast.success(message);
+    } catch (error) { toast.error(error instanceof Error ? error.message : 'Unable to update identity review'); }
+    finally { setActingId(null); }
+  }
+
+  return (
+    <section id="nabis-identity-review" className="scroll-mt-24 rounded-2xl border border-[#d6dae2] bg-white px-4 py-5 sm:px-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-[#3559a9]" />
+            <h3 className="text-[17px] font-semibold text-[#1d1f23]">Nabis identity review</h3>
+            <Badge variant={openConflicts.length ? 'warning' : 'success'}>{openConflicts.length} open</Badge>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm text-[#5c6674]">Sales continue syncing when Nabis and CRM ownership disagree. Resolve ownership here; the app never guesses.</p>
+        </div>
+        <Button type="button" variant="secondary" onClick={() => void load()} disabled={loading}>
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Refresh reviews
+        </Button>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-[#e2e8f0] bg-[#f7f9fc] p-4">
+        <div className="flex flex-wrap items-center gap-2 text-[#24324f]">
+          <Mail className="h-4 w-4" /><p className="text-[14px] font-semibold">Conflict alerts</p>
+          <Badge variant={data?.emailProviderReady ? 'success' : 'warning'}>{data?.emailProviderReady ? 'email ready' : 'email setup required'}</Badge>
+        </div>
+        <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(220px,1fr)_auto_auto_auto] lg:items-end">
+          <label className="text-[13px] font-medium text-[#38404d]">Review email
+            <input type="email" value={email} onChange={(event) => setEmail(event.currentTarget.value)} className="mt-1 block h-11 w-full rounded-xl border border-[#cbd2dc] bg-white px-3 text-sm outline-none focus:border-[#5f86e8] focus:ring-2 focus:ring-[#dce7ff]" placeholder="admin@company.com" />
+          </label>
+          <Toggle label="Email" checked={emailEnabled} onChange={setEmailEnabled} />
+          <Toggle label="In-app" checked={inAppEnabled} onChange={setInAppEnabled} />
+          <Button type="button" onClick={() => void savePreference()} disabled={saving || !email.trim()}>{saving ? 'Saving…' : 'Save alerts'}</Button>
+        </div>
+        {!data?.emailProviderReady ? <p className="mt-3 text-[12px] text-[#9a5717]">In-app review remains active. Production email starts when the approved sender is connected.</p> : null}
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {loading && !data ? <p className="text-sm text-[#5c6674]">Loading identity reviews…</p> : null}
+        {!loading && openConflicts.length === 0 ? <div className="flex items-center gap-3 rounded-xl border border-[#b9dfce] bg-[#f0fbf6] px-4 py-4 text-sm text-[#176c49]"><CheckCircle2 className="h-5 w-5" />No unresolved Nabis identity conflicts.</div> : null}
+        {openConflicts.map((conflict) => {
+          const isActing = actingId === conflict.id;
+          const isConfirming = confirm?.id === conflict.id;
+          return <article key={conflict.id} className="rounded-xl border border-[#efc58d] bg-[#fffaf1] p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3"><AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-[#ae6114]" /><div>
+                <p className="font-semibold text-[#352818]">{conflict.metadata.incomingAccountName}</p>
+                <p className="mt-1 text-sm text-[#6c5537]">Current CRM owner: {conflict.metadata.currentOwnerAccountName ?? 'none'} · seen {conflict.metadata.occurrenceCount} time{conflict.metadata.occurrenceCount === 1 ? '' : 's'}</p>
+                <p className="mt-1 text-[12px] text-[#826846]">Last detected {dateTime(conflict.metadata.lastDetectedAt)}</p>
+                <p className="mt-2 text-[12px] text-[#6c5537]">Nabis retailer {conflict.metadata.sourceIdentifiers.nabisRetailerId ?? 'unknown'} · license {conflict.metadata.sourceIdentifiers.licenseNumber ?? 'unknown'}</p>
+              </div></div>
+              <Badge variant={conflict.metadata.email.status === 'SENT' ? 'success' : 'warning'}>email {conflict.metadata.email.status.toLowerCase()}</Badge>
+            </div>
+            {isConfirming ? <div className="mt-4 rounded-xl border border-[#d8b477] bg-white p-3">
+              <p className="text-sm font-semibold text-[#352818]">{confirm.decision === 'KEEP_CURRENT_OWNER' ? `Keep ${conflict.metadata.currentOwnerAccountName ?? 'the current CRM owner'}?` : `Transfer the CRM page to ${conflict.metadata.incomingAccountName}?`}</p>
+              <p className="mt-1 text-[12px] text-[#6c5537]">This records an explicit identity override and audit event. Future syncs follow your decision.</p>
+              <div className="mt-3 flex gap-2"><Button type="button" onClick={() => void runAction({ action: 'resolve', notificationId: conflict.id, decision: confirm.decision }, 'Identity conflict resolved.')} disabled={isActing}>{isActing ? 'Resolving…' : 'Confirm decision'}</Button><Button type="button" variant="secondary" onClick={() => setConfirm(null)} disabled={isActing}>Cancel</Button></div>
+            </div> : <div className="mt-4 flex flex-wrap gap-2">
+              {conflict.metadata.currentOwnerAccountName ? <Button type="button" variant="secondary" onClick={() => setConfirm({ id: conflict.id, decision: 'KEEP_CURRENT_OWNER' })}>Keep current owner</Button> : null}
+              <Button type="button" onClick={() => setConfirm({ id: conflict.id, decision: 'TRANSFER_TO_INCOMING' })}>Transfer to Nabis account</Button>
+              {conflict.metadata.email.status !== 'SENT' ? <Button type="button" variant="ghost" onClick={() => void runAction({ action: 'retry-email', notificationId: conflict.id }, 'Conflict email retried.')} disabled={isActing || !data?.emailProviderReady}>Retry email</Button> : null}
+            </div>}
+          </article>;
+        })}
+      </div>
+
+      {resolvedConflicts.length ? <details className="mt-4 rounded-xl border border-[#e2e8f0] bg-[#f7f9fc] px-4 py-3"><summary className="cursor-pointer text-sm font-semibold text-[#38404d]">Recent resolved reviews ({resolvedConflicts.length})</summary><div className="mt-3 space-y-2">{resolvedConflicts.map((conflict) => <div key={conflict.id} className="flex flex-wrap justify-between gap-2 rounded-lg bg-white px-3 py-2 text-[13px] text-[#5c6674]"><span>{conflict.metadata.incomingAccountName}</span><span>{conflict.metadata.resolution?.decision === 'TRANSFER_TO_INCOMING' ? 'Transferred' : 'Kept current owner'} · {dateTime(conflict.metadata.resolution?.resolvedAt)}</span></div>)}</div></details> : null}
+    </section>
+  );
+}
+
+function Toggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (checked: boolean) => void }) {
+  return <label className="flex h-11 items-center gap-2 rounded-xl border border-[#cbd2dc] bg-white px-3 text-sm font-medium text-[#38404d]"><input type="checkbox" checked={checked} onChange={(event) => onChange(event.currentTarget.checked)} className="h-4 w-4 accent-[#1d5eea]" />{label}</label>;
+}

--- a/components/settings/nabis-sync-admin-panel.tsx
+++ b/components/settings/nabis-sync-admin-panel.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, Database, History, RefreshCw, Store, TimerReset } from '
 import { toast } from 'sonner';
 import { Badge, Button } from '@/components/ui';
 import { WorkspacePanel, WorkspacePanelHeader } from '@/components/layout/workspace-page';
+import { NabisIdentityReviewPanel } from '@/components/settings/nabis-identity-review-panel';
 
 type SyncStatus = 'IDLE' | 'RUNNING' | 'SUCCESS' | 'ERROR';
 
@@ -14,6 +15,7 @@ type SyncModule = {
   status: SyncStatus;
   updatedAt: string | null;
   lastSuccessfulSyncAt: string | null;
+  lastAttemptAt: string | null;
   error: string | null;
   rateLimited: boolean;
   retryAfterMs: number | null;
@@ -255,7 +257,7 @@ export function NabisSyncAdminPanel() {
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="text-[15px] font-semibold text-[#1d1f23]">{shortModuleLabel(module.module)}</p>
-                    <p className="mt-1 text-[12px] text-[#5c6674]">Updated: {formatDateTime(module.updatedAt)}</p>
+                    <p className="mt-1 text-[12px] text-[#5c6674]">Last attempt: {formatDateTime(module.lastAttemptAt)}</p>
                   </div>
                   <Badge variant={statusBadgeVariant(module.status)}>{module.status.toLowerCase()}</Badge>
                 </div>
@@ -281,6 +283,8 @@ export function NabisSyncAdminPanel() {
               </div>
             ))}
           </div>
+
+          <NabisIdentityReviewPanel />
 
           <label className="flex items-start gap-3 rounded-2xl border border-[#d6dae2] bg-[#f7f9fc] px-4 py-4">
             <input

--- a/components/settings/nabis-sync-admin-panel.tsx
+++ b/components/settings/nabis-sync-admin-panel.tsx
@@ -284,8 +284,6 @@ export function NabisSyncAdminPanel() {
             ))}
           </div>
 
-          <NabisIdentityReviewPanel />
-
           <label className="flex items-start gap-3 rounded-2xl border border-[#d6dae2] bg-[#f7f9fc] px-4 py-4">
             <input
               type="checkbox"
@@ -350,6 +348,8 @@ export function NabisSyncAdminPanel() {
           </div>
         </>
       ) : null}
+
+      <NabisIdentityReviewPanel />
     </WorkspacePanel>
   );
 }

--- a/docs/superpowers/plans/2026-08-14-nabis-identity-review-continuity.md
+++ b/docs/superpowers/plans/2026-08-14-nabis-identity-review-continuity.md
@@ -1,0 +1,271 @@
+# Nabis Identity Review Continuity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Nabis sales current when CRM identity requires review, notify the configured administrator once, and provide a complete authenticated resolution workflow.
+
+**Architecture:** Add a conflict decision/lifecycle module between the Notion adapter and Account ownership write, backed by existing notification/preference/audit models and a server-only email adapter. Run orders before optional retailer CRM mirroring, expose independent status, and extend the existing Nabis Settings panel with alert configuration and conflict resolution.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Prisma/PostgreSQL, Vitest, Playwright, Tailwind/shadcn-style UI, server-side Resend REST adapter.
+
+## Global Constraints
+
+- No fuzzy automatic merges or destructive deletion.
+- Ambiguous identity never writes ownership.
+- Email failure never interrupts order ingestion.
+- Configuration and resolution are fully usable from authenticated UI.
+- No production test records; browser verification uses interception.
+- RED-first tests precede every production-code behavior.
+- Production email configuration and any one-time data repair remain approval-lane actions.
+
+---
+
+### Task 1: Conflict decision and persistence lifecycle
+
+**Files:**
+- Create: `lib/server/nabis-identity-conflicts.ts`
+- Create: `lib/server/nabis-identity-conflicts.test.ts`
+- Modify: `lib/server/nabis-sync.ts`
+
+**Interfaces:**
+- Produces: `assessNabisIdentityLink(input): "LINK" | "REVIEW"`
+- Produces: `recordNabisIdentityConflict(input): Promise<ConflictRecordResult>`
+- Consumes: Notion `reviewRequired`, current page owner, incoming Account/source identifiers.
+
+- [ ] **Step 1: Write failing pure decision tests**
+
+```ts
+expect(assessNabisIdentityLink({ reviewRequired: true, incomingAccountId: 'a', ownerAccountId: null })).toBe('REVIEW');
+expect(assessNabisIdentityLink({ reviewRequired: false, incomingAccountId: 'a', ownerAccountId: 'b' })).toBe('REVIEW');
+expect(assessNabisIdentityLink({ reviewRequired: false, incomingAccountId: 'a', ownerAccountId: 'a' })).toBe('LINK');
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `npm test -- lib/server/nabis-identity-conflicts.test.ts`
+Expected: FAIL because the module/exports do not exist.
+
+- [ ] **Step 3: Implement the minimal decision and deterministic conflict key**
+
+```ts
+export function assessNabisIdentityLink(input: LinkAssessmentInput) {
+  return input.reviewRequired || (input.ownerAccountId && input.ownerAccountId !== input.incomingAccountId) ? 'REVIEW' : 'LINK';
+}
+```
+
+Use a stable hash of org, incoming Account, candidate page, and reason for `conflictKey`.
+
+- [ ] **Step 4: Write and run RED persistence tests**
+
+Inject a repository interface and assert first detection creates one OPEN notification, repeated detection updates occurrence metadata, and resolved-then-reintroduced creates a new lifecycle generation.
+
+Run: `npm test -- lib/server/nabis-identity-conflicts.test.ts`
+Expected: FAIL on missing persistence implementation.
+
+- [ ] **Step 5: Implement notification lifecycle and integrate caller**
+
+Before assigning a candidate page ID, query the organization-scoped current owner. For REVIEW, persist/update the conflict, do not write `notionPageId`, and continue processing. For LINK, retain the existing write and identity mapping behavior.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+Run: `npm test -- lib/server/nabis-identity-conflicts.test.ts lib/server/notion-crm-sync.test.ts lib/server/nabis-sync.test.ts`
+Expected: PASS.
+
+Commit: `fix: preserve identity ownership on ambiguous Nabis matches`
+
+### Task 2: Idempotent email adapter and recipient preferences
+
+**Files:**
+- Create: `lib/server/transactional-email.ts`
+- Create: `lib/server/transactional-email.test.ts`
+- Modify: `lib/server/nabis-identity-conflicts.ts`
+- Modify: `lib/server/nabis-identity-conflicts.test.ts`
+
+**Interfaces:**
+- Produces: `sendIdentityConflictEmail(input): Promise<EmailDeliveryResult>`
+- Produces: `resolveIdentityConflictRecipient(orgId): Promise<RecipientResolution>`
+- Consumes: `RESEND_API_KEY`, configured sender, `EXCEPTIONS` preference, default admin email.
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Assert missing transport returns `{ status: "UNAVAILABLE" }`, a configured send includes deterministic idempotency header, non-2xx responses return `{ status: "FAILED" }`, and no secret enters logs/output.
+
+- [ ] **Step 2: Run RED**
+
+Run: `npm test -- lib/server/transactional-email.test.ts`
+Expected: FAIL because the adapter does not exist.
+
+- [ ] **Step 3: Implement server-only fetch adapter**
+
+POST minimal HTML/text content to the provider API. Return provider-neutral `SENT`, `FAILED`, or `UNAVAILABLE`; never throw raw provider content through the sync path.
+
+- [ ] **Step 4: Write failing lifecycle email tests**
+
+Assert only a newly opened lifecycle invokes the sender, repeat detections do not, and delivery failure updates conflict metadata without rejecting conflict persistence.
+
+- [ ] **Step 5: Implement recipient resolution and lifecycle send**
+
+Use the authenticated administrator's saved `EXCEPTIONS` preference. Fall back to configured administrator email and the most recent matching organization session for in-app targeting. GET remains read-only.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+Run: `npm test -- lib/server/transactional-email.test.ts lib/server/nabis-identity-conflicts.test.ts`
+Expected: PASS.
+
+Commit: `feat: alert administrators to identity review conflicts`
+
+### Task 3: Sales-first sync and truthful freshness
+
+**Files:**
+- Modify: `lib/server/nabis-sync.ts`
+- Modify: `lib/server/nabis-sync.test.ts`
+- Modify: `lib/server/nabis-sync-status.ts`
+- Create or modify: `lib/server/nabis-sync-status.test.ts`
+- Modify: `lib/dashboard/nabis-server.ts`
+
+**Interfaces:**
+- Produces: independent `{ orders, retailers }` combined result.
+- Produces: `lastSuccessfulSyncAt` and separate `lastAttemptAt` semantics.
+
+- [ ] **Step 1: Write failing sequencing test**
+
+Inject/drive a combined runner where order ingestion succeeds and retailer CRM fails; assert order completion occurs first and remains recorded.
+
+- [ ] **Step 2: Run RED**
+
+Run: `npm test -- lib/server/nabis-sync.test.ts`
+Expected: FAIL because retailer currently runs first.
+
+- [ ] **Step 3: Reorder the combined sync and preserve independent outcomes**
+
+Call `syncNabisOrdersCore` before `syncNabisRetailersCore`. Keep the global lease and module checkpoints. A handled review does not throw; a real retailer failure occurs only after order success.
+
+- [ ] **Step 4: Write failing freshness test**
+
+Given an ERROR checkpoint updated today and an earlier successful run, expect last success to use the successful run and last attempt to use the failed checkpoint.
+
+- [ ] **Step 5: Implement truthful status lookup**
+
+Query recent successful module runs as fallback and expose failed attempt timestamps separately. Never fall back from an ERROR checkpoint to its `updatedAt` as a successful sync.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+Run: `npm test -- lib/server/nabis-sync.test.ts lib/server/nabis-sync-status.test.ts lib/dashboard/nabis-refresh.test.ts`
+Expected: PASS.
+
+Commit: `fix: keep Nabis sales current through CRM failures`
+
+### Task 4: Authenticated conflict settings API
+
+**Files:**
+- Create: `app/api/settings/nabis-identity-conflicts/route.ts`
+- Create: `app/api/settings/nabis-identity-conflicts/preferences/route.ts`
+- Create: `app/api/settings/nabis-identity-conflicts/[conflictId]/resolve/route.ts`
+- Create: `app/api/settings/nabis-identity-conflicts/[conflictId]/retry-email/route.ts`
+- Create: `lib/server/nabis-identity-conflict-admin.ts`
+- Create: `lib/server/nabis-identity-conflict-admin.test.ts`
+
+**Interfaces:**
+- Produces: `getIdentityConflictAdminData(orgId, actor)`.
+- Produces: `saveIdentityConflictPreference(input)`.
+- Produces: `resolveIdentityConflict(input)` with `KEEP_CURRENT_OWNER | TRANSFER_TO_INCOMING`.
+- Produces: `retryIdentityConflictEmail(input)`.
+
+- [ ] **Step 1: Write failing admin-domain tests**
+
+Assert org scoping, stale-version rejection, already-resolved idempotency, keep-owner mapping, transfer transaction, and audit metadata.
+
+- [ ] **Step 2: Run RED**
+
+Run: `npm test -- lib/server/nabis-identity-conflict-admin.test.ts`
+Expected: FAIL because the admin module does not exist.
+
+- [ ] **Step 3: Implement transactional admin functions**
+
+Re-read conflict metadata and both Accounts, verify ownership, update identity mappings/ownership atomically, mark resolved, and append audit event. Return fresh queue readback.
+
+- [ ] **Step 4: Add guarded routes with Zod validation**
+
+Admin/Ops/Finance GET; Admin preference/retry; Admin/Ops resolution. Return 409 for stale version/ownership changes and 404 for cross-org IDs.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+Run: `npm test -- lib/server/nabis-identity-conflict-admin.test.ts && npm run typecheck`
+Expected: PASS.
+
+Commit: `feat: add authenticated identity conflict controls`
+
+### Task 5: Complete Nabis Settings review UI
+
+**Files:**
+- Modify: `components/settings/nabis-sync-admin-panel.tsx`
+- Create: `components/settings/nabis-identity-review-panel.tsx`
+- Create: `components/settings/nabis-identity-review-panel.test.tsx` only if the existing Vitest environment supports DOM; otherwise cover domain/API with Playwright.
+- Modify: `DESIGN-SYSTEM.md` only if a reusable conflict-state pattern is missing.
+
+**Interfaces:**
+- Consumes: Settings conflict GET/PATCH/POST routes.
+- Produces: alert settings, queue, resolution modal, retry email, and fresh readback.
+
+- [ ] **Step 1: Write failing browser E2E skeleton**
+
+Intercept the conflict APIs and assert the Nabis Settings panel exposes recipient input, open conflict details, canonical-owner choices, disabled-until-confirmed resolve action, and resolved history.
+
+- [ ] **Step 2: Run RED**
+
+Run the focused Playwright test.
+Expected: FAIL because the Identity Review section is absent.
+
+- [ ] **Step 3: Implement the thin panel**
+
+Use existing Button/Input/Badge/Dialog patterns and design tokens. Implement loading skeleton, empty, API error/retry, open, delivery-failed, resolving, resolved, validation, saved, and transport-unavailable states.
+
+- [ ] **Step 4: Run GREEN across desktop/mobile/keyboard**
+
+Run the focused Playwright test at desktop and mobile sizes. Verify keyboard focus/confirmation and no overlap with fixed navigation.
+
+- [ ] **Step 5: Commit**
+
+Commit: `feat: add Nabis identity review workspace`
+
+### Task 6: Full verification, review, deploy, and production proof
+
+**Files:**
+- Modify: `SESSION.md`
+- Modify: draft PR #165 body/status/comments.
+
+**Interfaces:**
+- Consumes: completed code and tests.
+- Produces: validated PR, deployed production behavior, and read-only proof.
+
+- [ ] **Step 1: Run static and full automated validation**
+
+Run: `npm run verify`
+Expected: lint, typecheck, unit tests, Prisma validation, and build all PASS.
+
+Run: `npm run test:e2e`
+Expected: all Playwright tests PASS.
+
+- [ ] **Step 2: Self-review the complete diff**
+
+Check correctness, auth/org scoping, email idempotency, secrets, UI state completeness, test quality, and file-count coherence. Fix findings with new RED tests where behavior changes.
+
+- [ ] **Step 3: Capture browser evidence**
+
+Save desktop/mobile screenshots and a short interaction recording of configure → review → resolve using intercepted data.
+
+- [ ] **Step 4: Update SESSION and PR proof**
+
+Document RED/GREEN commands, full validation, screenshots/video, remaining environment boundary, and changed-file scope.
+
+- [ ] **Step 5: Complete approval-lane configuration if required**
+
+Post `@bryce approval requested: configure the production transactional-email provider and sender required for identity-conflict alerts.` on PR #165 only if production transport is absent. Do not expose secrets.
+
+- [ ] **Step 6: Merge/deploy and verify**
+
+After required approval and green checks, merge PR #165, verify the Vercel production deployment, exercise only read-only/live-safe UI paths, run an authorized sales refresh, and read back independent module timestamps/counts. Do not create test records.
+
+- [ ] **Step 7: Handle the existing conflict safely**
+
+Identify exact records read-only. Present any proposed one-time ownership change before mutation. If no production write is approved, leave the review item open and report the precise boundary while confirming sales ingestion is healthy.

--- a/docs/superpowers/specs/2026-08-14-nabis-identity-review-continuity-design.md
+++ b/docs/superpowers/specs/2026-08-14-nabis-identity-review-continuity-design.md
@@ -1,0 +1,117 @@
+# External Identity Review and Sales-Sync Continuity Design
+
+## Summary
+
+An ambiguous external-record match must not be treated as confirmed identity. When review is required, the application will preserve existing ownership, continue sales-data ingestion, create one actionable review item, and notify the configured administrator without exposing private source data outside authenticated surfaces.
+
+## Goals
+
+- Keep sales-data ingestion independent from optional CRM mirroring.
+- Preserve existing external-record ownership until an authorized user resolves ambiguity.
+- Deduplicate review items and email alerts.
+- Make notification configuration, review, and resolution fully usable from the authenticated Settings UI.
+- Distinguish successful sync timestamps from failed attempts.
+- Keep every resolution organization-scoped and audited.
+
+## Non-goals
+
+- Fuzzy automatic merges.
+- Destructive account or external-record deletion.
+- A general-purpose messaging system.
+- Unrelated sync or application-shell refactors.
+
+## Domain Boundaries
+
+External identity matching produces three explicit outcomes:
+
+- `linked`: exact or same-owner identity; the link may be persisted.
+- `review-required`: ambiguous or differently owned identity; no ownership write occurs.
+- `failed`: provider operation failed; the failure is recorded without undoing completed sales ingestion.
+
+Before any ownership write, the server verifies the current organization-scoped owner. The database uniqueness constraint remains the final invariant rather than the first conflict detector.
+
+Each unresolved conflict has a deterministic key and lifecycle state. Repeated detection updates the existing open item instead of creating duplicate records or emails. Resolution records the selected canonical account, actor, timestamp, and audit reference.
+
+## Sync Sequencing
+
+The combined refresh becomes sales-first:
+
+1. Acquire the existing sync lease.
+2. Ingest recent orders.
+3. Refresh retailer/account data and perform optional CRM mirroring.
+4. Report the independent outcome of each module.
+
+A review-required outcome is handled business state, not a crashed sync. A provider failure may still fail its own module, but completed sales ingestion remains successful and visible.
+
+Last-success timestamps come only from successful runs. Failed-attempt timestamps are reported separately and are never labeled as synced.
+
+## Notification Design
+
+Use existing notification, preference, identity, and audit boundaries where practical. A server-only email adapter keeps provider details out of domain logic.
+
+- The configured administrator receives one opening email per conflict lifecycle.
+- Delivery uses a deterministic idempotency key.
+- Delivery failure is visible in-app and never interrupts sales ingestion.
+- The Settings UI provides validated recipient and channel controls.
+- Default values may be derived from existing administrator configuration, but GET requests never write preferences.
+- Production provider configuration remains approval-lane work.
+
+Email content includes only the minimum context needed to sign in and review the conflict. Private source details remain inside the authenticated application.
+
+## Browser UI
+
+Extend the existing sync Settings surface with two complete sections.
+
+### Alert settings
+
+- Validated recipient input.
+- Email and in-app toggles.
+- Transport readiness without revealing secrets.
+- Save, reset, loading, validation, saved, and unavailable states.
+
+### Identity review
+
+- Open, failed-delivery, and resolved counts.
+- Open conflicts first with reason, occurrence count, freshness, and both candidate records.
+- Resolved history below the active queue.
+- Loading skeleton, actionable error, and useful empty state.
+- An explicit confirmation flow showing before/after ownership.
+- Transfer is never the default choice.
+
+Admin and Ops may resolve conflicts. Finance may inspect the queue. Only Admin may change external notification settings.
+
+## Resolution Safety
+
+- Re-read both records and current ownership inside the transaction.
+- Reject stale UI versions and cross-organization identifiers.
+- Apply ownership and identity-mapping changes atomically.
+- Record actor, decision, and before/after state in the audit log.
+- Return fresh readback so the UI reflects persisted truth.
+
+## Test Strategy
+
+Use RED-first tests for:
+
+- ambiguous matches never writing ownership;
+- exact and same-owner matches linking normally;
+- conflict and email deduplication;
+- email failure isolation;
+- sales ingestion completing before optional CRM failure;
+- last-success timestamp semantics;
+- transactional, organization-scoped resolution;
+- API authorization and validation;
+- UI loading, empty, open, resolved, error, and success states.
+
+Browser tests use intercepted deterministic responses and create no production test records. The core flow is configure recipient → inspect conflict → confirm ownership → resolve → verify history.
+
+Run `npm run verify` and `npm run test:e2e` before completion.
+
+## Rollout Boundary
+
+Code may merge only after automated validation, browser proof, self-review, and any required approval-lane configuration confirmation. Production verification uses existing records and read-only status checks. Any one-time data repair requires exact-record review and separate explicit approval before mutation.
+
+## Alternatives Considered
+
+- Silently skipping ambiguous links keeps sync running but hides required work.
+- Automatically merging candidates reduces clicks but risks corrupting identity.
+- The selected approach combines safe review state, idempotent notification, explicit browser resolution, and sales-first sequencing.

--- a/lib/server/nabis-identity-conflict-admin.test.ts
+++ b/lib/server/nabis-identity-conflict-admin.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildNabisIdentityResolutionActions } from '@/lib/server/nabis-identity-conflict-admin';
+
+describe('buildNabisIdentityResolutionActions', () => {
+  const conflict = {
+    incomingAccountId: 'incoming-account',
+    currentOwnerAccountId: 'current-owner',
+    candidatePageId: '01234567-89ab-cdef-0123-456789abcdef',
+    sourceIdentifiers: {
+      licensedLocationId: 'loc-1',
+      nabisRetailerId: 'retailer-1',
+      licenseNumber: 'ocm-123',
+    },
+  };
+
+  it('keeps the existing owner and maps source identifiers to it', () => {
+    expect(buildNabisIdentityResolutionActions(conflict, 'KEEP_CURRENT_OWNER')).toMatchObject({
+      targetAccountId: 'current-owner',
+      clearOwnerAccountId: null,
+      linkCandidatePageToTarget: false,
+    });
+  });
+
+  it('transfers the page and identifiers to the incoming account', () => {
+    expect(buildNabisIdentityResolutionActions(conflict, 'TRANSFER_TO_INCOMING')).toMatchObject({
+      targetAccountId: 'incoming-account',
+      clearOwnerAccountId: 'current-owner',
+      linkCandidatePageToTarget: true,
+    });
+  });
+
+  it('rejects keeping an owner when no current owner exists', () => {
+    expect(() =>
+      buildNabisIdentityResolutionActions({ ...conflict, currentOwnerAccountId: null }, 'KEEP_CURRENT_OWNER'),
+    ).toThrow('No current owner');
+  });
+});

--- a/lib/server/nabis-identity-conflict-admin.ts
+++ b/lib/server/nabis-identity-conflict-admin.ts
@@ -1,0 +1,193 @@
+import 'server-only';
+
+import { AccountIdentityType, NotificationCategory, Prisma } from '@prisma/client';
+import { prisma } from '@/lib/db/prisma';
+import { normalizeIdentityValue } from '@/lib/server/account-identity';
+import {
+  listNabisIdentityConflicts,
+  resolveNabisIdentityConflictRecipient,
+  retryNabisIdentityConflictEmail,
+  type NabisIdentityConflictMetadata,
+} from '@/lib/server/nabis-identity-conflicts';
+import { transactionalEmailReady } from '@/lib/server/transactional-email';
+
+export type NabisIdentityResolutionDecision = 'KEEP_CURRENT_OWNER' | 'TRANSFER_TO_INCOMING';
+
+type ResolutionConflict = Pick<
+  NabisIdentityConflictMetadata,
+  'incomingAccountId' | 'currentOwnerAccountId' | 'candidatePageId' | 'sourceIdentifiers'
+>;
+
+export function buildNabisIdentityResolutionActions(
+  conflict: ResolutionConflict,
+  decision: NabisIdentityResolutionDecision,
+) {
+  if (decision === 'KEEP_CURRENT_OWNER' && !conflict.currentOwnerAccountId) {
+    throw new Error('No current owner is available to keep.');
+  }
+  const targetAccountId = decision === 'KEEP_CURRENT_OWNER' ? conflict.currentOwnerAccountId! : conflict.incomingAccountId;
+  return {
+    targetAccountId,
+    clearOwnerAccountId:
+      decision === 'TRANSFER_TO_INCOMING' && conflict.currentOwnerAccountId !== conflict.incomingAccountId
+        ? conflict.currentOwnerAccountId
+        : null,
+    linkCandidatePageToTarget: decision === 'TRANSFER_TO_INCOMING',
+    identifiers: [
+      [AccountIdentityType.NOTION_PAGE_ID, conflict.candidatePageId],
+      [AccountIdentityType.LICENSED_LOCATION_ID, conflict.sourceIdentifiers.licensedLocationId],
+      [AccountIdentityType.NABIS_RETAILER_ID, conflict.sourceIdentifiers.nabisRetailerId],
+      [AccountIdentityType.LICENSE_NUMBER, conflict.sourceIdentifiers.licenseNumber],
+    ].filter((item): item is [AccountIdentityType, string] => Boolean(item[1])),
+  };
+}
+
+export async function getNabisIdentityReviewSettings(orgId: string) {
+  const [conflicts, recipient] = await Promise.all([
+    listNabisIdentityConflicts(orgId),
+    resolveNabisIdentityConflictRecipient(orgId),
+  ]);
+  return {
+    conflicts,
+    preference: {
+      email: recipient.email,
+      emailEnabled: recipient.emailEnabled,
+      inAppEnabled: recipient.inAppEnabled,
+    },
+    emailProviderReady: transactionalEmailReady(),
+  };
+}
+
+export async function saveNabisIdentityReviewPreference(input: {
+  orgId: string;
+  clerkUserId: string;
+  email: string;
+  emailEnabled: boolean;
+  inAppEnabled: boolean;
+}) {
+  return prisma.notificationPreference.upsert({
+    where: {
+      orgId_clerkUserId_category: {
+        orgId: input.orgId,
+        clerkUserId: input.clerkUserId,
+        category: NotificationCategory.EXCEPTIONS,
+      },
+    },
+    update: {
+      email: input.email.trim().toLowerCase(),
+      emailEnabled: input.emailEnabled,
+      inAppEnabled: input.inAppEnabled,
+    },
+    create: {
+      orgId: input.orgId,
+      clerkUserId: input.clerkUserId,
+      category: NotificationCategory.EXCEPTIONS,
+      email: input.email.trim().toLowerCase(),
+      emailEnabled: input.emailEnabled,
+      inAppEnabled: input.inAppEnabled,
+    },
+  });
+}
+
+export async function resolveNabisIdentityConflict(input: {
+  orgId: string;
+  notificationId: string;
+  decision: NabisIdentityResolutionDecision;
+  actor: { clerkUserId: string; email: string | null };
+}) {
+  const conflict = (await listNabisIdentityConflicts(input.orgId)).find((item) => item.id === input.notificationId);
+  if (!conflict || conflict.metadata.status !== 'OPEN') {
+    throw new Error('Open Nabis identity conflict not found.');
+  }
+
+  const liveOwner = await prisma.account.findFirst({
+    where: { orgId: input.orgId, notionPageId: conflict.metadata.candidatePageId },
+    select: { id: true },
+  });
+  const actions = buildNabisIdentityResolutionActions(
+    { ...conflict.metadata, currentOwnerAccountId: liveOwner?.id ?? conflict.metadata.currentOwnerAccountId },
+    input.decision,
+  );
+  const resolvedAt = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    const target = await tx.account.findFirst({ where: { id: actions.targetAccountId, orgId: input.orgId }, select: { id: true } });
+    if (!target) throw new Error('Selected account no longer exists.');
+
+    if (actions.clearOwnerAccountId) {
+      await tx.account.updateMany({
+        where: { id: actions.clearOwnerAccountId, orgId: input.orgId, notionPageId: conflict.metadata.candidatePageId },
+        data: { notionPageId: null },
+      });
+    }
+    if (actions.linkCandidatePageToTarget) {
+      await tx.account.update({ where: { id: actions.targetAccountId }, data: { notionPageId: conflict.metadata.candidatePageId } });
+    }
+    for (const [identityType, identityValue] of actions.identifiers) {
+      await tx.accountIdentityMapping.upsert({
+        where: {
+          orgId_identityType_normalizedValue: {
+            orgId: input.orgId,
+            identityType,
+            normalizedValue: normalizeIdentityValue(identityType, identityValue),
+          },
+        },
+        update: {
+          accountId: actions.targetAccountId,
+          identityValue,
+          source: 'NABIS_IDENTITY_REVIEW',
+          isOverride: true,
+          active: true,
+          createdByClerkUserId: input.actor.clerkUserId,
+          createdByEmail: input.actor.email,
+        },
+        create: {
+          orgId: input.orgId,
+          accountId: actions.targetAccountId,
+          identityType,
+          identityValue,
+          normalizedValue: normalizeIdentityValue(identityType, identityValue),
+          source: 'NABIS_IDENTITY_REVIEW',
+          isOverride: true,
+          active: true,
+          createdByClerkUserId: input.actor.clerkUserId,
+          createdByEmail: input.actor.email,
+        },
+      });
+    }
+
+    const metadata: NabisIdentityConflictMetadata = {
+      ...conflict.metadata,
+      status: 'RESOLVED',
+      resolution: {
+        decision: input.decision,
+        resolvedAt: resolvedAt.toISOString(),
+        resolvedByClerkUserId: input.actor.clerkUserId,
+        resolvedByEmail: input.actor.email,
+      },
+    };
+    await tx.notification.update({
+      where: { id: input.notificationId },
+      data: { readAt: resolvedAt, metadata: metadata as unknown as Prisma.InputJsonValue },
+    });
+    await tx.auditEvent.create({
+      data: {
+        orgId: input.orgId,
+        actorClerkUserId: input.actor.clerkUserId,
+        actorEmail: input.actor.email,
+        action: 'nabis_identity_conflict_resolved',
+        entityType: 'notification',
+        entityId: input.notificationId,
+        metadata: {
+          decision: input.decision,
+          targetAccountId: actions.targetAccountId,
+          conflictKey: conflict.metadata.conflictKey,
+        },
+      },
+    });
+  });
+
+  return { id: input.notificationId, status: 'RESOLVED' as const };
+}
+
+export { retryNabisIdentityConflictEmail };

--- a/lib/server/nabis-identity-conflicts.test.ts
+++ b/lib/server/nabis-identity-conflicts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assessNabisIdentityLink,
   createNabisIdentityConflictKey,
+  deliverNabisIdentityConflictEmail,
   recordNabisIdentityConflict,
   type IdentityConflictNotification,
 } from '@/lib/server/nabis-identity-conflicts';
@@ -165,5 +166,106 @@ describe('Nabis identity conflict lifecycle', () => {
       lastDetectedAt: '2026-08-14T14:00:00.000Z',
     });
     expect(opened).toBe(0);
+  });
+
+  it('records one idempotent opening email result without throwing on delivery failure', async () => {
+    const notification: IdentityConflictNotification = {
+      id: 'notification-1',
+      orgId: 'org-1',
+      recipientKey: 'user-1',
+      title: 'Nabis identity review required',
+      body: 'Review Incoming Account and Current Account.',
+      createdAt: '2026-08-14T14:00:00.000Z',
+      metadata: {
+        schemaVersion: 1,
+        kind: 'nabis_identity_conflict',
+        conflictKey: 'nabis-identity:abc123',
+        status: 'OPEN',
+        occurrenceCount: 1,
+        firstDetectedAt: '2026-08-14T14:00:00.000Z',
+        lastDetectedAt: '2026-08-14T14:00:00.000Z',
+        incomingAccountId: 'account-incoming',
+        incomingAccountName: 'Incoming Account',
+        candidatePageId: 'page-1',
+        currentOwnerAccountId: 'account-current',
+        currentOwnerAccountName: 'Current Account',
+        reason: 'license_conflict',
+        sourceIdentifiers: conflictInput().sourceIdentifiers,
+        email: { status: 'PENDING' },
+      },
+    };
+    const sends: Array<{ to: string; idempotencyKey: string }> = [];
+    const updates: IdentityConflictNotification[] = [];
+
+    await expect(
+      deliverNabisIdentityConflictEmail(notification, {
+        resolveRecipient: async () => ({ email: 'admin@piccplatform.com', enabled: true }),
+        send: async (message) => {
+          sends.push({ to: message.to, idempotencyKey: message.idempotencyKey });
+          return { status: 'FAILED' as const, providerMessageId: null, error: 'Transactional email delivery failed (422).' };
+        },
+        update: async (next) => {
+          updates.push(next);
+        },
+        now: () => new Date('2026-08-14T14:01:00.000Z'),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(sends).toEqual([
+      {
+        to: 'admin@piccplatform.com',
+        idempotencyKey: 'nabis-identity-review-notification-1',
+      },
+    ]);
+    expect(updates[0]?.metadata.email).toEqual({
+      status: 'FAILED',
+      providerMessageId: null,
+      error: 'Transactional email delivery failed (422).',
+      attemptedAt: '2026-08-14T14:01:00.000Z',
+    });
+  });
+
+  it('does not call the provider when email alerts are disabled', async () => {
+    const notification = {
+      id: 'notification-1',
+      orgId: 'org-1',
+      recipientKey: 'user-1',
+      title: 'Nabis identity review required',
+      body: 'Review Incoming Account.',
+      createdAt: '2026-08-14T14:00:00.000Z',
+      metadata: {
+        schemaVersion: 1 as const,
+        kind: 'nabis_identity_conflict' as const,
+        conflictKey: 'nabis-identity:abc123',
+        status: 'OPEN' as const,
+        occurrenceCount: 1,
+        firstDetectedAt: '2026-08-14T14:00:00.000Z',
+        lastDetectedAt: '2026-08-14T14:00:00.000Z',
+        incomingAccountId: 'account-incoming',
+        incomingAccountName: 'Incoming Account',
+        candidatePageId: 'page-1',
+        currentOwnerAccountId: null,
+        currentOwnerAccountName: null,
+        reason: 'license_conflict' as const,
+        sourceIdentifiers: conflictInput().sourceIdentifiers,
+        email: { status: 'PENDING' as const },
+      },
+    };
+    let sent = false;
+    const updates: IdentityConflictNotification[] = [];
+
+    await deliverNabisIdentityConflictEmail(notification, {
+      resolveRecipient: async () => ({ email: 'admin@piccplatform.com', enabled: false }),
+      send: async () => {
+        sent = true;
+        return { status: 'SENT' as const, providerMessageId: 'email-1', error: null };
+      },
+      update: async (next) => {
+        updates.push(next);
+      },
+    });
+
+    expect(sent).toBe(false);
+    expect(updates[0]?.metadata.email.status).toBe('UNAVAILABLE');
   });
 });

--- a/lib/server/nabis-identity-conflicts.test.ts
+++ b/lib/server/nabis-identity-conflicts.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assessNabisIdentityLink,
+  createNabisIdentityConflictKey,
+  recordNabisIdentityConflict,
+  type IdentityConflictNotification,
+} from '@/lib/server/nabis-identity-conflicts';
+
+describe('Nabis identity link assessment', () => {
+  it('requires review when the CRM adapter reports an ambiguous match', () => {
+    expect(
+      assessNabisIdentityLink({
+        reviewRequired: true,
+        incomingAccountId: 'account-incoming',
+        ownerAccountId: null,
+      }),
+    ).toBe('REVIEW');
+  });
+
+  it('requires review when another account owns the candidate page', () => {
+    expect(
+      assessNabisIdentityLink({
+        reviewRequired: false,
+        incomingAccountId: 'account-incoming',
+        ownerAccountId: 'account-current-owner',
+      }),
+    ).toBe('REVIEW');
+  });
+
+  it('links exact unowned and same-owner pages', () => {
+    expect(
+      assessNabisIdentityLink({
+        reviewRequired: false,
+        incomingAccountId: 'account-incoming',
+        ownerAccountId: null,
+      }),
+    ).toBe('LINK');
+    expect(
+      assessNabisIdentityLink({
+        reviewRequired: false,
+        incomingAccountId: 'account-incoming',
+        ownerAccountId: 'account-incoming',
+      }),
+    ).toBe('LINK');
+  });
+
+  it('builds a stable conflict key from normalized identity evidence', () => {
+    const first = createNabisIdentityConflictKey({
+      orgId: 'ORG-1',
+      incomingAccountId: 'ACCOUNT-1',
+      candidatePageId: 'ABC-DEF',
+      reason: 'license_conflict',
+    });
+    const second = createNabisIdentityConflictKey({
+      orgId: ' org-1 ',
+      incomingAccountId: 'account-1',
+      candidatePageId: 'abcdef',
+      reason: 'license_conflict',
+    });
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^nabis-identity:[a-f0-9]{64}$/);
+  });
+});
+
+describe('Nabis identity conflict lifecycle', () => {
+  function conflictInput() {
+    return {
+      orgId: 'org-1',
+      recipientKey: 'user-1',
+      incomingAccountId: 'account-incoming',
+      incomingAccountName: 'Incoming Account',
+      candidatePageId: 'page-1',
+      currentOwnerAccountId: 'account-current',
+      currentOwnerAccountName: 'Current Account',
+      reason: 'license_conflict' as const,
+      sourceIdentifiers: {
+        licensedLocationId: 'location-1',
+        nabisRetailerId: 'retailer-1',
+        licenseNumber: 'license-1',
+      },
+    };
+  }
+
+  it('opens one notification and calls the opening hook once', async () => {
+    const opened: IdentityConflictNotification[] = [];
+    const created: IdentityConflictNotification[] = [];
+    const result = await recordNabisIdentityConflict(conflictInput(), {
+      findOpenByKey: async () => null,
+      create: async (notification) => {
+        const persisted = { ...notification, id: 'notification-1' };
+        created.push(persisted);
+        return persisted;
+      },
+      update: async () => {
+        throw new Error('Unexpected update');
+      },
+      onOpened: async (notification) => {
+        opened.push(notification);
+      },
+      now: () => new Date('2026-08-14T14:00:00.000Z'),
+    });
+
+    expect(result.created).toBe(true);
+    expect(created).toHaveLength(1);
+    expect(created[0]?.metadata).toMatchObject({
+      status: 'OPEN',
+      occurrenceCount: 1,
+      firstDetectedAt: '2026-08-14T14:00:00.000Z',
+      lastDetectedAt: '2026-08-14T14:00:00.000Z',
+    });
+    expect(opened).toHaveLength(1);
+  });
+
+  it('updates the existing open item without calling the opening hook again', async () => {
+    const key = createNabisIdentityConflictKey(conflictInput());
+    const existing: IdentityConflictNotification = {
+      id: 'notification-1',
+      orgId: 'org-1',
+      recipientKey: 'user-1',
+      title: 'Nabis identity review required',
+      body: 'Review Incoming Account and Current Account.',
+      createdAt: '2026-08-14T13:00:00.000Z',
+      metadata: {
+        schemaVersion: 1,
+        kind: 'nabis_identity_conflict',
+        conflictKey: key,
+        status: 'OPEN',
+        occurrenceCount: 1,
+        firstDetectedAt: '2026-08-14T13:00:00.000Z',
+        lastDetectedAt: '2026-08-14T13:00:00.000Z',
+        incomingAccountId: 'account-incoming',
+        incomingAccountName: 'Incoming Account',
+        candidatePageId: 'page-1',
+        currentOwnerAccountId: 'account-current',
+        currentOwnerAccountName: 'Current Account',
+        reason: 'license_conflict',
+        sourceIdentifiers: conflictInput().sourceIdentifiers,
+        email: { status: 'PENDING' },
+      },
+    };
+    let opened = 0;
+    const updates: IdentityConflictNotification[] = [];
+
+    const result = await recordNabisIdentityConflict(conflictInput(), {
+      findOpenByKey: async () => existing,
+      create: async () => {
+        throw new Error('Unexpected create');
+      },
+      update: async (_id, notification) => {
+        const updated = { ...existing, ...notification, id: existing.id };
+        updates.push(updated);
+        return updated;
+      },
+      onOpened: async () => {
+        opened += 1;
+      },
+      now: () => new Date('2026-08-14T14:00:00.000Z'),
+    });
+
+    expect(result.created).toBe(false);
+    expect(updates[0]?.metadata).toMatchObject({
+      occurrenceCount: 2,
+      firstDetectedAt: '2026-08-14T13:00:00.000Z',
+      lastDetectedAt: '2026-08-14T14:00:00.000Z',
+    });
+    expect(opened).toBe(0);
+  });
+});

--- a/lib/server/nabis-identity-conflicts.ts
+++ b/lib/server/nabis-identity-conflicts.ts
@@ -263,7 +263,7 @@ export async function deliverNabisIdentityConflictEmail(
   });
 }
 
-function parseConflictMetadata(value: Prisma.JsonValue): NabisIdentityConflictMetadata | null {
+export function parseNabisIdentityConflictMetadata(value: Prisma.JsonValue): NabisIdentityConflictMetadata | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return null;
   }
@@ -279,7 +279,7 @@ function parseConflictMetadata(value: Prisma.JsonValue): NabisIdentityConflictMe
 }
 
 function fromPrismaNotification(row: PrismaNotificationRow): IdentityConflictNotification | null {
-  const metadata = parseConflictMetadata(row.metadata);
+  const metadata = parseNabisIdentityConflictMetadata(row.metadata);
   if (!metadata) return null;
   return {
     id: row.id,
@@ -397,4 +397,18 @@ export async function persistNabisIdentityConflict(
         });
       }),
   });
+}
+
+export async function retryNabisIdentityConflictEmail(orgId: string, notificationId: string) {
+  const notification = (await listNabisIdentityConflicts(orgId)).find((item) => item.id === notificationId);
+  if (!notification || notification.metadata.status !== 'OPEN') {
+    throw new Error('Open Nabis identity conflict not found.');
+  }
+  const recipient = await resolveNabisIdentityConflictRecipient(orgId);
+  await deliverNabisIdentityConflictEmail(notification, {
+    resolveRecipient: async () => ({ email: recipient.email, enabled: recipient.emailEnabled }),
+    send: sendTransactionalEmail,
+    update: updateConflictEmailState,
+  });
+  return (await listNabisIdentityConflicts(orgId)).find((item) => item.id === notificationId) ?? notification;
 }

--- a/lib/server/nabis-identity-conflicts.ts
+++ b/lib/server/nabis-identity-conflicts.ts
@@ -1,8 +1,9 @@
 import 'server-only';
 
 import { createHash } from 'node:crypto';
-import { Prisma } from '@prisma/client';
+import { NotificationCategory, Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db/prisma';
+import { sendTransactionalEmail, type TransactionalEmailResult } from '@/lib/server/transactional-email';
 
 export type NabisIdentityReviewReason =
   | 'nabis_retailer_id_conflict'
@@ -76,6 +77,19 @@ type IdentityConflictRepository = {
   create: (notification: IdentityConflictNotificationDraft) => Promise<IdentityConflictNotification>;
   update: (id: string, notification: IdentityConflictNotificationDraft) => Promise<IdentityConflictNotification>;
   onOpened?: (notification: IdentityConflictNotification) => Promise<void>;
+  now?: () => Date;
+};
+
+type ConflictEmailDependencies = {
+  resolveRecipient: () => Promise<{ email: string; enabled: boolean }>;
+  send: (message: {
+    to: string;
+    subject: string;
+    text: string;
+    html: string;
+    idempotencyKey: string;
+  }) => Promise<TransactionalEmailResult>;
+  update: (notification: IdentityConflictNotification) => Promise<void>;
   now?: () => Date;
 };
 
@@ -181,6 +195,74 @@ export async function recordNabisIdentityConflict(input: NabisIdentityConflictIn
   return { notification, created: true };
 }
 
+function escapeHtml(value: string) {
+  return value.replace(/[&<>'"]/g, (character) => {
+    const entities: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      "'": '&#39;',
+      '"': '&quot;',
+    };
+    return entities[character] ?? character;
+  });
+}
+
+export async function deliverNabisIdentityConflictEmail(
+  notification: IdentityConflictNotification,
+  dependencies: ConflictEmailDependencies,
+) {
+  const recipient = await dependencies.resolveRecipient();
+  const attemptedAt = (dependencies.now ?? (() => new Date()))().toISOString();
+
+  if (!recipient.enabled) {
+    await dependencies.update({
+      ...notification,
+      metadata: {
+        ...notification.metadata,
+        email: {
+          status: 'UNAVAILABLE',
+          providerMessageId: null,
+          error: 'Email alerts are disabled.',
+          attemptedAt,
+        },
+      },
+    });
+    return;
+  }
+
+  const settingsUrl = `${process.env.PICC_APP_BASE_URL?.trim() || 'https://piccnewyork.org'}/settings#nabis-identity-review`;
+  const incomingName = notification.metadata.incomingAccountName;
+  const currentName = notification.metadata.currentOwnerAccountName ?? 'an existing CRM record';
+  const subject = `PICC identity review: ${incomingName}`;
+  const text = [
+    `${incomingName} needs identity review against ${currentName}.`,
+    'Sales ingestion continued; no ambiguous ownership change was made.',
+    `Review and resolve: ${settingsUrl}`,
+  ].join('\n\n');
+  const html = `<p><strong>${escapeHtml(incomingName)}</strong> needs identity review against ${escapeHtml(currentName)}.</p><p>Sales ingestion continued; no ambiguous ownership change was made.</p><p><a href="${escapeHtml(settingsUrl)}">Review and resolve in PICC Settings</a></p>`;
+  const result = await dependencies.send({
+    to: recipient.email,
+    subject,
+    text,
+    html,
+    idempotencyKey: `nabis-identity-review-${notification.id}`,
+  });
+
+  await dependencies.update({
+    ...notification,
+    metadata: {
+      ...notification.metadata,
+      email: {
+        status: result.status,
+        providerMessageId: result.providerMessageId,
+        error: result.error,
+        attemptedAt,
+      },
+    },
+  });
+}
+
 function parseConflictMetadata(value: Prisma.JsonValue): NabisIdentityConflictMetadata | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return null;
@@ -222,13 +304,59 @@ export async function listNabisIdentityConflicts(orgId: string) {
   return rows.map(fromPrismaNotification).filter((row): row is IdentityConflictNotification => Boolean(row));
 }
 
+export async function resolveNabisIdentityConflictRecipient(orgId: string) {
+  const preference = await prisma.notificationPreference.findFirst({
+    where: {
+      orgId,
+      category: NotificationCategory.EXCEPTIONS,
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+  const email = preference?.email?.trim().toLowerCase() || process.env.PICC_ADMIN_EMAIL?.trim().toLowerCase() || 'bryce@piccplatform.com';
+  const session = preference?.clerkUserId
+    ? null
+    : await prisma.appSessionAudit.findFirst({
+        where: {
+          orgId,
+          email: {
+            equals: email,
+            mode: 'insensitive',
+          },
+        },
+        orderBy: { lastSeenAt: 'desc' },
+        select: { clerkUserId: true },
+      });
+
+  return {
+    email,
+    emailEnabled: preference?.emailEnabled ?? true,
+    inAppEnabled: preference?.inAppEnabled ?? true,
+    clerkUserId: preference?.clerkUserId ?? session?.clerkUserId ?? null,
+    recipientKey: preference?.clerkUserId ?? session?.clerkUserId ?? `email:${email}`,
+  };
+}
+
+async function updateConflictEmailState(notification: IdentityConflictNotification) {
+  await prisma.notification.update({
+    where: { id: notification.id },
+    data: {
+      metadata: notification.metadata as unknown as Prisma.InputJsonValue,
+    },
+  });
+}
+
 export async function persistNabisIdentityConflict(
   input: NabisIdentityConflictInput,
   options?: { onOpened?: (notification: IdentityConflictNotification) => Promise<void> },
 ) {
-  return recordNabisIdentityConflict(input, {
+  const recipient = await resolveNabisIdentityConflictRecipient(input.orgId);
+  const normalizedInput = {
+    ...input,
+    recipientKey: recipient.recipientKey,
+  };
+  return recordNabisIdentityConflict(normalizedInput, {
     findOpenByKey: async (conflictKey) => {
-      const conflicts = await listNabisIdentityConflicts(input.orgId);
+      const conflicts = await listNabisIdentityConflicts(normalizedInput.orgId);
       return conflicts.find((conflict) => conflict.metadata.status === 'OPEN' && conflict.metadata.conflictKey === conflictKey) ?? null;
     },
     create: async (notification) => {
@@ -259,6 +387,14 @@ export async function persistNabisIdentityConflict(
       if (!mapped) throw new Error('Updated identity conflict could not be read back.');
       return mapped;
     },
-    onOpened: options?.onOpened,
+    onOpened:
+      options?.onOpened ??
+      (async (notification) => {
+        await deliverNabisIdentityConflictEmail(notification, {
+          resolveRecipient: async () => ({ email: recipient.email, enabled: recipient.emailEnabled }),
+          send: sendTransactionalEmail,
+          update: updateConflictEmailState,
+        });
+      }),
   });
 }

--- a/lib/server/nabis-identity-conflicts.ts
+++ b/lib/server/nabis-identity-conflicts.ts
@@ -1,0 +1,264 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/db/prisma';
+
+export type NabisIdentityReviewReason =
+  | 'nabis_retailer_id_conflict'
+  | 'license_conflict'
+  | 'name_location_conflict'
+  | 'page_owned_by_another_account';
+
+export type NabisIdentityConflictStatus = 'OPEN' | 'RESOLVED';
+
+export type NabisIdentityConflictEmail = {
+  status: 'PENDING' | 'SENT' | 'FAILED' | 'UNAVAILABLE';
+  providerMessageId?: string | null;
+  error?: string | null;
+  attemptedAt?: string | null;
+};
+
+export type NabisIdentityConflictMetadata = {
+  schemaVersion: 1;
+  kind: 'nabis_identity_conflict';
+  conflictKey: string;
+  status: NabisIdentityConflictStatus;
+  occurrenceCount: number;
+  firstDetectedAt: string;
+  lastDetectedAt: string;
+  incomingAccountId: string;
+  incomingAccountName: string;
+  candidatePageId: string;
+  currentOwnerAccountId: string | null;
+  currentOwnerAccountName: string | null;
+  reason: NabisIdentityReviewReason;
+  sourceIdentifiers: {
+    licensedLocationId: string | null;
+    nabisRetailerId: string | null;
+    licenseNumber: string | null;
+  };
+  email: NabisIdentityConflictEmail;
+  resolution?: {
+    decision: 'KEEP_CURRENT_OWNER' | 'TRANSFER_TO_INCOMING';
+    resolvedAt: string;
+    resolvedByClerkUserId: string;
+    resolvedByEmail: string | null;
+  };
+};
+
+export type IdentityConflictNotification = {
+  id: string;
+  orgId: string;
+  recipientKey: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  metadata: NabisIdentityConflictMetadata;
+};
+
+export type NabisIdentityConflictInput = {
+  orgId: string;
+  recipientKey: string;
+  incomingAccountId: string;
+  incomingAccountName: string;
+  candidatePageId: string;
+  currentOwnerAccountId: string | null;
+  currentOwnerAccountName: string | null;
+  reason: NabisIdentityReviewReason;
+  sourceIdentifiers: NabisIdentityConflictMetadata['sourceIdentifiers'];
+};
+
+type IdentityConflictNotificationDraft = Omit<IdentityConflictNotification, 'id'>;
+
+type IdentityConflictRepository = {
+  findOpenByKey: (conflictKey: string) => Promise<IdentityConflictNotification | null>;
+  create: (notification: IdentityConflictNotificationDraft) => Promise<IdentityConflictNotification>;
+  update: (id: string, notification: IdentityConflictNotificationDraft) => Promise<IdentityConflictNotification>;
+  onOpened?: (notification: IdentityConflictNotification) => Promise<void>;
+  now?: () => Date;
+};
+
+type PrismaNotificationRow = {
+  id: string;
+  orgId: string;
+  userClerkId: string;
+  title: string;
+  body: string | null;
+  metadata: Prisma.JsonValue;
+  createdAt: Date;
+};
+
+export function assessNabisIdentityLink(input: {
+  reviewRequired: boolean;
+  incomingAccountId: string;
+  ownerAccountId: string | null;
+}): 'LINK' | 'REVIEW' {
+  if (input.reviewRequired) {
+    return 'REVIEW';
+  }
+
+  if (input.ownerAccountId && input.ownerAccountId !== input.incomingAccountId) {
+    return 'REVIEW';
+  }
+
+  return 'LINK';
+}
+
+function normalizedKeyPart(value: string) {
+  return value.trim().toLowerCase().replaceAll('-', '');
+}
+
+export function createNabisIdentityConflictKey(input: {
+  orgId: string;
+  incomingAccountId: string;
+  candidatePageId: string;
+  reason: NabisIdentityReviewReason;
+}) {
+  const payload = [input.orgId, input.incomingAccountId, input.candidatePageId, input.reason]
+    .map(normalizedKeyPart)
+    .join(':');
+  return `nabis-identity:${createHash('sha256').update(payload).digest('hex')}`;
+}
+
+export async function recordNabisIdentityConflict(input: NabisIdentityConflictInput, repository: IdentityConflictRepository) {
+  const now = (repository.now ?? (() => new Date()))().toISOString();
+  const conflictKey = createNabisIdentityConflictKey(input);
+  const existing = await repository.findOpenByKey(conflictKey);
+
+  if (existing) {
+    const updated = await repository.update(existing.id, {
+      ...existing,
+      orgId: input.orgId,
+      recipientKey: input.recipientKey,
+      body: `Review ${input.incomingAccountName} and ${input.currentOwnerAccountName ?? 'the candidate CRM record'}.`,
+      metadata: {
+        ...existing.metadata,
+        occurrenceCount: existing.metadata.occurrenceCount + 1,
+        lastDetectedAt: now,
+        incomingAccountName: input.incomingAccountName,
+        currentOwnerAccountId: input.currentOwnerAccountId,
+        currentOwnerAccountName: input.currentOwnerAccountName,
+        sourceIdentifiers: input.sourceIdentifiers,
+      },
+    });
+    return { notification: updated, created: false };
+  }
+
+  const notification = await repository.create({
+    orgId: input.orgId,
+    recipientKey: input.recipientKey,
+    title: 'Nabis identity review required',
+    body: `Review ${input.incomingAccountName} and ${input.currentOwnerAccountName ?? 'the candidate CRM record'}.`,
+    createdAt: now,
+    metadata: {
+      schemaVersion: 1,
+      kind: 'nabis_identity_conflict',
+      conflictKey,
+      status: 'OPEN',
+      occurrenceCount: 1,
+      firstDetectedAt: now,
+      lastDetectedAt: now,
+      incomingAccountId: input.incomingAccountId,
+      incomingAccountName: input.incomingAccountName,
+      candidatePageId: input.candidatePageId,
+      currentOwnerAccountId: input.currentOwnerAccountId,
+      currentOwnerAccountName: input.currentOwnerAccountName,
+      reason: input.reason,
+      sourceIdentifiers: input.sourceIdentifiers,
+      email: { status: 'PENDING' },
+    },
+  });
+
+  if (repository.onOpened) {
+    try {
+      await repository.onOpened(notification);
+    } catch {
+      // Opening a review item must not fail the sales sync when notification delivery fails.
+    }
+  }
+
+  return { notification, created: true };
+}
+
+function parseConflictMetadata(value: Prisma.JsonValue): NabisIdentityConflictMetadata | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const metadata = value as Record<string, unknown>;
+  if (
+    metadata.kind !== 'nabis_identity_conflict' ||
+    typeof metadata.conflictKey !== 'string' ||
+    (metadata.status !== 'OPEN' && metadata.status !== 'RESOLVED')
+  ) {
+    return null;
+  }
+  return metadata as NabisIdentityConflictMetadata;
+}
+
+function fromPrismaNotification(row: PrismaNotificationRow): IdentityConflictNotification | null {
+  const metadata = parseConflictMetadata(row.metadata);
+  if (!metadata) return null;
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    recipientKey: row.userClerkId,
+    title: row.title,
+    body: row.body ?? '',
+    createdAt: row.createdAt.toISOString(),
+    metadata,
+  };
+}
+
+export async function listNabisIdentityConflicts(orgId: string) {
+  const rows = await prisma.notification.findMany({
+    where: {
+      orgId,
+      title: 'Nabis identity review required',
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 500,
+  });
+  return rows.map(fromPrismaNotification).filter((row): row is IdentityConflictNotification => Boolean(row));
+}
+
+export async function persistNabisIdentityConflict(
+  input: NabisIdentityConflictInput,
+  options?: { onOpened?: (notification: IdentityConflictNotification) => Promise<void> },
+) {
+  return recordNabisIdentityConflict(input, {
+    findOpenByKey: async (conflictKey) => {
+      const conflicts = await listNabisIdentityConflicts(input.orgId);
+      return conflicts.find((conflict) => conflict.metadata.status === 'OPEN' && conflict.metadata.conflictKey === conflictKey) ?? null;
+    },
+    create: async (notification) => {
+      const row = await prisma.notification.create({
+        data: {
+          orgId: notification.orgId,
+          userClerkId: notification.recipientKey,
+          title: notification.title,
+          body: notification.body,
+          metadata: notification.metadata as unknown as Prisma.InputJsonValue,
+        },
+      });
+      const mapped = fromPrismaNotification(row);
+      if (!mapped) throw new Error('Created identity conflict could not be read back.');
+      return mapped;
+    },
+    update: async (id, notification) => {
+      const row = await prisma.notification.update({
+        where: { id },
+        data: {
+          userClerkId: notification.recipientKey,
+          title: notification.title,
+          body: notification.body,
+          metadata: notification.metadata as unknown as Prisma.InputJsonValue,
+        },
+      });
+      const mapped = fromPrismaNotification(row);
+      if (!mapped) throw new Error('Updated identity conflict could not be read back.');
+      return mapped;
+    },
+    onOpened: options?.onOpened,
+  });
+}

--- a/lib/server/nabis-sync-status.test.ts
+++ b/lib/server/nabis-sync-status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { IntegrationSyncStatus } from '@prisma/client';
+import { resolveLastSuccessfulSyncAt } from '@/lib/server/nabis-sync-status';
+
+describe('Nabis successful freshness timestamps', () => {
+  it('uses the latest successful run instead of a failed checkpoint update', () => {
+    expect(
+      resolveLastSuccessfulSyncAt({
+        checkpointStatus: IntegrationSyncStatus.ERROR,
+        checkpointMetadata: { error: 'failed attempt' },
+        checkpointUpdatedAt: new Date('2026-08-14T14:00:00.000Z'),
+        latestSuccessfulRunFinishedAt: new Date('2026-08-07T05:06:03.022Z'),
+      }),
+    ).toBe('2026-08-07T05:06:03.022Z');
+  });
+
+  it('uses a successful checkpoint update when no explicit success timestamp exists', () => {
+    expect(
+      resolveLastSuccessfulSyncAt({
+        checkpointStatus: IntegrationSyncStatus.SUCCESS,
+        checkpointMetadata: {},
+        checkpointUpdatedAt: new Date('2026-08-14T14:00:00.000Z'),
+        latestSuccessfulRunFinishedAt: null,
+      }),
+    ).toBe('2026-08-14T14:00:00.000Z');
+  });
+
+  it('prefers the explicit successful timestamp preserved in checkpoint metadata', () => {
+    expect(
+      resolveLastSuccessfulSyncAt({
+        checkpointStatus: IntegrationSyncStatus.ERROR,
+        checkpointMetadata: { lastSuccessfulSyncAt: '2026-08-13T10:00:00.000Z' },
+        checkpointUpdatedAt: new Date('2026-08-14T14:00:00.000Z'),
+        latestSuccessfulRunFinishedAt: new Date('2026-08-12T10:00:00.000Z'),
+      }),
+    ).toBe('2026-08-13T10:00:00.000Z');
+  });
+});

--- a/lib/server/nabis-sync-status.ts
+++ b/lib/server/nabis-sync-status.ts
@@ -54,10 +54,19 @@ function isoOrNull(value: Date | string | null | undefined) {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
-function lastSuccessfulSyncAt(metadata: CheckpointMetadata, updatedAt: Date, status: IntegrationSyncStatus) {
+export function resolveLastSuccessfulSyncAt(input: {
+  checkpointStatus: IntegrationSyncStatus | null | undefined;
+  checkpointMetadata: unknown;
+  checkpointUpdatedAt: Date | null | undefined;
+  latestSuccessfulRunFinishedAt: Date | null | undefined;
+}) {
+  const metadata = metadataObject(input.checkpointMetadata);
   const explicit = stringValue(metadata.lastSuccessfulSyncAt);
   if (explicit) return explicit;
-  return status === IntegrationSyncStatus.SUCCESS ? updatedAt.toISOString() : null;
+  if (input.checkpointStatus === IntegrationSyncStatus.SUCCESS && input.checkpointUpdatedAt) {
+    return input.checkpointUpdatedAt.toISOString();
+  }
+  return input.latestSuccessfulRunFinishedAt?.toISOString() ?? null;
 }
 
 export async function getNabisAdminSyncStatus(orgId: string) {
@@ -121,6 +130,28 @@ export async function getNabisAdminSyncStatus(orgId: string) {
     }),
   ]);
 
+  const successfulRuns = await prisma.syncRun.findMany({
+    where: {
+      orgId,
+      status: IntegrationSyncStatus.SUCCESS,
+      module: {
+        in: [...NABIS_STATUS_MODULES],
+      },
+    },
+    orderBy: { finishedAt: 'desc' },
+    take: 100,
+    select: {
+      module: true,
+      finishedAt: true,
+    },
+  });
+  const latestSuccessfulRunByModule = new Map<string, Date>();
+  for (const run of successfulRuns) {
+    if (run.finishedAt && !latestSuccessfulRunByModule.has(run.module)) {
+      latestSuccessfulRunByModule.set(run.module, run.finishedAt);
+    }
+  }
+
   const checkpoints = new Map((integration?.checkpoints ?? []).map((checkpoint) => [checkpoint.module as NabisStatusModule, checkpoint]));
   const modules = NABIS_STATUS_MODULES.map((module) => {
     const checkpoint = checkpoints.get(module);
@@ -129,7 +160,13 @@ export async function getNabisAdminSyncStatus(orgId: string) {
       module,
       status: checkpoint?.status ?? IntegrationSyncStatus.IDLE,
       updatedAt: checkpoint?.updatedAt.toISOString() ?? null,
-      lastSuccessfulSyncAt: checkpoint ? lastSuccessfulSyncAt(metadata, checkpoint.updatedAt, checkpoint.status) : null,
+      lastSuccessfulSyncAt: resolveLastSuccessfulSyncAt({
+        checkpointStatus: checkpoint?.status,
+        checkpointMetadata: checkpoint?.metadata,
+        checkpointUpdatedAt: checkpoint?.updatedAt,
+        latestSuccessfulRunFinishedAt: latestSuccessfulRunByModule.get(module),
+      }),
+      lastAttemptAt: checkpoint?.updatedAt.toISOString() ?? null,
       error: stringValue(metadata.error),
       rateLimited: metadata.rateLimited === true,
       retryAfterMs: numberValue(metadata.retryAfterMs),

--- a/lib/server/nabis-sync.test.ts
+++ b/lib/server/nabis-sync.test.ts
@@ -10,8 +10,30 @@ import {
   pageIsOlderThanCutoff,
   parseNabisOrderForCache,
   parseNabisOrderLineForCache,
+  runNabisSalesFirstSync,
   staleNabisRetailerIdsMissingFromFeed,
 } from '@/lib/server/nabis-sync';
+
+describe('Nabis combined sync sequencing', () => {
+  it('commits order ingestion before retailer CRM work can fail', async () => {
+    const events: string[] = [];
+
+    await expect(
+      runNabisSalesFirstSync({
+        syncOrders: async () => {
+          events.push('orders');
+          return { orders: 12 };
+        },
+        syncRetailers: async () => {
+          events.push('retailers');
+          throw new Error('CRM unavailable');
+        },
+      }),
+    ).rejects.toThrow('CRM unavailable');
+
+    expect(events).toEqual(['orders', 'retailers']);
+  });
+});
 
 describe('Nabis sync line cache parsing', () => {
   it('stores promo-adjusted order totals for NY V2 orders with discounts', () => {

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -8,6 +8,7 @@ import { appendAuditEvent } from '@/lib/server/audit-log';
 import { ensureDispensaryCrmPageFromRetailer } from '@/lib/server/notion-crm-sync';
 import { ensureActivePolicySnapshot } from '@/lib/server/policy-snapshots';
 import { assessNabisIdentityLink, persistNabisIdentityConflict } from '@/lib/server/nabis-identity-conflicts';
+import { resolveLastSuccessfulSyncAt } from '@/lib/server/nabis-sync-status';
 import { excludedInternalTransferRetailers, isExcludedInternalTransferRetailerName } from '@/lib/nabis/internal-transfers';
 
 const DEFAULT_API_BASE_URL = 'https://platform-api.nabis.pro';
@@ -1936,6 +1937,15 @@ async function syncNabisOrdersCore(orgId: string, integrationId: string, actor?:
   });
 }
 
+export async function runNabisSalesFirstSync<TOrders, TRetailers>(input: {
+  syncOrders: () => Promise<TOrders>;
+  syncRetailers: () => Promise<TRetailers>;
+}) {
+  const orders = await input.syncOrders();
+  const retailers = await input.syncRetailers();
+  return { orders, retailers };
+}
+
 export async function syncNabisRetailersAndOrders(orgId: string, actor?: SyncActor, options?: OrderSyncOptions & { syncCrm?: boolean }) {
   await ensureActivePolicySnapshot(orgId, actor);
   const integration = await ensureNabisIntegration(orgId);
@@ -1943,13 +1953,10 @@ export async function syncNabisRetailersAndOrders(orgId: string, actor?: SyncAct
   return withNabisSyncLease(
     { orgId, integrationId: integration.id, module: options?.historicalBackfill ? 'retailers_and_orders_historical_backfill' : options?.reconciliation ? 'retailers_and_orders_reconcile' : 'retailers_and_orders', actor },
     async () => {
-      const retailerResult = await syncNabisRetailersCore(orgId, integration.id, actor, { syncCrm: options?.syncCrm === true });
-      const orderResult = await syncNabisOrdersCore(orgId, integration.id, actor, options);
-
-      return {
-        retailers: retailerResult,
-        orders: orderResult,
-      };
+      return runNabisSalesFirstSync({
+        syncOrders: () => syncNabisOrdersCore(orgId, integration.id, actor, options),
+        syncRetailers: () => syncNabisRetailersCore(orgId, integration.id, actor, { syncCrm: options?.syncCrm === true }),
+      });
     },
   );
 }
@@ -1976,6 +1983,18 @@ export async function getNabisSyncFreshness(orgId: string) {
           updatedAt: true,
         },
       },
+      syncRuns: {
+        where: {
+          status: IntegrationSyncStatus.SUCCESS,
+          module: { in: ['retailers', 'orders', 'orders_reconcile'] },
+        },
+        orderBy: { finishedAt: 'desc' },
+        take: 30,
+        select: {
+          module: true,
+          finishedAt: true,
+        },
+      },
     },
   });
 
@@ -1985,25 +2004,37 @@ export async function getNabisSyncFreshness(orgId: string) {
   const orderCheckpoint = byModule.get('orders');
   const reconcileCheckpoint = byModule.get('orders_reconcile');
   const leaseCheckpoint = byModule.get(NABIS_SYNC_LEASE_MODULE);
+  const latestSuccessfulRunByModule = new Map<string, Date>();
+  for (const run of integration?.syncRuns ?? []) {
+    if (run.finishedAt && !latestSuccessfulRunByModule.has(run.module)) {
+      latestSuccessfulRunByModule.set(run.module, run.finishedAt);
+    }
+  }
 
-  const orderSyncAt =
-    ((orderCheckpoint?.metadata as Record<string, unknown> | null)?.lastSuccessfulSyncAt as string | undefined) ??
-    orderCheckpoint?.updatedAt.toISOString() ??
-    null;
-  const retailerSyncAt =
-    ((retailerCheckpoint?.metadata as Record<string, unknown> | null)?.lastSuccessfulSyncAt as string | undefined) ??
-    retailerCheckpoint?.updatedAt.toISOString() ??
-    null;
+  const orderSyncAt = resolveLastSuccessfulSyncAt({
+    checkpointStatus: orderCheckpoint?.status,
+    checkpointMetadata: orderCheckpoint?.metadata,
+    checkpointUpdatedAt: orderCheckpoint?.updatedAt,
+    latestSuccessfulRunFinishedAt: latestSuccessfulRunByModule.get('orders'),
+  });
+  const retailerSyncAt = resolveLastSuccessfulSyncAt({
+    checkpointStatus: retailerCheckpoint?.status,
+    checkpointMetadata: retailerCheckpoint?.metadata,
+    checkpointUpdatedAt: retailerCheckpoint?.updatedAt,
+    latestSuccessfulRunFinishedAt: latestSuccessfulRunByModule.get('retailers'),
+  });
 
   return {
     integrationStatus: integration?.status ?? IntegrationSyncStatus.IDLE,
     lastSyncAt: integration?.lastSyncedAt?.toISOString() ?? null,
     lastOrderSyncAt: orderSyncAt,
     lastRetailerSyncAt: retailerSyncAt,
-    lastReconciliationAt:
-      ((reconcileCheckpoint?.metadata as Record<string, unknown> | null)?.lastSuccessfulSyncAt as string | undefined) ??
-      reconcileCheckpoint?.updatedAt.toISOString() ??
-      null,
+    lastReconciliationAt: resolveLastSuccessfulSyncAt({
+      checkpointStatus: reconcileCheckpoint?.status,
+      checkpointMetadata: reconcileCheckpoint?.metadata,
+      checkpointUpdatedAt: reconcileCheckpoint?.updatedAt,
+      latestSuccessfulRunFinishedAt: latestSuccessfulRunByModule.get('orders_reconcile'),
+    }),
     activeSync: activeNabisSyncFromLease({
       status: leaseCheckpoint?.status,
       metadata: leaseCheckpoint?.metadata,

--- a/lib/server/nabis-sync.ts
+++ b/lib/server/nabis-sync.ts
@@ -7,6 +7,7 @@ import { ensureAccountIdentityMappings, resolveCanonicalAccountByIdentifiers } f
 import { appendAuditEvent } from '@/lib/server/audit-log';
 import { ensureDispensaryCrmPageFromRetailer } from '@/lib/server/notion-crm-sync';
 import { ensureActivePolicySnapshot } from '@/lib/server/policy-snapshots';
+import { assessNabisIdentityLink, persistNabisIdentityConflict } from '@/lib/server/nabis-identity-conflicts';
 import { excludedInternalTransferRetailers, isExcludedInternalTransferRetailerName } from '@/lib/nabis/internal-transfers';
 
 const DEFAULT_API_BASE_URL = 'https://platform-api.nabis.pro';
@@ -223,6 +224,14 @@ function requiredApiKey() {
     throw new Error('NABIS_API_KEY is required');
   }
   return apiKey;
+}
+
+function identityConflictRecipientKey(actor?: SyncActor) {
+  if (actor?.clerkUserId?.trim()) {
+    return actor.clerkUserId.trim();
+  }
+  const adminEmail = process.env.PICC_ADMIN_EMAIL?.trim().toLowerCase() || 'bryce@piccplatform.com';
+  return `email:${adminEmail}`;
 }
 
 function getApiBaseUrl() {
@@ -1239,26 +1248,64 @@ async function upsertLocalAccountFromRetailer(
       notionPageId: account.notionPageId,
     });
     notionPageId = notion.pageId;
-
-    await prisma.account.update({
-      where: { id: account.id },
-      data: {
+    const currentOwner = await prisma.account.findFirst({
+      where: {
+        orgId,
         notionPageId,
       },
-    });
-
-    await appendAuditEvent({
-      orgId,
-      action: notion.created ? 'CRM_ACCOUNT_CREATED_FROM_NABIS' : 'CRM_ACCOUNT_LINKED_FROM_NABIS',
-      entityType: 'Account',
-      entityId: account.id,
-      actorClerkUserId: actor?.clerkUserId ?? null,
-      actorEmail: actor?.email ?? null,
-      metadata: {
-        licensedLocationId: retailer.licensedLocationId,
-        notionPageId,
+      select: {
+        id: true,
+        name: true,
       },
     });
+    const linkDecision = assessNabisIdentityLink({
+      reviewRequired: notion.reviewRequired === true,
+      incomingAccountId: account.id,
+      ownerAccountId: currentOwner?.id ?? null,
+    });
+
+    if (linkDecision === 'REVIEW') {
+      notionPageId = account.notionPageId;
+      try {
+        await persistNabisIdentityConflict({
+          orgId,
+          recipientKey: identityConflictRecipientKey(actor),
+          incomingAccountId: account.id,
+          incomingAccountName: account.name,
+          candidatePageId: notion.pageId,
+          currentOwnerAccountId: currentOwner?.id ?? null,
+          currentOwnerAccountName: currentOwner?.name ?? null,
+          reason: notion.reviewReason ?? 'page_owned_by_another_account',
+          sourceIdentifiers: {
+            licensedLocationId: retailer.licensedLocationId,
+            nabisRetailerId: retailer.externalRetailerId,
+            licenseNumber: retailer.licenseNumber,
+          },
+        });
+      } catch (error) {
+        console.error('[picc-nabis-identity-review]', error);
+      }
+    } else {
+      await prisma.account.update({
+        where: { id: account.id },
+        data: {
+          notionPageId,
+        },
+      });
+
+      await appendAuditEvent({
+        orgId,
+        action: notion.created ? 'CRM_ACCOUNT_CREATED_FROM_NABIS' : 'CRM_ACCOUNT_LINKED_FROM_NABIS',
+        entityType: 'Account',
+        entityId: account.id,
+        actorClerkUserId: actor?.clerkUserId ?? null,
+        actorEmail: actor?.email ?? null,
+        metadata: {
+          licensedLocationId: retailer.licensedLocationId,
+          notionPageId,
+        },
+      });
+    }
   }
 
   await ensureAccountIdentityMappings({

--- a/lib/server/transactional-email.test.ts
+++ b/lib/server/transactional-email.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { sendTransactionalEmail } from '@/lib/server/transactional-email';
+
+const originalEnv = process.env;
+
+describe('transactional email adapter', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.RESEND_API_KEY;
+    delete process.env.PICC_ALERTS_FROM_EMAIL;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('reports unavailable without attempting delivery when transport is not configured', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendTransactionalEmail({
+        to: 'admin@piccplatform.com',
+        subject: 'Review required',
+        text: 'Open Settings to review.',
+        html: '<p>Open Settings to review.</p>',
+        idempotencyKey: 'conflict-1',
+      }),
+    ).resolves.toEqual({ status: 'UNAVAILABLE', providerMessageId: null, error: 'Transactional email is not configured.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends with a deterministic idempotency key and returns the provider id', async () => {
+    process.env.RESEND_API_KEY = 'test-api-key';
+    process.env.PICC_ALERTS_FROM_EMAIL = 'PICC Alerts <alerts@piccplatform.com>';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'email-1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendTransactionalEmail({
+        to: 'admin@piccplatform.com',
+        subject: 'Review required',
+        text: 'Open Settings to review.',
+        html: '<p>Open Settings to review.</p>',
+        idempotencyKey: 'conflict-1',
+      }),
+    ).resolves.toEqual({ status: 'SENT', providerMessageId: 'email-1', error: null });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.resend.com/emails',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-api-key',
+          'Idempotency-Key': 'conflict-1',
+        }),
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+      from: 'PICC Alerts <alerts@piccplatform.com>',
+      to: ['admin@piccplatform.com'],
+      subject: 'Review required',
+    });
+  });
+
+  it('returns a sanitized failure without exposing provider response content', async () => {
+    process.env.RESEND_API_KEY = 'test-api-key';
+    process.env.PICC_ALERTS_FROM_EMAIL = 'PICC Alerts <alerts@piccplatform.com>';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('sensitive provider detail', { status: 422 })));
+
+    await expect(
+      sendTransactionalEmail({
+        to: 'admin@piccplatform.com',
+        subject: 'Review required',
+        text: 'Open Settings to review.',
+        html: '<p>Open Settings to review.</p>',
+        idempotencyKey: 'conflict-1',
+      }),
+    ).resolves.toEqual({ status: 'FAILED', providerMessageId: null, error: 'Transactional email delivery failed (422).' });
+  });
+});

--- a/lib/server/transactional-email.ts
+++ b/lib/server/transactional-email.ts
@@ -1,0 +1,68 @@
+import 'server-only';
+
+export type TransactionalEmailResult = {
+  status: 'SENT' | 'FAILED' | 'UNAVAILABLE';
+  providerMessageId: string | null;
+  error: string | null;
+};
+
+export function transactionalEmailReady() {
+  return Boolean(process.env.RESEND_API_KEY?.trim() && process.env.PICC_ALERTS_FROM_EMAIL?.trim());
+}
+
+export async function sendTransactionalEmail(input: {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+  idempotencyKey: string;
+}): Promise<TransactionalEmailResult> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const from = process.env.PICC_ALERTS_FROM_EMAIL?.trim();
+  if (!apiKey || !from) {
+    return {
+      status: 'UNAVAILABLE',
+      providerMessageId: null,
+      error: 'Transactional email is not configured.',
+    };
+  }
+
+  try {
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': input.idempotencyKey,
+      },
+      body: JSON.stringify({
+        from,
+        to: [input.to],
+        subject: input.subject,
+        text: input.text,
+        html: input.html,
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        status: 'FAILED',
+        providerMessageId: null,
+        error: `Transactional email delivery failed (${response.status}).`,
+      };
+    }
+
+    const payload = (await response.json().catch(() => ({}))) as { id?: unknown };
+    return {
+      status: 'SENT',
+      providerMessageId: typeof payload.id === 'string' ? payload.id : null,
+      error: null,
+    };
+  } catch {
+    return {
+      status: 'FAILED',
+      providerMessageId: null,
+      error: 'Transactional email delivery failed.',
+    };
+  }
+}

--- a/tests/e2e/nabis-identity-review.spec.ts
+++ b/tests/e2e/nabis-identity-review.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type Decision = 'KEEP_CURRENT_OWNER' | 'TRANSFER_TO_INCOMING';
+
+function conflict(id: string, incomingAccountName: string, currentOwnerAccountName: string) {
+  const now = '2026-08-14T14:30:00.000Z';
+  return {
+    id,
+    createdAt: now,
+    metadata: {
+      status: 'OPEN' as 'OPEN' | 'RESOLVED',
+      occurrenceCount: 2,
+      firstDetectedAt: now,
+      lastDetectedAt: now,
+      incomingAccountName,
+      currentOwnerAccountName,
+      reason: 'page_owned_by_another_account',
+      sourceIdentifiers: { licensedLocationId: `location-${id}`, nabisRetailerId: `retailer-${id}`, licenseNumber: `license-${id}` },
+      email: { status: 'FAILED' as const, error: 'Transactional email is not configured.', attemptedAt: now },
+      resolution: undefined as { decision: Decision; resolvedAt: string } | undefined,
+    },
+  };
+}
+
+async function mockReviewApi(page: Page) {
+  const state = {
+    conflicts: [
+      conflict('cm123456789012345678901234', 'Incoming Retailer One', 'Current CRM Owner One'),
+      conflict('cm223456789012345678901234', 'Incoming Retailer Two', 'Current CRM Owner Two'),
+    ],
+    preference: { email: 'bryce@piccplatform.com', emailEnabled: true, inAppEnabled: true },
+    emailProviderReady: false,
+  };
+
+  await page.route('**/api/settings/nabis-identity-conflicts', async (route) => {
+    const request = route.request();
+    const payload = request.method() === 'GET' ? null : request.postDataJSON();
+    if (request.method() === 'PATCH') {
+      state.preference = { email: payload.email, emailEnabled: payload.emailEnabled, inAppEnabled: payload.inAppEnabled };
+    }
+    if (request.method() === 'POST' && payload.action === 'resolve') {
+      const item = state.conflicts.find((entry) => entry.id === payload.notificationId);
+      if (item) {
+        item.metadata.status = 'RESOLVED';
+        item.metadata.resolution = { decision: payload.decision, resolvedAt: '2026-08-14T14:35:00.000Z' };
+      }
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+  });
+
+  return state;
+}
+
+test('configures alerts and resolves both Nabis identity decisions', async ({ page }) => {
+  await mockReviewApi(page);
+  await page.goto('/settings');
+  await page.getByRole('heading', { name: 'Nabis identity review' }).scrollIntoViewIfNeeded();
+  await expect(page.getByText('2 open', { exact: true })).toBeVisible();
+
+  await page.getByLabel('Review email').fill('alerts@piccplatform.com');
+  await page.getByText('Email', { exact: true }).click();
+  await page.getByText('Email', { exact: true }).click();
+  await page.getByRole('button', { name: 'Save alerts' }).click();
+  await expect(page.getByText('Nabis conflict alerts saved.')).toBeVisible();
+
+  const transfer = page.getByRole('article').filter({ hasText: 'Incoming Retailer One' });
+  await transfer.getByRole('button', { name: 'Transfer to Nabis account' }).click();
+  await expect(transfer.getByText('Transfer the CRM page to Incoming Retailer One?')).toBeVisible();
+  await transfer.getByRole('button', { name: 'Cancel' }).click();
+  await transfer.getByRole('button', { name: 'Transfer to Nabis account' }).click();
+  await transfer.getByRole('button', { name: 'Confirm decision' }).click();
+  await expect(page.getByText('1 open', { exact: true })).toBeVisible();
+
+  const keep = page.getByRole('article').filter({ hasText: 'Incoming Retailer Two' });
+  await keep.getByRole('button', { name: 'Keep current owner' }).click();
+  await keep.getByRole('button', { name: 'Confirm decision' }).click();
+  await expect(page.getByText('No unresolved Nabis identity conflicts.')).toBeVisible();
+});
+
+test('keeps the Nabis review panel usable at mobile width', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockReviewApi(page);
+  await page.goto('/settings');
+  const panel = page.locator('#nabis-identity-review');
+  await panel.scrollIntoViewIfNeeded();
+  await expect(panel).toBeVisible();
+  expect(await panel.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  const buttonHeights = await panel.getByRole('button').evaluateAll((buttons) => buttons.map((button) => button.getBoundingClientRect().height));
+  expect(Math.min(...buttonHeights)).toBeGreaterThanOrEqual(44);
+});


### PR DESCRIPTION
## Why

An ambiguous external-record identity match could interrupt sales-data refresh and left the dashboard showing a failed attempt as though it were a successful sync.

Closes #164

## What changed

- Orders now ingest before optional retailer/CRM linking, so identity conflicts cannot freeze revenue.
- Ambiguous ownership is preserved and converted into one deduplicated review item.
- Settings now provides a complete review queue, alert recipient controls, keep/transfer confirmation, retry state, and resolved history.
- Resolution writes explicit identity overrides and audit history.
- New conflicts attempt one idempotent transactional email without blocking sales ingestion.
- Failed attempts no longer replace the last-successful timestamp shown to operators.

## What did not change

- No fuzzy automatic merging.
- No destructive record deletion.
- No schema migration or production data backfill.
- No unrelated sync or application-shell refactor.

## Validation

- `npm run verify`
  - lint passed
  - typecheck passed
  - 32 test files / 152 tests passed
  - Prisma schema valid
  - production build passed
- `npx playwright test tests/e2e/nabis-identity-review.spec.ts --project=chromium`
  - 2 browser tests passed
  - covered alert save/toggle, cancel/confirm, keep/transfer, resolved empty state, 390px mobile layout, 44px touch targets
- Manual Chromium pass at 1440px and 390px found no horizontal overflow.

## Production proof and remaining risk

- Vercel preview deployment passed.
- The production Resend resource is selected on the free plan for `piccnewyork.org`, but Vercel requires the account owner to accept its one-time Marketplace terms before provisioning `RESEND_API_KEY`.
- Until those terms are accepted, the Settings UI explicitly shows `email setup required`; in-app review and sales-sync continuity remain active.
