### PR TITLE
Improve mobile CRM workspace foundation

### DIFF
--- a/DESIGN-SYSTEM.md
+++ b/DESIGN-SYSTEM.md
@@ -46,3 +46,4 @@ This app is a field operating system for sales, ops, and vendor-day execution. S
 - Empty: explain the active filter/query and provide the next useful action.
 - Error: show the failed system, human-readable reason, and retry if available.
 - Freshness: show source, last sync, stale/syncing state, and retry/detail where useful.
+- Freshness controls are collapsed by default on every operational screen. The closed state shows only a compact `Last sync` timestamp plus essential state; source, record counts, errors, and manual actions belong in the disclosure details.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,50 +1,39 @@
-# Session: Issue 161 Territory Save Clearance
+# Session: Issue 163 Mobile CRM UI Foundation
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/161
-- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/162
-- Branch: `codex/161-territory-save-clearance`
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/163
+- Branch: `codex/163-contact-foundation`
+- Draft PR: pending
 
 ## Scope
 
-- Keep the territory boundary editor fully above the fixed bottom navigation.
-- Keep the editor body independently scrollable when its point list exceeds the available height.
-- Keep the `Save Boundary` footer visible, keyboard reachable, and clickable at short desktop and mobile viewports.
-- Add focused regression coverage for the reported overlap.
+- Improve reusable mobile CRM status and navigation components.
+- Improve readability and interaction consistency across related CRM views.
+- Add focused regression coverage for the changed user flows.
 
 ## Out of scope
 
-- Boundary persistence, API, database, schema, authentication, authorization, or production-data changes.
-- Map-provider, map-control, or primary-navigation redesign.
+- Database, authentication, permissions, secrets, external integrations, and production-data changes.
 - Changes to `/Users/brycejohnson/Code/map-app`.
 
 ## Constraints
 
-- Reuse the existing `--picc-bottom-nav-clearance` design token.
-- Preserve the current Google Maps boundary editing workflow and fixed primary navigation.
-- Use a failing browser behavior test before implementation.
-- Run `npm run verify` and `npm run test:e2e` before completion.
-- Capture desktop and mobile user-visible evidence.
+- Preserve the current PWA shell and server boundaries.
+- Use RED-first tests for behavior changes.
+- Run `npm run verify` and `npm run test:e2e`.
+- Capture mobile browser proof for changed UI flows.
 
 ## Ownership and overlap
 
-- Owned paths: `components/mobile/territory-boundary-sheet.tsx`, focused territory editor tests, `SESSION.md`, and UI evidence.
-- Open PRs #160, #144, #135, and #82 were checked.
-- PR #160 owns subway/map-overlay paths but does not own the boundary sheet.
-- PRs #135 and #82 do not overlap.
-- PR #144 is a stale broad monorepo migration that conflicts with the canonical architecture and declares no owned paths.
+- Owned paths: shared CRM presentation components, affected mobile CRM views, focused tests, `SESSION.md`, and UI evidence.
+- A fresh open-PR overlap check is required before source edits.
 
 ## Validation evidence
 
-- RED: at 1440x800, the primary navigation began at y=704 while `Save Boundary` ended at y=821.5.
-- GREEN: the focused Playwright suite passed all four checks covering real internal scroll movement with a stationary footer, tab-order keyboard save, mobile portrait, mobile landscape with at least a 44px usable form body, short desktop, and the reported 1800x1280 viewport.
-- `npm run verify`: passed lint, typecheck, 27 Vitest files with 126 tests, Prisma validation, and the Next.js production build.
-- `npm run test:e2e`: 22 Playwright tests passed.
-- Read-only review found the initial landscape test allowed a collapsed scroll body; the strengthened test failed at 0px, the height-aware inset was corrected, and the focused four-viewport suite passed again.
-- Desktop screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-desktop.png`.
-- Mobile screenshot: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ff906-4d75-7e53-80d1-bceaf818dc46/territory-save-mobile.png`.
+- Baseline: 28 Vitest files and 134 tests passed under Node 22.22.0.
+- Pending focused RED/GREEN tests and browser verification.
 
 ## Remaining verification boundary
 
-The local UI uses intercepted read and save responses and does not mutate production data. Production proof remains pending merge and deployment.
+- Production UI proof follows merge and deployment.

--- a/SESSION.md
+++ b/SESSION.md
@@ -4,7 +4,7 @@
 
 - GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/163
 - Branch: `codex/163-contact-foundation`
-- Draft PR: pending
+- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/167
 
 ## Scope
 
@@ -27,12 +27,18 @@
 ## Ownership and overlap
 
 - Owned paths: shared CRM presentation components, affected mobile CRM views, focused tests, `SESSION.md`, and UI evidence.
-- A fresh open-PR overlap check is required before source edits.
+- Checked open PRs #166, #144, #135, and #82 before source edits.
+- PR #166 is documentation-only. PR #135 has a stale, narrow overlap in Account Details; the implementation here is additive and will be rebased if #135 lands first.
 
 ## Validation evidence
 
 - Baseline: 28 Vitest files and 134 tests passed under Node 22.22.0.
-- Pending focused RED/GREEN tests and browser verification.
+- RED/GREEN: focused presentation and interaction contract tests cover compact sync summaries, Gmail/SMS/phone links, and follow-up request payloads.
+- Targeted mobile Playwright: 2 tests passed for dense account cards, alphabet-rail clearance, New Follow-Up, direct Account Details contact actions, and the post-action prompt.
+- Browser evidence: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ffc03-da13-7281-ae9a-5216d1b9437f/accounts-mobile-contact-foundation.png` and `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ffc03-da13-7281-ae9a-5216d1b9437f/account-contact-actions-follow-up.png`.
+- `npm run verify`: passed (lint, typecheck, 31 Vitest files / 141 tests, Prisma validation, production build).
+- `npm run test:e2e`: 25 browser tests passed under Node 22.22.0.
+- Final diff check: `git diff --check` passed.
 
 ## Remaining verification boundary
 

--- a/app/(main)/contacts/page.tsx
+++ b/app/(main)/contacts/page.tsx
@@ -10,20 +10,15 @@ export default async function ContactsPage() {
   return (
     <div className="min-h-full bg-[linear-gradient(180deg,#f7f9fc_0%,#eef2f7_100%)]">
       <AccountsSectionTabs />
-      <div className="mx-auto max-w-[var(--app-shell-max)] space-y-5 px-4 pb-28 pt-5 md:px-6">
-        <header className="flex items-start justify-between gap-4">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#818a98]">Accounts</p>
-            <h1 className="mt-1 text-2xl font-semibold tracking-[-0.03em] text-[#18212d]">Contacts</h1>
-            <p className="mt-1 max-w-xl text-sm leading-6 text-[#657081]">People linked to each dispensary in the live CRM.</p>
-          </div>
+      <div className="mx-auto max-w-[var(--app-shell-max)] space-y-3 px-4 pb-28 pt-4 md:px-6">
+        <header className="flex justify-end">
           <ContactCreateFlow accounts={runtime.accounts} />
         </header>
-        <section className="grid gap-3 lg:grid-cols-2" aria-label="Contact data freshness">
+        <section className="grid gap-2 sm:grid-cols-2" aria-label="Contact data freshness">
           <DataFreshnessBanner freshness={runtime.freshness.contacts} compact />
           <DataFreshnessBanner freshness={runtime.freshness.accounts} compact />
         </section>
-        <ContactsTable rows={runtime.contacts} />
+        <ContactsTable rows={runtime.contacts} accounts={runtime.accounts.map((account) => ({ id: account.notionPageId, name: account.name }))} />
       </div>
     </div>
   );

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { currentUser } from '@clerk/nextjs/server';
 import { Role } from '@prisma/client';
+import { ChevronDown } from 'lucide-react';
 import { FollowUpActionBoard, type HomeFollowUpItem } from '@/components/home/follow-up-action-board';
 import { HotLeadsBoard, type HomeHotLeadItem } from '@/components/home/hot-leads-board';
 import { PreferredPartnerRepChart } from '@/components/home/preferred-partner-rep-chart';
@@ -304,17 +305,24 @@ export default async function HomePage() {
         }
       />
 
-      <WorkspaceSection eyebrow="Freshness" title="What is synced right now" description="The screen should feel current without forcing a full refresh every time you navigate back.">
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+      <details className="group overflow-hidden rounded-xl border border-[#dbe1e9] bg-[#f8fafc]">
+        <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-4 py-2 text-sm text-[#344052] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#276fd3] focus-visible:ring-inset [&::-webkit-details-marker]:hidden">
+          <span className="font-semibold">Last sync: {freshnessTiles[1]?.value ?? 'Not synced yet'}</span>
+          <span className="ml-auto text-xs text-[#7a8492]">{freshnessTiles.length} sources</span>
+          <ChevronDown className="h-4 w-4 transition-transform duration-200 group-open:rotate-180" aria-hidden="true" />
+        </summary>
+        <div className="grid grid-cols-1 gap-2 border-t border-[#dbe1e9] p-3 md:grid-cols-2 xl:grid-cols-3">
           {freshnessTiles.map((tile) => (
-            <div key={tile.title} className="rounded-2xl border border-[#e2e8f0] bg-[#f8fafc] p-4">
-              <p className="text-sm font-medium text-[#18212d]">{tile.title}</p>
-              <p className="mt-1 text-lg font-semibold text-[#18212d]">{tile.value}</p>
-              <p className="mt-1 text-sm text-[#5c6674]">{tile.description}</p>
+            <div key={tile.title} className="rounded-lg border border-[#e2e8f0] bg-white px-3 py-2.5">
+              <div className="flex items-baseline justify-between gap-3">
+                <p className="text-sm font-medium text-[#18212d]">{tile.title}</p>
+                <p className="text-sm font-semibold text-[#18212d]">{tile.value}</p>
+              </div>
+              <p className="mt-1 text-xs text-[#5c6674]">{tile.description}</p>
             </div>
           ))}
         </div>
-      </WorkspaceSection>
+      </details>
 
       {preferredPartnerSummary ? (
         <WorkspaceSection

--- a/components/crm/account-follow-up-flow.tsx
+++ b/components/crm/account-follow-up-flow.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { CalendarPlus, Loader2, Search, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { buildAccountFollowUpPayload } from '@/lib/contacts/contact-follow-up';
+
+export type FollowUpAccountOption = {
+  id: string;
+  notionPageId: string;
+  name: string;
+  repNames: string[];
+};
+
+function dateAfter(days: number) {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return [date.getFullYear(), String(date.getMonth() + 1).padStart(2, '0'), String(date.getDate()).padStart(2, '0')].join('-');
+}
+
+export function AccountFollowUpFlow({ accounts }: { accounts: FollowUpAccountOption[] }) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState('');
+  const [followUpDate, setFollowUpDate] = useState('');
+  const [reason, setReason] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = accounts.find((account) => account.id === selectedId) ?? null;
+  const filtered = useMemo(() => {
+    const query = search.trim().toLocaleLowerCase('en-US');
+    if (!query) return accounts.slice(0, 50);
+    return accounts
+      .filter((account) => `${account.name} ${account.repNames.join(' ')}`.toLocaleLowerCase('en-US').includes(query))
+      .slice(0, 50);
+  }, [accounts, search]);
+
+  function changeOpen(nextOpen: boolean) {
+    if (saving) return;
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setSearch('');
+      setSelectedId('');
+      setFollowUpDate('');
+      setReason('');
+      setError(null);
+    }
+  }
+
+  async function save() {
+    if (!selected || !followUpDate || !reason.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/territory/check-in', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(buildAccountFollowUpPayload({ account: selected, followUpDate, reason })),
+      });
+      const payload = (await response.json().catch(() => ({}))) as { error?: string; syncWarning?: string | null };
+      if (!response.ok) throw new Error(payload.error || 'Follow-up could not be saved.');
+      toast.success('Follow-up set', { description: payload.syncWarning || `${selected.name} is scheduled for ${followUpDate}.` });
+      changeOpen(false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Follow-up could not be saved.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={changeOpen}>
+      <Dialog.Trigger asChild>
+        <button type="button" className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-[#cfd6e1] bg-white px-3 text-[14px] font-semibold text-[#344052] shadow-sm transition hover:bg-[#f3f6fa] active:scale-[0.98]">
+          <CalendarPlus className="h-4 w-4" />
+          New follow-up
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[5300] bg-[#17202d]/45" />
+        <Dialog.Content className="fixed inset-x-3 bottom-[calc(var(--picc-bottom-nav-clearance)+12px)] z-[5301] mx-auto max-h-[calc(100dvh-var(--picc-bottom-nav-clearance)-32px)] max-w-lg overflow-y-auto rounded-2xl border border-[#d4dae4] bg-[#f8fafc] p-4 shadow-[0_24px_70px_rgba(24,33,45,0.24)] sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:w-[calc(100vw-32px)] sm:-translate-x-1/2 sm:-translate-y-1/2">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <Dialog.Title className="text-[19px] font-semibold text-[#18212d]">New follow-up</Dialog.Title>
+              <Dialog.Description className="mt-1 text-[14px] text-[#667183]">Choose the account, date, and next action.</Dialog.Description>
+            </div>
+            <Dialog.Close className="grid h-10 w-10 place-items-center rounded-lg text-[#5f6978] hover:bg-[#e9edf3]" aria-label="Close new follow-up" disabled={saving}>
+              <X className="h-5 w-5" />
+            </Dialog.Close>
+          </div>
+
+          {selected ? (
+            <div className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-[#cbd3df] bg-white p-3">
+              <div className="min-w-0">
+                <p className="truncate text-[15px] font-semibold text-[#18212d]">{selected.name}</p>
+                <p className="truncate text-[12px] text-[#7a8492]">Rep: {selected.repNames.join(', ') || 'Unassigned'}</p>
+              </div>
+              <button type="button" onClick={() => setSelectedId('')} className="text-[13px] font-semibold text-[#c93412]">Change</button>
+            </div>
+          ) : (
+            <div className="mt-4 overflow-hidden rounded-xl border border-[#cbd3df] bg-white">
+              <label className="flex h-11 items-center gap-2 border-b border-[#e0e5ed] px-3">
+                <Search className="h-4 w-4 text-[#7b8491]" />
+                <span className="sr-only">Search accounts</span>
+                <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search account or rep" className="min-w-0 flex-1 bg-transparent text-[15px] outline-none placeholder:text-[#929ba8]" />
+              </label>
+              <div className="max-h-48 overflow-y-auto p-1.5">
+                {filtered.length ? filtered.map((account) => (
+                  <button key={account.id} type="button" onClick={() => setSelectedId(account.id)} className="w-full rounded-lg px-3 py-2.5 text-left hover:bg-[#f1f4f8]">
+                    <p className="truncate text-[14px] font-semibold text-[#253142]">{account.name}</p>
+                    <p className="truncate text-[12px] text-[#7a8492]">{account.repNames.join(', ') || 'Unassigned'}</p>
+                  </button>
+                )) : <p className="px-3 py-6 text-center text-[14px] text-[#77818f]">No matching accounts</p>}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            {[{ label: 'Tomorrow', days: 1 }, { label: '3 days', days: 3 }, { label: '1 week', days: 7 }].map((option) => (
+              <button key={option.days} type="button" onClick={() => setFollowUpDate(dateAfter(option.days))} className="min-h-10 rounded-lg border border-[#cbd3df] bg-white px-2 text-[13px] font-semibold text-[#344052] hover:bg-[#f0f3f7] active:scale-[0.98]">{option.label}</button>
+            ))}
+          </div>
+          <label className="mt-3 block text-[13px] font-semibold text-[#344052]">
+            Follow-up date
+            <input type="date" value={followUpDate} onChange={(event) => setFollowUpDate(event.target.value)} className="mt-1 h-11 w-full rounded-lg border border-[#cbd3df] bg-white px-3 text-[16px] text-[#18212d]" />
+          </label>
+          <label className="mt-3 block text-[13px] font-semibold text-[#344052]">
+            Next action
+            <input value={reason} onChange={(event) => setReason(event.target.value)} placeholder="What needs to happen next?" className="mt-1 h-11 w-full rounded-lg border border-[#cbd3df] bg-white px-3 text-[15px] font-normal text-[#18212d] placeholder:text-[#929ba8]" />
+          </label>
+          {error ? <p role="alert" className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800">{error}</p> : null}
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <Dialog.Close className="min-h-11 rounded-lg border border-[#cbd3df] bg-white px-3 text-[14px] font-semibold text-[#344052]" disabled={saving}>Cancel</Dialog.Close>
+            <button type="button" onClick={() => void save()} disabled={saving || !selected || !followUpDate || !reason.trim()} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-[#c93412] px-3 text-[14px] font-semibold text-white hover:bg-[#ad2d0e] active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-[#d7aaa0]">
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <CalendarPlus className="h-4 w-4" />}
+              {saving ? 'Saving' : 'Set follow-up'}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/crm/advanced-data-table.tsx
+++ b/components/crm/advanced-data-table.tsx
@@ -12,7 +12,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { Download, Filter, Settings2 } from 'lucide-react';
+import { Download } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
@@ -21,7 +21,7 @@ import { Button, Input } from '@/components/ui';
 interface Props<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
-  title: string;
+  title?: string;
   searchPlaceholder?: string;
   onExportCsv?: () => void;
   mobileCardRenderer?: (row: TData) => ReactNode;
@@ -71,21 +71,22 @@ export function AdvancedDataTable<TData, TValue>({
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-col gap-3 rounded-xl border p-4 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h2 className="text-h2 font-semibold">{title}</h2>
-          <p className="text-sm text-slate-500">Sticky headers, saved views, and bulk actions for power users.</p>
-        </div>
-        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+      <div className="flex flex-col gap-3 rounded-xl border border-[#d8dee8] bg-white p-3 md:flex-row md:items-center md:justify-between">
+        {title ? <h2 className="text-h2 font-semibold">{title}</h2> : null}
+        <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
           <Input
             value={globalFilter}
             onChange={(event) => setGlobalFilter(event.target.value)}
             placeholder={searchPlaceholder}
-            className="h-11 w-full sm:w-[260px]"
+            aria-label={searchPlaceholder}
+            className="h-11 min-w-0 flex-1 border-[#cbd3df] bg-white text-[#18212d] placeholder:text-[#929baa] sm:max-w-[360px] dark:bg-white dark:text-[#18212d] dark:placeholder:text-[#929baa]"
           />
-          <Button variant="secondary" className="h-11 min-w-[44px]"><Filter className="h-4 w-4" /> Filters</Button>
-          <Button variant="secondary" className="h-11 min-w-[44px]"><Settings2 className="h-4 w-4" /> Saved Views</Button>
-          <Button variant="outline" className="h-11 min-w-[44px]" onClick={onExportCsv}><Download className="h-4 w-4" /> Export</Button>
+          {onExportCsv ? (
+            <Button variant="outline" className="h-11 min-w-[44px] shrink-0" onClick={onExportCsv} aria-label="Export CSV">
+              <Download className="h-4 w-4" />
+              <span className="hidden sm:inline">Export</span>
+            </Button>
+          ) : null}
         </div>
       </div>
 

--- a/components/crm/contact-create-flow.tsx
+++ b/components/crm/contact-create-flow.tsx
@@ -28,7 +28,7 @@ const emptyDraft = {
   phone: '',
 };
 
-export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption[] }) {
+export function ContactCreateFlow({ accounts, triggerVariant = 'default' }: { accounts: ContactAccountOption[]; triggerVariant?: 'default' | 'icon' }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const requestedOpen = searchParams.get('new') === '1';
@@ -144,10 +144,17 @@ export function ContactCreateFlow({ accounts }: { accounts: ContactAccountOption
         <button
           type="button"
           onClick={() => void loadAccountsIfNeeded()}
-          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[#c93412] px-4 text-sm font-semibold text-white shadow-[0_8px_18px_rgba(201,52,18,0.22)] transition hover:bg-[#ad2d0e] active:scale-[0.98]"
+          aria-label={triggerVariant === 'icon' ? 'Add contact' : undefined}
+          title={triggerVariant === 'icon' ? 'Add contact' : undefined}
+          className={cn(
+            'inline-flex items-center justify-center bg-[#c93412] font-semibold text-white transition hover:bg-[#ad2d0e] active:scale-[0.98]',
+            triggerVariant === 'icon'
+              ? 'h-10 w-10 rounded-lg shadow'
+              : 'min-h-11 gap-2 whitespace-nowrap rounded-xl px-4 text-sm shadow-[0_8px_18px_rgba(201,52,18,0.22)]',
+          )}
         >
           <Plus className="h-4 w-4" />
-          Add contact
+          {triggerVariant === 'default' ? 'Add contact' : null}
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>

--- a/components/crm/contact-quick-actions.tsx
+++ b/components/crm/contact-quick-actions.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { CalendarDays, Loader2, Mail, MessageSquare, Phone, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { buildContactActionHref, type ContactActionKind } from '@/lib/contacts/contact-actions';
+import { buildCommunicationFollowUpPayload } from '@/lib/contacts/contact-follow-up';
+import { cn } from '@/lib/utils';
+
+export type ContactQuickActionContact = {
+  id: string;
+  name: string;
+  roleTitle: string;
+  email: string;
+  phone: string;
+};
+
+export type ContactQuickActionAccount = {
+  id: string;
+  name: string;
+};
+
+function dateAfter(days: number) {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return [date.getFullYear(), String(date.getMonth() + 1).padStart(2, '0'), String(date.getDate()).padStart(2, '0')].join('-');
+}
+
+const actionMeta = {
+  email: { label: 'Email', launchedLabel: 'Gmail', Icon: Mail },
+  text: { label: 'Text', launchedLabel: 'Messages', Icon: MessageSquare },
+  call: { label: 'Call', launchedLabel: 'Phone', Icon: Phone },
+} satisfies Record<ContactActionKind, { label: string; launchedLabel: string; Icon: typeof Mail }>;
+
+export function ContactQuickActions({
+  contact,
+  accounts,
+  className,
+}: {
+  contact: ContactQuickActionContact;
+  accounts: ContactQuickActionAccount[];
+  className?: string;
+}) {
+  const [pendingAction, setPendingAction] = useState<ContactActionKind | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState(accounts.length === 1 ? accounts[0]?.id ?? '' : '');
+  const [followUpDate, setFollowUpDate] = useState('');
+  const [reason, setReason] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const links = useMemo(
+    () =>
+      (Object.keys(actionMeta) as ContactActionKind[])
+        .map((kind) => ({
+          kind,
+          href: buildContactActionHref({ kind, email: contact.email, phone: contact.phone, accountName: accounts[0]?.name ?? 'PICC' }),
+          ...actionMeta[kind],
+        }))
+        .filter((item): item is typeof item & { href: string } => Boolean(item.href)),
+    [accounts, contact.email, contact.phone],
+  );
+
+  function closePrompt() {
+    if (saving) return;
+    setPendingAction(null);
+    setFollowUpDate('');
+    setReason('');
+    setError(null);
+    setSelectedAccountId(accounts.length === 1 ? accounts[0]?.id ?? '' : '');
+  }
+
+  async function saveFollowUp() {
+    if (!pendingAction || !selectedAccountId || !followUpDate) return;
+    const account = accounts.find((candidate) => candidate.id === selectedAccountId);
+    if (!account) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/territory/check-in', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(
+          buildCommunicationFollowUpPayload({
+            action: pendingAction,
+            account,
+            contact,
+            followUpDate,
+            reason,
+          }),
+        ),
+      });
+      const payload = (await response.json().catch(() => ({}))) as { error?: string; syncWarning?: string | null };
+      if (!response.ok) throw new Error(payload.error || 'Follow-up could not be saved.');
+
+      toast.success('Follow-up set', {
+        description: payload.syncWarning || `${contact.name} is scheduled for ${followUpDate}.`,
+      });
+      closePrompt();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Follow-up could not be saved.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <div className={cn('flex items-center gap-1.5', className)} aria-label={`Contact ${contact.name}`}>
+        {links.map(({ kind, href, label, Icon }) => (
+          <a
+            key={kind}
+            href={href}
+            target={kind === 'email' ? '_blank' : undefined}
+            rel={kind === 'email' ? 'noreferrer' : undefined}
+            aria-label={`${label} ${contact.name}`}
+            title={`${label} ${contact.name}`}
+            className="inline-flex h-10 min-w-10 items-center justify-center gap-1.5 rounded-lg border border-[#cfd6e1] bg-white px-2.5 text-[13px] font-semibold text-[#263242] transition hover:border-[#9eabba] hover:bg-[#f3f6fa] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#276fd3] active:scale-[0.98]"
+            onClick={(event) => {
+              event.stopPropagation();
+              setPendingAction(kind);
+              setError(null);
+            }}
+          >
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden xl:inline">{label}</span>
+          </a>
+        ))}
+      </div>
+
+      <Dialog.Root open={pendingAction !== null} onOpenChange={(open) => !open && closePrompt()}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-[5300] bg-[#17202d]/45" />
+          <Dialog.Content
+            className="fixed inset-x-3 bottom-[calc(var(--picc-bottom-nav-clearance)+12px)] z-[5301] mx-auto max-h-[calc(100dvh-var(--picc-bottom-nav-clearance)-32px)] max-w-md overflow-y-auto rounded-2xl border border-[#d4dae4] bg-[#f8fafc] p-4 shadow-[0_24px_70px_rgba(24,33,45,0.24)] sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:w-[calc(100vw-32px)] sm:-translate-x-1/2 sm:-translate-y-1/2"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <Dialog.Title className="text-[19px] font-semibold text-[#18212d]">Set follow-up?</Dialog.Title>
+                <Dialog.Description className="mt-1 text-[14px] leading-5 text-[#667183]">
+                  {pendingAction ? `${actionMeta[pendingAction].launchedLabel} opened for ${contact.name}. Add the next touch while it is fresh.` : null}
+                </Dialog.Description>
+              </div>
+              <Dialog.Close className="grid h-10 w-10 shrink-0 place-items-center rounded-lg text-[#5f6978] hover:bg-[#e9edf3]" aria-label="Close follow-up prompt" disabled={saving}>
+                <X className="h-5 w-5" />
+              </Dialog.Close>
+            </div>
+
+            {accounts.length > 1 ? (
+              <label className="mt-4 block text-[13px] font-semibold text-[#344052]">
+                Account
+                <select value={selectedAccountId} onChange={(event) => setSelectedAccountId(event.target.value)} className="mt-1 h-11 w-full rounded-lg border border-[#cbd3df] bg-white px-3 text-[15px] text-[#18212d]">
+                  <option value="">Choose an account</option>
+                  {accounts.map((account) => <option key={account.id} value={account.id}>{account.name}</option>)}
+                </select>
+              </label>
+            ) : null}
+
+            {accounts.length === 0 ? (
+              <p role="alert" className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-amber-900">
+                This contact is not linked to an account yet. Link an account before setting a follow-up.
+              </p>
+            ) : (
+              <>
+                <div className="mt-4 grid grid-cols-3 gap-2">
+                  {[
+                    { label: 'Tomorrow', days: 1 },
+                    { label: '3 days', days: 3 },
+                    { label: '1 week', days: 7 },
+                  ].map((option) => (
+                    <button key={option.days} type="button" onClick={() => setFollowUpDate(dateAfter(option.days))} className="min-h-10 rounded-lg border border-[#cbd3df] bg-white px-2 text-[13px] font-semibold text-[#344052] hover:bg-[#f0f3f7] active:scale-[0.98]">
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+
+                <label className="mt-3 block text-[13px] font-semibold text-[#344052]">
+                  Follow-up date
+                  <input type="date" value={followUpDate} onChange={(event) => setFollowUpDate(event.target.value)} className="mt-1 h-11 w-full rounded-lg border border-[#cbd3df] bg-white px-3 text-[16px] text-[#18212d]" />
+                </label>
+
+                <label className="mt-3 block text-[13px] font-semibold text-[#344052]">
+                  Note <span className="font-normal text-[#7b8491]">(optional)</span>
+                  <input value={reason} onChange={(event) => setReason(event.target.value)} placeholder="What needs to happen next?" className="mt-1 h-11 w-full rounded-lg border border-[#cbd3df] bg-white px-3 text-[15px] font-normal text-[#18212d] placeholder:text-[#929ba8]" />
+                </label>
+              </>
+            )}
+
+            {error ? <p role="alert" className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800">{error}</p> : null}
+
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              <button type="button" onClick={closePrompt} disabled={saving} className="min-h-11 rounded-lg border border-[#cbd3df] bg-white px-3 text-[14px] font-semibold text-[#344052] disabled:opacity-60">
+                Not now
+              </button>
+              <button type="button" onClick={() => void saveFollowUp()} disabled={saving || !selectedAccountId || !followUpDate} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-[#c93412] px-3 text-[14px] font-semibold text-white transition hover:bg-[#ad2d0e] active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-[#d7aaa0]">
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <CalendarDays className="h-4 w-4" />}
+                {saving ? 'Saving' : 'Set follow-up'}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/components/crm/contacts-table.tsx
+++ b/components/crm/contacts-table.tsx
@@ -2,6 +2,7 @@
 
 import type { ColumnDef } from '@tanstack/react-table';
 import { AdvancedDataTable } from '@/components/crm/advanced-data-table';
+import { ContactQuickActions, type ContactQuickActionAccount } from '@/components/crm/contact-quick-actions';
 import { Badge } from '@/components/ui';
 
 export type ContactTableRow = {
@@ -13,9 +14,21 @@ export type ContactTableRow = {
   phone: string;
   status: 'ACTIVE' | 'INACTIVE';
   linkedWork: string;
+  accountPageIds?: string[];
 };
 
-const columns: ColumnDef<ContactTableRow>[] = [
+function normalizePageId(value: string) {
+  return value.replace(/-/g, '').trim().toLowerCase();
+}
+
+export function ContactsTable({ rows, accounts }: { rows: ContactTableRow[]; accounts: ContactQuickActionAccount[] }) {
+  const accountById = new Map(accounts.map((account) => [normalizePageId(account.id), account]));
+  const accountsFor = (row: ContactTableRow) =>
+    (row.accountPageIds ?? [])
+      .map((id) => accountById.get(normalizePageId(id)))
+      .filter((account): account is ContactQuickActionAccount => Boolean(account));
+
+  const columns: ColumnDef<ContactTableRow>[] = [
   {
     accessorKey: 'name',
     header: 'Contact',
@@ -47,12 +60,20 @@ const columns: ColumnDef<ContactTableRow>[] = [
     accessorKey: 'linkedWork',
     header: 'Linked Work',
   },
+  {
+    id: 'actions',
+    header: 'Actions',
+    cell: ({ row }) => (
+      <ContactQuickActions
+        contact={row.original}
+        accounts={accountsFor(row.original)}
+      />
+    ),
+  },
 ];
 
-export function ContactsTable({ rows }: { rows: ContactTableRow[] }) {
   return (
     <AdvancedDataTable
-      title="Contact Directory"
       data={rows}
       columns={columns}
       searchPlaceholder="Search contact, role, or dispensary..."
@@ -68,11 +89,11 @@ export function ContactsTable({ rows }: { rows: ContactTableRow[] }) {
             <Badge variant={row.status === 'ACTIVE' ? 'success' : 'secondary'}>{row.status}</Badge>
           </div>
           <div className="space-y-1 text-sm text-slate-600">
-            <p>{row.accountName}</p>
-            <p>{row.email}</p>
+            <p className="font-medium text-[#344052]">{row.accountName}</p>
+            <p className="break-all">{row.email}</p>
             <p>{row.phone}</p>
-            <p className="text-xs uppercase tracking-wide text-slate-500">{row.linkedWork}</p>
           </div>
+          <ContactQuickActions contact={row} accounts={accountsFor(row)} className="pt-1" />
         </>
       )}
     />

--- a/components/dashboard/nabis-sales-dashboard.tsx
+++ b/components/dashboard/nabis-sales-dashboard.tsx
@@ -9,6 +9,7 @@ import {
   AlertCircle,
   BarChart3,
   Calendar,
+  ChevronDown,
   DollarSign,
   Download,
   Loader2,
@@ -369,14 +370,17 @@ export function NabisSalesDashboard() {
                 </div>
                 <div>
                   <h1 className="text-xl font-semibold text-[#18212d]">Nabis Sales Dashboard</h1>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-[#5f6773]">
-                    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 font-medium text-emerald-700">
-                      <Wifi className="mr-1.5 h-3.5 w-3.5" />
-                      Local synced Nabis data
-                    </span>
-                    {metadata ? <span>Last synced {formatTimestamp(metadata.fetchedAt)}</span> : null}
-                    {metadata?.lastRetailerSyncAt ? <span>Retailers {formatTimestamp(metadata.lastRetailerSyncAt)}</span> : null}
-                  </div>
+                  <details className="group mt-1 text-sm text-[#5f6773]">
+                    <summary className="inline-flex min-h-8 cursor-pointer list-none items-center gap-2 rounded-lg px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#276fd3] [&::-webkit-details-marker]:hidden">
+                      <Wifi className="h-3.5 w-3.5 text-emerald-700" />
+                      <span>{metadata ? `Last sync: ${formatTimestamp(metadata.fetchedAt)}` : 'Last sync: Not recorded'}</span>
+                      <ChevronDown className="h-3.5 w-3.5 transition-transform duration-200 group-open:rotate-180" />
+                    </summary>
+                    <div className="mt-1 flex flex-wrap gap-2 pl-1 text-xs">
+                      <span className="rounded-full bg-emerald-50 px-2.5 py-1 font-medium text-emerald-700">Local synced Nabis data</span>
+                      {metadata?.lastRetailerSyncAt ? <span className="px-1 py-1">Retailers {formatTimestamp(metadata.lastRetailerSyncAt)}</span> : null}
+                    </div>
+                  </details>
                 </div>
               </div>
             </div>

--- a/components/mobile/account-detail-sheet.tsx
+++ b/components/mobile/account-detail-sheet.tsx
@@ -2,10 +2,12 @@
 
 import Link from 'next/link';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
-import { AlertCircle, CheckCircle2, Clock3, Copy, Mail, MapPinned, MessageSquare, Navigation, PencilLine, Phone, PhoneCall, X } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ChevronDown, Clock3, Copy, MapPinned, Navigation, PencilLine, PhoneCall, X } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAppAccess } from '@/components/auth/app-access-provider';
+import { ContactCreateFlow } from '@/components/crm/contact-create-flow';
+import { ContactQuickActions } from '@/components/crm/contact-quick-actions';
 import { MockOrderProposalPanel } from '@/components/crm/mock-order-proposal-panel';
 import { PreferredPartnerProposalPanel } from '@/components/crm/preferred-partner-proposal-panel';
 import { PreferredPartnerSavingsPanel } from '@/components/crm/preferred-partner-savings-panel';
@@ -167,7 +169,6 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
   const [checkInFollowUpNeededDraft, setCheckInFollowUpNeededDraft] = useState<boolean | null>(null);
   const [checkInFollowUpReasonDraft, setCheckInFollowUpReasonDraft] = useState('');
   const [checkInContact, setCheckInContact] = useState<TerritoryStoreContact | null>(null);
-  const [contactActionTarget, setContactActionTarget] = useState<TerritoryStoreContact | null>(null);
   const [streetViewLoadError, setStreetViewLoadError] = useState(false);
 
   useEffect(() => {
@@ -179,7 +180,6 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
       setCheckInFollowUpNeededDraft(null);
       setCheckInFollowUpReasonDraft('');
       setCheckInContact(null);
-      setContactActionTarget(null);
       setStreetViewLoadError(false);
       return;
     }
@@ -191,7 +191,6 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
     setCheckInFollowUpNeededDraft(null);
     setCheckInFollowUpReasonDraft('');
     setCheckInContact(null);
-    setContactActionTarget(null);
     setStreetViewLoadError(false);
 
     const cachedDetail = readCachedStoreDetail(store.id);
@@ -362,52 +361,6 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
 
   function callStore() {
     launchDial(activeStore.phoneNumber, activeStore.name);
-  }
-
-  function callFromContactCard(contact: TerritoryStoreContact) {
-    launchDial(cleanContactField(contact.phone), contact.name);
-  }
-
-  function hasContactEmail(contact: TerritoryStoreContact) {
-    return Boolean(cleanContactField(contact.email));
-  }
-
-  function hasContactPhone(contact: TerritoryStoreContact) {
-    return Boolean(cleanContactField(contact.phone));
-  }
-
-  function openContactActions(contact: TerritoryStoreContact) {
-    if (!hasContactEmail(contact) && !hasContactPhone(contact)) {
-      toast.message(`No contact method is available for ${contact.name}.`);
-      return;
-    }
-    setContactActionTarget(contact);
-  }
-
-  function contactViaEmail(contact: TerritoryStoreContact) {
-    const email = cleanContactField(contact.email);
-    if (!email) {
-      toast.error(`No email available for ${contact.name}.`);
-      return;
-    }
-    const subject = encodeURIComponent(`PICC follow-up: ${activeStore.name}`);
-    window.location.href = `mailto:${email}?subject=${subject}`;
-    setContactActionTarget(null);
-  }
-
-  function contactViaText(contact: TerritoryStoreContact) {
-    const phone = toDialablePhone(contact.phone);
-    if (!phone) {
-      toast.error(`No phone available for ${contact.name}.`);
-      return;
-    }
-    window.location.href = `sms:${phone}`;
-    setContactActionTarget(null);
-  }
-
-  function contactViaCall(contact: TerritoryStoreContact) {
-    callFromContactCard(contact);
-    setContactActionTarget(null);
   }
 
   function openCheckInModal(contact: TerritoryStoreContact | null = null) {
@@ -636,22 +589,34 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
               </DetailSection>
 
               <div className="border-b border-[#c6c7cb] px-5 py-4">
-                <p className="text-[14px] uppercase tracking-wide text-[#8c9098]">Associated Contacts</p>
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-[14px] uppercase tracking-wide text-[#8c9098]">Associated Contacts</p>
+                  {appAccess.canEdit ? (
+                    <ContactCreateFlow
+                      accounts={[{
+                        notionPageId: activeStore.notionPageId,
+                        name: activeStore.name,
+                        city: activeStore.city ?? null,
+                        state: activeStore.state ?? null,
+                      }]}
+                    />
+                  ) : null}
+                </div>
                 {contacts.length === 0 ? <p className="mt-1 text-[16px] text-[#1d1f23]">No contacts linked.</p> : null}
                 {contacts.map((contact) => (
-                  <div key={contact.id} className="mt-2 rounded-lg border border-[#c7c8cd] bg-[#f3f3f6] px-3 py-2">
+                  <div key={contact.id} className="mt-2 rounded-lg border border-[#d5dae3] bg-white px-3 py-3">
                     <div className="flex items-start justify-between gap-3">
-                      <Link href={`/contacts/${encodeURIComponent(contact.id)}`} className="text-[16px] font-semibold text-[#1f4e9f] underline-offset-2 hover:underline">
-                        {contact.name}
-                      </Link>
-                      <div className="flex items-center gap-1.5">
-                        <button
-                          type="button"
-                          className="rounded-md border border-[#b4b7bf] px-2.5 py-1 text-[13px] font-medium text-[#27303f] hover:bg-[#e8eaf0]"
-                          onClick={() => openContactActions(contact)}
-                        >
-                          Contact
-                        </button>
+                      <div className="min-w-0">
+                        <Link href={`/contacts/${encodeURIComponent(contact.id)}`} className="text-[16px] font-semibold text-[#1f4e9f] underline-offset-2 hover:underline">
+                          {contact.name}
+                        </Link>
+                        <p className="text-[13px] text-[#697281]">{contact.roleTitle || 'Role not set'}</p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1.5">
+                        <ContactQuickActions
+                          contact={contact}
+                          accounts={[{ id: activeStore.notionPageId, name: activeStore.name }]}
+                        />
                         {appAccess.canEdit ? (
                           <button
                             type="button"
@@ -664,10 +629,10 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
                         ) : null}
                       </div>
                     </div>
-                    <p className="text-[14px] text-[#5e6169]">{contact.roleTitle || '—'}</p>
-                    <p className="text-[14px] text-[#5e6169]">
-                      {contact.email || '—'} · {contact.phone || '—'}
-                    </p>
+                    <div className="mt-2 grid gap-1 text-[14px] text-[#5e6169] sm:grid-cols-2">
+                      <p className="break-all">{contact.email || 'No email'}</p>
+                      <p>{contact.phone || 'No phone'}</p>
+                    </div>
                   </div>
                 ))}
               </div>
@@ -832,60 +797,6 @@ export function AccountDetailSheet({ store, onClose, onAddToRoute, routeSelected
             </>
           ) : null}
         </div>
-
-        {contactActionTarget ? (
-          <div className="fixed inset-0 z-[5210] bg-black/40" onClick={() => setContactActionTarget(null)}>
-            <div className="absolute inset-x-0 bottom-[var(--picc-bottom-nav-clearance)] mx-auto max-h-[calc(100dvh-var(--picc-bottom-nav-clearance)-24px)] max-w-[720px] overflow-y-auto rounded-t-2xl bg-[#f8f8fb] px-4 pb-[max(16px,env(safe-area-inset-bottom))] pt-4" onClick={(event) => event.stopPropagation()}>
-              <div className="mb-3 flex items-start justify-between gap-3">
-                <div>
-                  <h3 className="text-[20px] font-semibold text-[#1d1f23]">Contact {contactActionTarget.name}</h3>
-                  <p className="text-[14px] text-[#5f6269]">{activeStore.name}</p>
-                </div>
-                <button
-                  type="button"
-                  className="rounded-md p-1 text-[#5f6269] hover:bg-[#ececf1]"
-                  onClick={() => setContactActionTarget(null)}
-                  aria-label="Close contact modal"
-                >
-                  <X className="h-5 w-5" />
-                </button>
-              </div>
-
-              <div className="grid gap-2">
-                {hasContactEmail(contactActionTarget) ? (
-                  <button
-                    type="button"
-                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-[#c3c5cc] bg-white px-3 text-[15px] font-medium text-[#2b2f38]"
-                    onClick={() => contactViaEmail(contactActionTarget)}
-                  >
-                    <Mail className="h-4 w-4" />
-                    Email
-                  </button>
-                ) : null}
-                {hasContactPhone(contactActionTarget) ? (
-                  <button
-                    type="button"
-                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-[#c3c5cc] bg-white px-3 text-[15px] font-medium text-[#2b2f38]"
-                    onClick={() => contactViaText(contactActionTarget)}
-                  >
-                    <MessageSquare className="h-4 w-4" />
-                    Text
-                  </button>
-                ) : null}
-                {hasContactPhone(contactActionTarget) ? (
-                  <button
-                    type="button"
-                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-[#c3c5cc] bg-white px-3 text-[15px] font-medium text-[#2b2f38]"
-                    onClick={() => contactViaCall(contactActionTarget)}
-                  >
-                    <Phone className="h-4 w-4" />
-                    Call
-                  </button>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        ) : null}
 
         {checkInModalOpen && appAccess.canEdit ? (
           <div className="fixed inset-0 z-[5200] bg-black/40" onClick={() => !checkingIn && setCheckInModalOpen(false)}>
@@ -1066,23 +977,19 @@ function AccountDetailConfidence({
   const Icon = tone.Icon;
 
   return (
-    <div className={cn('mt-4 rounded-2xl border px-3 py-3 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.45)]', tone.className)}>
-      <div className="flex items-start gap-2">
-        <Icon className="mt-0.5 h-4 w-4 shrink-0" />
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[13px] font-semibold">{tone.label}</span>
-            <span className="rounded-full border border-current/15 bg-white/55 px-2 py-0.5 text-[11px] font-semibold">
-              {contactLabel}
-            </span>
-          </div>
-          <p className="mt-1 text-[12px] leading-5 opacity-85">
-            Source: {source}. Last sync: {syncedAt}. Last edit: {editedAt}.
-          </p>
-          {accountFreshness?.error ? <p className="mt-1 text-[12px] font-medium opacity-90">{accountFreshness.error}</p> : null}
-        </div>
+    <details className={cn('group mt-4 rounded-xl border shadow-[inset_0_0_0_1px_rgba(255,255,255,0.45)]', tone.className)}>
+      <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#276fd3] focus-visible:ring-inset [&::-webkit-details-marker]:hidden">
+        <Icon className="h-4 w-4 shrink-0" />
+        <span className="min-w-0 flex-1 truncate text-[12px] font-semibold">Last sync: {syncedAt}</span>
+        <span className="hidden rounded-full border border-current/15 bg-white/55 px-2 py-0.5 text-[11px] font-semibold sm:inline">{tone.label}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200 group-open:rotate-180" />
+      </summary>
+      <div className="border-t border-current/15 px-3 py-2 text-[12px] leading-5 opacity-85">
+        <p>{contactLabel}</p>
+        <p>Source: {source}. Last edit: {editedAt}.</p>
+        {accountFreshness?.error ? <p className="mt-1 font-medium opacity-90">{accountFreshness.error}</p> : null}
       </div>
-    </div>
+    </details>
   );
 }
 

--- a/components/mobile/accounts-mobile.tsx
+++ b/components/mobile/accounts-mobile.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { AlertTriangle, Filter, Loader2, MapPin, RefreshCw, SlidersHorizontal, X } from 'lucide-react';
+import { AlertTriangle, Filter, Loader2, RefreshCw, SlidersHorizontal, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { AccountDetailSheet } from '@/components/mobile/account-detail-sheet';
+import { AccountFollowUpFlow } from '@/components/crm/account-follow-up-flow';
+import { ContactCreateFlow } from '@/components/crm/contact-create-flow';
 import { AlphabetRail } from '@/components/mobile/alphabet-rail';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 import { MobileSearch } from '@/components/mobile/mobile-search';
@@ -68,6 +70,10 @@ export function AccountsMobile() {
   });
 
   const allStores = useMemo(() => storesQuery.data?.stores ?? [], [storesQuery.data?.stores]);
+  const contactAccounts = useMemo(
+    () => allStores.map((store) => ({ notionPageId: store.notionPageId, name: store.name, city: store.city ?? null, state: store.state ?? null })),
+    [allStores],
+  );
   const accountFreshness = useMemo(
     () => (storesQuery.data ? buildTerritoryFreshness(storesQuery.data.meta) : null),
     [storesQuery.data],
@@ -203,6 +209,10 @@ export function AccountsMobile() {
       </MobileHeader>
 
       <div className="mx-auto max-w-[var(--app-shell-max)] px-4 pb-28 pt-4 md:px-5 lg:px-6">
+        <div className="mb-3 flex items-center justify-end gap-2">
+          <AccountFollowUpFlow accounts={allStores.map((store) => ({ id: store.id, notionPageId: store.notionPageId, name: store.name, repNames: store.repNames }))} />
+          <ContactCreateFlow accounts={contactAccounts} />
+        </div>
         <div className="sticky top-0 z-20 -mx-4 border-b border-[#dce2eb] bg-[#f7f9fc]/95 px-4 pb-3 pt-2 backdrop-blur md:-mx-5 md:px-5 lg:-mx-6 lg:px-6">
           <div className="grid grid-cols-[minmax(0,1fr)_48px] gap-2">
             <MobileSearch value={search} onChange={setSearch} placeholder="Search Accounts" />
@@ -307,8 +317,9 @@ export function AccountsMobile() {
             </div>
           ) : null}
 
-          <div className="space-y-4">
-            {grouped.map(([letter, list]) => (
+          <div className="grid grid-cols-[minmax(0,1fr)_28px] items-start gap-2">
+            <div className="space-y-4">
+              {grouped.map(([letter, list]) => (
               <section
                 key={letter}
                 ref={(element) => {
@@ -322,38 +333,52 @@ export function AccountsMobile() {
                       key={store.id}
                       type="button"
                       onClick={() => setDetailStoreId(store.id)}
-                      className="w-full rounded-xl border border-[#e0e4eb] bg-white px-4 py-3 text-left shadow-[0_8px_24px_rgba(24,33,45,0.05)] transition hover:border-[#9db8f7] hover:bg-[#f5f9ff] active:scale-[0.995]"
+                      className="w-full rounded-xl border border-[#dce2eb] bg-white px-3.5 py-3 text-left shadow-[0_4px_16px_rgba(24,33,45,0.04)] transition hover:border-[#9db8f7] hover:bg-[#f5f9ff] active:scale-[0.995]"
                     >
-                      <p className="truncate text-[20px] font-semibold text-[#15171c]">{store.name}</p>
-                      <p className="mt-1 flex min-w-0 items-center gap-1 truncate text-[14px] text-[#6b7280]">
-                        <MapPin className="h-3.5 w-3.5 shrink-0" />
-                        <span className="truncate">{store.locationAddress ?? store.locationLabel ?? 'No address'}</span>
-                      </p>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <span className="rounded-full bg-[#eef3fb] px-2.5 py-1 text-[12px] font-semibold text-[#304153]">
-                          Rep: {store.repNames.length > 0 ? store.repNames.join(', ') : 'Unassigned'}
-                        </span>
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="min-w-0 truncate text-[18px] font-semibold leading-6 text-[#15171c]">{store.name}</p>
                         <NotionOptionChip
                           label={store.status || 'Status unknown'}
                           colorName={store.statusColorName}
                           fallbackHex={store.statusColor || '#5f6b7a'}
                         />
+                      </div>
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        <span className="rounded-full bg-[#eef3fb] px-2.5 py-1 text-[12px] font-semibold text-[#304153]">
+                          Rep: {store.repNames.length > 0 ? store.repNames.join(', ') : 'Unassigned'}
+                        </span>
                         {store.isPreferredPartner ? (
-                          <span className="rounded-full border border-black bg-black px-3 py-1 text-[12px] font-semibold text-white">
+                          <span className="rounded-full border border-[#202733] bg-[#202733] px-2.5 py-1 text-[12px] font-semibold text-white">
                             Preferred
                           </span>
                         ) : null}
                       </div>
+                      <dl className="mt-3 grid grid-cols-3 divide-x divide-[#e4e8ee] border-t border-[#e4e8ee] pt-2 text-[11px]">
+                        <div className="pr-2">
+                          <dt className="text-[#7a8492]">Overdue</dt>
+                          <dd className={store.daysOverdue && store.daysOverdue > 0 ? 'mt-0.5 font-semibold text-[#b43118]' : 'mt-0.5 font-semibold text-[#344052]'}>
+                            {typeof store.daysOverdue === 'number' ? (store.daysOverdue > 0 ? `${store.daysOverdue} days` : store.daysOverdue === 0 ? 'Due today' : 'Current') : 'Unavailable'}
+                          </dd>
+                        </div>
+                        <div className="px-2">
+                          <dt className="text-[#7a8492]">Pay days avg.</dt>
+                          <dd className="mt-0.5 font-semibold text-[#667183]">Unavailable</dd>
+                        </div>
+                        <div className="pl-2">
+                          <dt className="text-[#7a8492]">Nabis rank</dt>
+                          <dd className="mt-0.5 font-semibold text-[#667183]">Unavailable</dd>
+                        </div>
+                      </dl>
                     </button>
                   ))}
                 </div>
               </section>
-            ))}
+              ))}
+            </div>
+            {grouped.length > 0 ? <AlphabetRail layout="gutter" onSelect={(letter) => sectionRefs.current[letter]?.scrollIntoView({ behavior: 'smooth', block: 'start' })} /> : null}
           </div>
         </div>
       </div>
-
-      {grouped.length > 0 ? <AlphabetRail onSelect={(letter) => sectionRefs.current[letter]?.scrollIntoView({ behavior: 'smooth', block: 'start' })} /> : null}
 
       {showFilters ? (
         <AccountFiltersSheet

--- a/components/mobile/alphabet-rail.tsx
+++ b/components/mobile/alphabet-rail.tsx
@@ -4,16 +4,24 @@ const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ#'.split('');
 
 interface AlphabetRailProps {
   onSelect: (letter: string) => void;
+  layout?: 'overlay' | 'gutter';
 }
 
-export function AlphabetRail({ onSelect }: AlphabetRailProps) {
+export function AlphabetRail({ onSelect, layout = 'overlay' }: AlphabetRailProps) {
   return (
-    <div className="absolute right-1 top-[260px] z-[1200] flex w-6 flex-col items-center gap-0.5 text-[14px] font-semibold text-[#1e88e5]">
+    <nav
+      aria-label="Jump to account letter"
+      className={
+        layout === 'gutter'
+          ? 'sticky top-[150px] flex max-h-[calc(100dvh-250px)] w-7 flex-col items-center justify-between self-start rounded-full bg-white/90 py-1 text-[12px] font-semibold text-[#1e6fc7] shadow-[0_2px_10px_rgba(24,33,45,0.08)]'
+          : 'absolute right-1 top-[260px] z-[1200] flex w-6 flex-col items-center gap-0.5 text-[14px] font-semibold text-[#1e88e5]'
+      }
+    >
       {LETTERS.map((letter) => (
-        <button key={letter} type="button" onClick={() => onSelect(letter)} className="h-5 leading-5">
+        <button key={letter} type="button" onClick={() => onSelect(letter)} className="grid min-h-4 w-full place-items-center rounded-full leading-none hover:bg-[#eaf2fc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#276fd3]">
           {letter}
         </button>
       ))}
-    </div>
+    </nav>
   );
 }

--- a/components/mobile/territory-map-overlay-controls.tsx
+++ b/components/mobile/territory-map-overlay-controls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Crosshair, Download, Filter, Layers3, RefreshCw, Search, TrainFront } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { MobileSearch } from '@/components/mobile/mobile-search';
 import type { TerritoryStorePin } from '@/lib/territory/types';
 import { cn } from '@/lib/utils';
@@ -44,6 +45,7 @@ interface TerritoryMapOverlayControlsProps {
   showBoundaries: boolean;
   onOpenFilters: () => void;
   activeFiltersCount: number;
+  addContactControl?: ReactNode;
 }
 
 export function TerritoryMapOverlayControls({
@@ -78,6 +80,7 @@ export function TerritoryMapOverlayControls({
   showBoundaries,
   onOpenFilters,
   activeFiltersCount,
+  addContactControl,
 }: TerritoryMapOverlayControlsProps) {
   return (
     <>
@@ -335,6 +338,7 @@ export function TerritoryMapOverlayControls({
         >
           <TrainFront className={cn('h-5 w-5', showSubwayLines ? 'text-[#cd3814]' : 'text-[#7f828a]')} />
         </button>
+        {addContactControl}
       </div>
     </>
   );

--- a/components/mobile/territory-mobile.tsx
+++ b/components/mobile/territory-mobile.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAppAccess } from '@/components/auth/app-access-provider';
+import { ContactCreateFlow } from '@/components/crm/contact-create-flow';
 import { MobileHeader } from '@/components/mobile/mobile-header';
 import { SegmentedControl } from '@/components/mobile/segmented-control';
 import { AccountDetailSheet } from '@/components/mobile/account-detail-sheet';
@@ -816,6 +817,19 @@ export function TerritoryMobile() {
             showBoundaries={showBoundaries}
             onOpenFilters={openFiltersSheet}
             activeFiltersCount={activeFiltersCount}
+            addContactControl={
+              appAccess.canEdit ? (
+                <ContactCreateFlow
+                  triggerVariant="icon"
+                  accounts={stores.map((store) => ({
+                    notionPageId: store.notionPageId,
+                    name: store.name,
+                    city: store.city ?? null,
+                    state: store.state ?? null,
+                  }))}
+                />
+              ) : null
+            }
           />
         </div>
       ) : (

--- a/components/shared/data-freshness.tsx
+++ b/components/shared/data-freshness.tsx
@@ -1,44 +1,9 @@
-import { AlertCircle, CheckCircle2, Clock3, Loader2 } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ChevronDown, Clock3, Loader2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Badge } from '@/components/ui';
 import type { RuntimeFreshness } from '@/lib/runtime/account-contact-contract';
+import { buildFreshnessDisclosure } from '@/lib/ui/data-freshness-presentation';
 import { cn } from '@/lib/utils';
-
-function formatRelativeAge(ageSeconds: number | null) {
-  if (ageSeconds === null) {
-    return 'unknown';
-  }
-
-  if (ageSeconds < 60) {
-    return 'just now';
-  }
-
-  const minutes = Math.floor(ageSeconds / 60);
-  if (minutes < 60) {
-    return `${minutes}m ago`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 48) {
-    return `${hours}h ago`;
-  }
-
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-function formatTimestamp(value: string | null) {
-  if (!value) {
-    return 'No sync recorded';
-  }
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return 'Invalid sync time';
-  }
-
-  return date.toLocaleString();
-}
 
 function stateTone(state: RuntimeFreshness['state']) {
   if (state === 'fresh') {
@@ -99,32 +64,43 @@ export function DataFreshnessBanner({
 }) {
   const tone = stateTone(freshness.state);
   const Icon = tone.icon;
+  const disclosure = buildFreshnessDisclosure(freshness);
 
   return (
-    <div
+    <details
       className={cn(
-        'flex flex-col gap-3 rounded-xl border px-3 py-3 text-sm sm:flex-row sm:items-center sm:justify-between',
+        'group rounded-lg border text-sm shadow-[0_1px_2px_rgba(24,33,45,0.04)]',
         tone.className,
-        compact ? 'py-2' : null,
+        compact ? null : 'sm:max-w-2xl',
         className,
       )}
     >
-      <div className="flex min-w-0 items-start gap-3">
-        <Icon className={cn('mt-0.5 h-4 w-4 shrink-0', freshness.state === 'syncing' ? 'animate-spin' : null)} />
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-semibold">{freshness.label}</span>
-            <DataFreshnessBadge freshness={freshness} />
-            <span className="text-xs opacity-75">{formatRelativeAge(freshness.ageSeconds)}</span>
+      <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#276fd3] focus-visible:ring-inset [&::-webkit-details-marker]:hidden">
+        <Icon className={cn('h-4 w-4 shrink-0', freshness.state === 'syncing' ? 'animate-spin' : null)} />
+        <span className="min-w-0 flex-1 truncate text-xs font-semibold sm:text-sm">{disclosure.lastSyncLabel}</span>
+        <span className="hidden text-xs opacity-70 sm:inline">{disclosure.label}</span>
+        <span className="hidden shrink-0 sm:block">
+          <DataFreshnessBadge freshness={freshness} />
+        </span>
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200 group-open:rotate-180" aria-hidden="true" />
+      </summary>
+
+      <div className="border-t border-current/15 px-3 pb-3 pt-2">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-semibold">{disclosure.label}</span>
+              <span className="text-xs opacity-75">{disclosure.relativeAge}</span>
+            </div>
+            <p className="mt-1 leading-5 opacity-85">{disclosure.detail}</p>
+            <p className="mt-1 text-xs opacity-70">
+              {disclosure.recordsLabel}
+              {disclosure.error ? ` · ${disclosure.error}` : ''}
+            </p>
           </div>
-          <p className="mt-1 leading-5 opacity-85">{freshness.detail}</p>
-          <p className="mt-1 text-xs opacity-70">
-            Last sync: {formatTimestamp(freshness.syncedAt)} · Records: {freshness.recordsRead.toLocaleString()}
-            {freshness.error ? ` · ${freshness.error}` : ''}
-          </p>
         </div>
+        {action ? <div className="mt-3">{action}</div> : null}
       </div>
-      {action ? <div className="shrink-0">{action}</div> : null}
-    </div>
+    </details>
   );
 }

--- a/lib/contacts/contact-actions.test.ts
+++ b/lib/contacts/contact-actions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildContactActionHref } from '@/lib/contacts/contact-actions';
+
+describe('buildContactActionHref', () => {
+  it('opens email in a new Gmail compose with the contact and account context', () => {
+    expect(
+      buildContactActionHref({
+        kind: 'email',
+        email: ' buyer@example.com ',
+        phone: '',
+        accountName: 'Harbor House',
+      }),
+    ).toBe(
+      'https://mail.google.com/mail/?view=cm&fs=1&to=buyer%40example.com&su=PICC%20follow-up%3A%20Harbor%20House',
+    );
+  });
+
+  it('normalizes phone links for text and call without inventing a number', () => {
+    const input = { email: '', phone: '+1 (347) 555-0198', accountName: 'Harbor House' };
+
+    expect(buildContactActionHref({ ...input, kind: 'text' })).toBe('sms:+13475550198');
+    expect(buildContactActionHref({ ...input, kind: 'call' })).toBe('tel:+13475550198');
+    expect(buildContactActionHref({ ...input, kind: 'call', phone: '—' })).toBeNull();
+  });
+});

--- a/lib/contacts/contact-actions.ts
+++ b/lib/contacts/contact-actions.ts
@@ -1,0 +1,36 @@
+export type ContactActionKind = 'email' | 'text' | 'call';
+
+function clean(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return !trimmed || trimmed === '—' ? null : trimmed;
+}
+
+export function normalizeContactPhone(value: string | null | undefined) {
+  const phone = clean(value);
+  if (!phone) return null;
+
+  const normalized = phone.replace(/[^+\d]/g, '');
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function buildContactActionHref(input: {
+  kind: ContactActionKind;
+  email: string | null | undefined;
+  phone: string | null | undefined;
+  accountName: string;
+}) {
+  if (input.kind === 'email') {
+    const email = clean(input.email);
+    if (!email) return null;
+
+    return [
+      'https://mail.google.com/mail/?view=cm&fs=1',
+      `to=${encodeURIComponent(email)}`,
+      `su=${encodeURIComponent(`PICC follow-up: ${input.accountName}`)}`,
+    ].join('&');
+  }
+
+  const phone = normalizeContactPhone(input.phone);
+  if (!phone) return null;
+  return `${input.kind === 'text' ? 'sms' : 'tel'}:${phone}`;
+}

--- a/lib/contacts/contact-follow-up.test.ts
+++ b/lib/contacts/contact-follow-up.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { buildAccountFollowUpPayload, buildCommunicationFollowUpPayload } from '@/lib/contacts/contact-follow-up';
+
+describe('buildCommunicationFollowUpPayload', () => {
+  it('builds an honest account-scoped follow-up after a launched contact action', () => {
+    expect(
+      buildCommunicationFollowUpPayload({
+        action: 'email',
+        account: { id: 'account-page', name: 'Harbor House' },
+        contact: {
+          id: 'contact-page',
+          name: 'Mara Vega',
+          roleTitle: 'Buyer',
+          email: 'mara@example.com',
+          phone: '+13475550198',
+        },
+        followUpDate: '2026-08-18',
+        reason: '',
+      }),
+    ).toEqual({
+      store: {
+        id: 'account-page',
+        notionPageId: 'account-page',
+        name: 'Harbor House',
+      },
+      noteText: 'Follow-up scheduled after opening Gmail for Mara Vega.',
+      followUpDate: '2026-08-18',
+      followUpNeeded: true,
+      followUpReason: 'Follow up after email with Mara Vega',
+      associatedContact: {
+        id: 'contact-page',
+        name: 'Mara Vega',
+        roleTitle: 'Buyer',
+        email: 'mara@example.com',
+        phone: '+13475550198',
+      },
+    });
+  });
+
+  it('uses the rep note when one is provided', () => {
+    const payload = buildCommunicationFollowUpPayload({
+      action: 'call',
+      account: { id: 'account-page', name: 'Harbor House' },
+      contact: { id: 'contact-page', name: 'Mara Vega', roleTitle: '', email: '', phone: '' },
+      followUpDate: '2026-08-21',
+      reason: 'Confirm fall menu placement',
+    });
+
+    expect(payload.followUpReason).toBe('Confirm fall menu placement');
+    expect(payload.noteText).toBe('Follow-up scheduled after opening the phone app for Mara Vega.');
+  });
+});
+
+describe('buildAccountFollowUpPayload', () => {
+  it('builds a new follow-up without fabricating a completed contact event', () => {
+    expect(
+      buildAccountFollowUpPayload({
+        account: { id: 'store-id', notionPageId: 'account-page', name: 'Harbor House' },
+        followUpDate: '2026-08-20',
+        reason: 'Review the next order',
+      }),
+    ).toEqual({
+      store: { id: 'store-id', notionPageId: 'account-page', name: 'Harbor House' },
+      noteText: 'New follow-up scheduled: Review the next order',
+      followUpDate: '2026-08-20',
+      followUpNeeded: true,
+      followUpReason: 'Review the next order',
+    });
+  });
+});

--- a/lib/contacts/contact-follow-up.ts
+++ b/lib/contacts/contact-follow-up.ts
@@ -1,0 +1,69 @@
+import type { ContactActionKind } from '@/lib/contacts/contact-actions';
+
+type FollowUpAccount = {
+  id: string;
+  name: string;
+};
+
+type FollowUpContact = {
+  id: string;
+  name: string;
+  roleTitle: string;
+  email: string;
+  phone: string;
+};
+
+function launchedActionLabel(action: ContactActionKind) {
+  if (action === 'email') return 'opening Gmail';
+  if (action === 'text') return 'opening the message app';
+  return 'opening the phone app';
+}
+
+export function buildCommunicationFollowUpPayload(input: {
+  action: ContactActionKind;
+  account: FollowUpAccount;
+  contact: FollowUpContact;
+  followUpDate: string;
+  reason: string;
+}) {
+  const reason = input.reason.trim() || `Follow up after ${input.action} with ${input.contact.name}`;
+
+  return {
+    store: {
+      id: input.account.id,
+      notionPageId: input.account.id,
+      name: input.account.name,
+    },
+    noteText: `Follow-up scheduled after ${launchedActionLabel(input.action)} for ${input.contact.name}.`,
+    followUpDate: input.followUpDate,
+    followUpNeeded: true,
+    followUpReason: reason,
+    associatedContact: {
+      id: input.contact.id,
+      name: input.contact.name,
+      roleTitle: input.contact.roleTitle,
+      email: input.contact.email,
+      phone: input.contact.phone,
+    },
+  };
+}
+
+export function buildAccountFollowUpPayload(input: {
+  account: FollowUpAccount & { notionPageId: string };
+  followUpDate: string;
+  reason: string;
+}) {
+  const reason = input.reason.trim();
+
+  return {
+    store: {
+      id: input.account.id,
+      notionPageId: input.account.notionPageId,
+      name: input.account.name,
+    },
+    noteText: `New follow-up scheduled: ${reason}`,
+    followUpDate: input.followUpDate,
+    followUpNeeded: true,
+    followUpReason: reason,
+  };
+}

--- a/lib/ui/data-freshness-presentation.test.ts
+++ b/lib/ui/data-freshness-presentation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildFreshnessDisclosure } from '@/lib/ui/data-freshness-presentation';
+import type { RuntimeFreshness } from '@/lib/runtime/account-contact-contract';
+
+function freshness(overrides: Partial<RuntimeFreshness> = {}): RuntimeFreshness {
+  return {
+    source: 'notion-contacts',
+    label: 'Contacts',
+    state: 'fresh',
+    syncedAt: '2026-08-14T14:30:00.000Z',
+    lastEditedAt: '2026-08-14T14:20:00.000Z',
+    recordsRead: 2682,
+    ageSeconds: 90,
+    stale: false,
+    syncing: false,
+    error: null,
+    detail: 'Notion contact cache is current.',
+    ...overrides,
+  };
+}
+
+describe('buildFreshnessDisclosure', () => {
+  it('keeps the collapsed summary to source, state, and the last sync date', () => {
+    expect(buildFreshnessDisclosure(freshness())).toEqual({
+      label: 'Contacts',
+      stateLabel: 'Fresh',
+      relativeAge: '1m ago',
+      lastSyncLabel: 'Last sync: Aug 14, 2026, 10:30 AM',
+      detail: 'Notion contact cache is current.',
+      recordsLabel: 'Records: 2,682',
+      error: null,
+    });
+  });
+
+  it('uses a clear fallback without exposing invalid timestamps', () => {
+    expect(buildFreshnessDisclosure(freshness({ syncedAt: null, ageSeconds: null })).lastSyncLabel).toBe(
+      'Last sync: Not recorded',
+    );
+    expect(buildFreshnessDisclosure(freshness({ syncedAt: 'invalid' })).lastSyncLabel).toBe(
+      'Last sync: Invalid date',
+    );
+  });
+});

--- a/lib/ui/data-freshness-presentation.ts
+++ b/lib/ui/data-freshness-presentation.ts
@@ -1,0 +1,50 @@
+import type { RuntimeFreshness } from '@/lib/runtime/account-contact-contract';
+
+function formatRelativeAge(ageSeconds: number | null) {
+  if (ageSeconds === null) return 'unknown';
+  if (ageSeconds < 60) return 'just now';
+
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) return 'Not recorded';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Invalid date';
+
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function stateLabel(state: RuntimeFreshness['state']) {
+  if (state === 'fresh') return 'Fresh';
+  if (state === 'syncing') return 'Syncing';
+  if (state === 'error') return 'Sync issue';
+  if (state === 'stale') return 'Stale';
+  return 'Unknown';
+}
+
+export function buildFreshnessDisclosure(freshness: RuntimeFreshness) {
+  return {
+    label: freshness.label,
+    stateLabel: stateLabel(freshness.state),
+    relativeAge: formatRelativeAge(freshness.ageSeconds),
+    lastSyncLabel: `Last sync: ${formatTimestamp(freshness.syncedAt)}`,
+    detail: freshness.detail,
+    recordsLabel: `Records: ${freshness.recordsRead.toLocaleString('en-US')}`,
+    error: freshness.error,
+  };
+}

--- a/tests/e2e/contact-workspace.spec.ts
+++ b/tests/e2e/contact-workspace.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from '@playwright/test';
+
+const store = {
+  id: 'store-1',
+  notionPageId: 'account-page-1',
+  name: 'Harbor House',
+  status: 'Customer',
+  statusKey: 'customer',
+  statusColor: '#1f9d55',
+  statusColorName: 'green',
+  pinKind: 'customer',
+  repNames: ['Mina Torres'],
+  repEmails: ['mina@piccplatform.com'],
+  lat: 40.7128,
+  lng: -74.006,
+  locationLabel: 'New York, NY',
+  locationAddress: '88 Test Street, New York, NY',
+  locationSource: 'notion-place',
+  locationPrecision: 'exact',
+  isApproximate: false,
+  lastEditedTime: '2026-08-14T14:00:00.000Z',
+  city: 'New York',
+  state: 'NY',
+  daysOverdue: 6,
+  phoneNumber: '+12125550115',
+  email: 'orders@harbor.example',
+  referralSource: null,
+  isPreferredPartner: true,
+  followUpDate: null,
+  followUpNeeded: true,
+  followUpReason: null,
+  notes: null,
+  lastCheckIn: null,
+};
+
+function storesResponse() {
+  return {
+    stores: [store],
+    filters: {
+      statuses: [{ value: 'Customer', count: 1 }],
+      reps: [{ value: 'Mina Torres', count: 1 }],
+      pppStatuses: [],
+      headsetConnectionStatuses: [],
+      preferredPartners: [{ value: 'preferred', count: 1 }],
+      referralSources: [],
+      locationAvailability: [],
+      vendorDayStatuses: [],
+    },
+    meta: {
+      dataSource: 'notion-live-cache',
+      lastEditedMax: store.lastEditedTime,
+      recordsRead: 1,
+      unresolvedLocationCount: 0,
+      geocodedThisRequest: 0,
+      syncedAt: '2026-08-14T14:10:00.000Z',
+      stale: false,
+      syncing: false,
+      syncError: null,
+    },
+  };
+}
+
+function storeDetailResponse() {
+  return {
+    store,
+    contacts: [
+      {
+        id: 'contact-page-1',
+        name: 'Mara Vega',
+        roleTitle: 'Buyer',
+        email: 'mara@harbor.example',
+        phone: '+1 (347) 555-0198',
+        status: 'ACTIVE',
+        linkedWork: 'Primary contact',
+      },
+    ],
+    checkIns: [],
+    vendorDays: { total: 0, upcomingCount: 0, recent: [] },
+    crm: {
+      contact: null,
+      contactEmail: null,
+      contactPhone: null,
+      primaryContactName: 'Mara Vega',
+      primaryContactBuyer: 'Mara Vega',
+      primaryContactEmail: 'mara@harbor.example',
+      primaryContactPhone: '+1 (347) 555-0198',
+      rep: 'Mina Torres',
+      accountManager: null,
+      piccCreditStatus: null,
+      accountStatus: 'Customer',
+      lastOrderAmount: null,
+      lastContacted: null,
+      lastDeliveryDate: null,
+      lastSampleOrderDate: null,
+      lastOrderDate: null,
+      referralSource: null,
+      customerSince: null,
+      pennyBundlePromoStatus: null,
+      pppStatus: null,
+      headsetConnectionStatus: null,
+      productTracking: null,
+      displayTracking: null,
+    },
+    analytics: { matchedAccountId: null, matchedBy: 'account', monthly: [], recentOrders: [], orders: [] },
+    history: { accountUpdates: [] },
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/territory/stores?**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(storesResponse()) });
+  });
+  await page.route('**/api/territory/stores/store-1', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(storeDetailResponse()) });
+  });
+});
+
+test('accounts stay dense, keep the alphabet rail clear, and create a follow-up', async ({ page }) => {
+  let followUpPayload: unknown;
+  await page.route('**/api/territory/check-in', async (route) => {
+    followUpPayload = route.request().postDataJSON();
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, syncWarning: null }) });
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/accounts');
+
+  const accountCard = page.getByRole('button', { name: /Harbor House.*Customer.*Mina Torres/s });
+  await expect(accountCard).toBeVisible();
+  await expect(accountCard).not.toContainText('88 Test Street');
+  await expect(accountCard).toContainText('6 days');
+  await expect(accountCard).toContainText('Pay days avg.');
+  await expect(accountCard).toContainText('Nabis rank');
+
+  const rail = page.getByRole('navigation', { name: 'Jump to account letter' });
+  const [cardBox, railBox] = await Promise.all([accountCard.boundingBox(), rail.boundingBox()]);
+  expect(cardBox).not.toBeNull();
+  expect(railBox).not.toBeNull();
+  expect(cardBox!.x + cardBox!.width).toBeLessThanOrEqual(railBox!.x);
+  if (process.env.PICC_EVIDENCE_DIR) {
+    await page.screenshot({ path: `${process.env.PICC_EVIDENCE_DIR}/accounts-mobile-contact-foundation.png`, fullPage: true });
+  }
+
+  await page.getByRole('button', { name: 'New follow-up' }).click();
+  await page.getByPlaceholder('Search account or rep').fill('Harbor');
+  await page.getByRole('button', { name: /Harbor House.*Mina Torres/s }).click();
+  await page.getByRole('button', { name: 'Tomorrow' }).click();
+  await page.getByPlaceholder('What needs to happen next?').fill('Review the next order');
+  await page.getByRole('button', { name: 'Set follow-up' }).click();
+
+  await expect(page.getByText('Follow-up set')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'New follow-up' })).toBeHidden();
+  expect(followUpPayload).toMatchObject({
+    store: { id: 'store-1', notionPageId: 'account-page-1', name: 'Harbor House' },
+    followUpNeeded: true,
+    followUpReason: 'Review the next order',
+  });
+});
+
+test('account details exposes direct actions and prompts for a follow-up after Gmail opens', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/accounts');
+  await page.getByRole('button', { name: /Harbor House.*Customer.*Mina Torres/s }).click();
+
+  await expect(page.getByText('Associated Contacts')).toBeVisible();
+  const email = page.getByRole('link', { name: 'Email Mara Vega' });
+  const text = page.getByRole('link', { name: 'Text Mara Vega' });
+  const call = page.getByRole('link', { name: 'Call Mara Vega' });
+  await expect(email).toHaveAttribute('href', /https:\/\/mail\.google\.com\/mail\/\?view=cm&fs=1&to=mara%40harbor\.example/);
+  await expect(text).toHaveAttribute('href', 'sms:+13475550198');
+  await expect(call).toHaveAttribute('href', 'tel:+13475550198');
+
+  await page.evaluate(() => {
+    document.addEventListener(
+      'click',
+      (event) => {
+        const target = event.target as Element | null;
+        if (target?.closest('a[href^="https://mail.google.com/mail/"]')) event.preventDefault();
+      },
+      true,
+    );
+  });
+  await email.click();
+
+  await expect(page.getByRole('heading', { name: 'Set follow-up?' })).toBeVisible();
+  await expect(page.getByText('Gmail opened for Mara Vega.')).toBeVisible();
+  if (process.env.PICC_EVIDENCE_DIR) {
+    await page.screenshot({ path: `${process.env.PICC_EVIDENCE_DIR}/account-contact-actions-follow-up.png`, fullPage: true });
+  }
+  await page.getByRole('button', { name: 'Not now' }).click();
+  await expect(page.getByRole('heading', { name: 'Set follow-up?' })).toBeHidden();
+});


### PR DESCRIPTION
## Summary

- Refs #163
- Adds a compact, reusable data-freshness disclosure across the affected CRM, home, dashboard, and Account Details surfaces.
- Makes Contacts and Account Details immediately actionable with Gmail compose, text, and call links followed by an optional follow-up prompt.
- Densifies mobile account cards, moves the alphabet rail into a non-overlapping gutter, and adds working New Follow-Up and Add Contact entry points.

## Why

The current mobile CRM uses too much space for sync metadata, obscures core contact details, and makes common outreach and follow-up work unnecessarily indirect. This slice establishes shared interaction contracts and accessible mobile patterns before deeper integrations are added.

## Scope

- In scope: shared compact freshness UI; mobile Contacts and Accounts polish; Account Details contact actions; Gmail/SMS/phone deep links; user-triggered follow-up creation through the existing check-in endpoint; Add Contact on Accounts, Account Details, and Map; focused tests and browser proof.
- Out of scope: schema changes, Gmail OAuth/history ingestion, device call/text history, contact merge/archive/delete, daily email scheduling, and production-data writes performed during verification.
- Files changed: 23.
- If this PR changes more than 10 files, explain why: the work is one cross-surface mobile CRM interaction contract. Shared actions and freshness components replace duplicated UI in four existing surfaces, with corresponding unit and browser coverage. No broad architectural rewrite is included.

## Coordination

- Owned path globs: shared CRM presentation components, affected mobile CRM views, focused tests, `DESIGN-SYSTEM.md`, and `SESSION.md`.
- Open PRs checked for overlap: #166, #144, #135, #82.
- Blocked by: approval-lane review before merge.
- Blocks: later contact profile and Gmail integration slices.
- Parallel label: `parallel:exclusive`.
- Lane: approval lane.
- Approval-lane reason, if any: this adds a new UI path for user-triggered follow-up writes through an existing server endpoint.
- Large diff / boundary note, if any: all changes remain inside the existing CRM/mobile presentation and existing follow-up boundary; no schema, auth, secret, or integration configuration changes.

## Labels And Review Flags

- [x] PR has the right `type:*`, `priority:*`, `area:*`, and status labels
- [x] PR has `agent-generated` if opened or substantially authored by an agent
- [ ] PR has `needs-prod-proof` if it discusses production data, sync state, customer-visible totals, or live integration behavior
- [x] PR has the right `parallel:*` label and `meta:protocol-change` when it changes repo rules
- [x] Title and commit use a conventional prefix (`fix:`, `feat:`, `chore:`, `docs:`, `test:`, or `refactor:`)
- [x] Draft PR was opened at claim time before non-test source edits

## Validation

- [x] `npm test` (included in `npm run verify`: 31 files, 141 tests)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Browser/UI proof attached when UI behavior changed
- [ ] Read-only production proof included when production data/state is discussed
- [x] `SESSION.md` describes current scope, out-of-scope items, and constraints

Additional browser validation: `npm run test:e2e` — 25 passed.

## Screenshots / Browser Proof

Mobile browser proof was captured locally for the dense account cards/alphabet gutter and for Account Details contact actions with the post-Gmail follow-up prompt. Screenshots contain internal fixture context and are intentionally not attached to the public repository.

## Production Proof

No production-data claims or mutations were made. Browser verification used controlled route fixtures; the configured local database was unavailable and no production connection was used.

## Risk And Rollback

- Risk: the new follow-up affordances reuse an existing write endpoint and may expose pre-existing external-sync warnings to more users.
- Rollback: revert commit `1e05c0c`; no schema or data migration is involved.
