### PR TITLE
fix: keep territory drawing actions above mobile menu

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,46 +1,44 @@
-# Session: Issue 163 Mobile CRM UI Foundation
+# Session: Issue 171 Territory Drawing Action Clearance
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/163
-- Branch: `codex/163-contact-foundation`
-- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/167
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/171
+- Draft PR: pending
+- Branch: `codex/171-territory-drawing-actions`
+- Worktree: `/Users/brycejohnson/Code/PICC-Web-App`
 
 ## Scope
 
-- Improve reusable mobile CRM status and navigation components.
-- Improve readability and interaction consistency across related CRM views.
-- Add focused regression coverage for the changed user flows.
+- Keep `Finish Shape` and `Clear` fully visible and tappable above fixed mobile actions.
+- Preserve the existing `Save Boundary` clearance from the primary bottom navigation.
+- Add a phone-sized Playwright regression covering visibility, geometry, and interaction.
 
 ## Out of scope
 
-- Database, authentication, permissions, secrets, external integrations, and production-data changes.
+- Territory geometry, persistence, permissions, or API changes.
+- Primary map navigation redesign.
 - Changes to `/Users/brycejohnson/Code/map-app`.
-- Unrelated Nabis exception workflows or application-shell refactors.
 
 ## Constraints
 
-- Preserve the current PWA shell and server boundaries.
-- Use RED-first tests for behavior changes.
-- Run `npm run verify` and `npm run test:e2e`.
-- Capture mobile browser proof for changed UI flows.
+- Reproduce the clipping with a RED browser test before changing the component.
+- Keep the fix localized to the existing mobile territory boundary sheet.
+- Preserve portrait, landscape, keyboard, and desktop behavior.
+- Run `npm run verify`, the focused territory E2E spec, and the full E2E suite before completion.
 
 ## Ownership and overlap
 
-- Owned paths: shared CRM presentation components, affected mobile CRM views, focused tests, `SESSION.md`, and UI evidence.
-- Checked open PRs #166, #144, #135, and #82 before source edits.
-- PR #166 is documentation-only. PR #135 has a stale, narrow overlap in Account Details; the implementation here is additive and will be rebased if #135 lands first.
+- Owned paths: `components/mobile/territory-boundary-sheet.tsx`, `tests/e2e/territory-boundary-editor.spec.ts`, browser proof artifacts, and `SESSION.md`.
+- Open PRs were checked; none owns the territory boundary sheet or its E2E spec.
+- The unrelated untracked `.agents/account-detail-redirect-ai-tab.png` is not part of this work.
 
 ## Validation plan
 
-- Baseline: 28 Vitest files and 134 tests passed under Node 22.22.0.
-- RED/GREEN: focused presentation and interaction contract tests cover compact sync summaries, Gmail/SMS/phone links, and follow-up request payloads.
-- Targeted mobile Playwright: 2 tests passed for dense account cards, alphabet-rail clearance, New Follow-Up, direct Account Details contact actions, and the post-action prompt.
-- Browser evidence: `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ffc03-da13-7281-ae9a-5216d1b9437f/accounts-mobile-contact-foundation.png` and `/Users/brycejohnson/.codex/visualizations/2026/08/13/019ffc03-da13-7281-ae9a-5216d1b9437f/account-contact-actions-follow-up.png`.
-- `npm run verify`: passed (lint, typecheck, 31 Vitest files / 141 tests, Prisma validation, production build).
-- `npm run test:e2e`: 25 browser tests passed under Node 22.22.0.
-- Final diff check: `git diff --check` passed.
+- RED: at 390x844, assert `Finish Shape` and `Clear` do not extend under the fixed Save footer and can receive pointer clicks.
+- GREEN: run the focused territory boundary editor Playwright spec.
+- Regression: run repository verification and the full Playwright suite.
+- Visual: capture the corrected phone viewport with the drawing actions visible above bottom UI.
 
 ## Current state
 
-- Production UI proof follows merge and deployment.
+Issue and branch created. Regression test is next; production component code has not been changed.

--- a/SESSION.md
+++ b/SESSION.md
@@ -3,7 +3,7 @@
 ## Linked work
 
 - GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/171
-- Draft PR: pending
+- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/172
 - Branch: `codex/171-territory-drawing-actions`
 - Worktree: `/Users/brycejohnson/Code/PICC-Web-App`
 
@@ -41,4 +41,4 @@
 
 ## Current state
 
-Issue and branch created. Regression test is next; production component code has not been changed.
+RED reproduced the scrolling controls at y=81 instead of their original y=663. The fixed action footer is implemented and verified at portrait, landscape, short desktop, and reported desktop sizes. After rebasing onto current `main`, `npm run verify` passes with 159 unit tests and all 28 Playwright tests pass; PR review and merge remain.

--- a/components/mobile/territory-boundary-sheet.tsx
+++ b/components/mobile/territory-boundary-sheet.tsx
@@ -362,19 +362,6 @@ export function TerritoryBoundaryEditor({
               <Undo2 className="h-4 w-4" />
               Undo Point
             </button>
-            <button
-              type="button"
-              onClick={onFinishDrawing}
-              disabled={boundary.coordinates.length < 3}
-              className="inline-flex items-center gap-1 rounded-lg border border-[#9fd3aa] bg-[#effaf1] px-3 py-2 text-[13px] font-medium text-[#24703a] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <Check className="h-4 w-4" />
-              Finish Shape
-            </button>
-            <button type="button" onClick={onClearPoints} className="inline-flex items-center gap-1 rounded-lg border border-[#e2b4ab] bg-[#fff4f1] px-3 py-2 text-[13px] font-medium text-[#b43819]">
-              <Trash2 className="h-4 w-4" />
-              Clear
-            </button>
               </div>
 
               {boundary.coordinates.length > 0 ? (
@@ -406,14 +393,36 @@ export function TerritoryBoundaryEditor({
           </div>
         </div>
 
-        <div className="shrink-0 border-t border-[#f0d6ce] px-4 py-3">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-[12px] text-[#7b7e87]">{boundary.coordinates.length} point{boundary.coordinates.length === 1 ? '' : 's'} captured</p>
+        <div
+          className="shrink-0 border-t border-[#f0d6ce] px-3 py-3 [@media(max-height:500px)]:flex [@media(max-height:500px)]:items-center [@media(max-height:500px)]:gap-2 [@media(max-height:500px)]:py-2"
+          data-testid="territory-boundary-editor-footer"
+        >
+          <div className="mb-2 grid grid-cols-2 gap-2 [@media(max-height:500px)]:mb-0 [@media(max-height:500px)]:min-w-0 [@media(max-height:500px)]:flex-1 [@media(max-height:500px)]:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
+            <button
+              type="button"
+              onClick={onFinishDrawing}
+              disabled={boundary.coordinates.length < 3}
+              className="inline-flex min-h-11 items-center justify-center gap-1 whitespace-nowrap rounded-lg border border-[#9fd3aa] bg-[#effaf1] px-3 py-2 text-[13px] font-medium text-[#24703a] disabled:cursor-not-allowed disabled:opacity-50 [@media(max-height:500px)]:min-h-10 [@media(max-height:500px)]:px-2 [@media(max-height:500px)]:text-[12px]"
+            >
+              <Check className="h-4 w-4" />
+              Finish Shape
+            </button>
+            <button
+              type="button"
+              onClick={onClearPoints}
+              className="inline-flex min-h-11 items-center justify-center gap-1 whitespace-nowrap rounded-lg border border-[#e2b4ab] bg-[#fff4f1] px-3 py-2 text-[13px] font-medium text-[#b43819] [@media(max-height:500px)]:min-h-10 [@media(max-height:500px)]:px-2 [@media(max-height:500px)]:text-[12px]"
+            >
+              <Trash2 className="h-4 w-4" />
+              Clear
+            </button>
+          </div>
+          <div className="flex items-center justify-between gap-3 [@media(max-height:500px)]:shrink-0">
+            <p className="text-[12px] text-[#7b7e87] [@media(max-height:500px)]:hidden">{boundary.coordinates.length} point{boundary.coordinates.length === 1 ? '' : 's'} captured</p>
             <button
               type="button"
               onClick={onSave}
               disabled={saving}
-              className="inline-flex items-center gap-2 rounded-lg bg-[#cd3814] px-4 py-2 text-[13px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex min-h-11 items-center gap-2 whitespace-nowrap rounded-lg bg-[#cd3814] px-4 py-2 text-[13px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50 [@media(max-height:500px)]:min-h-10 [@media(max-height:500px)]:px-3 [@media(max-height:500px)]:text-[12px]"
             >
               <Save className="h-4 w-4" />
               {saving ? 'Saving...' : 'Save Boundary'}

--- a/tests/e2e/territory-boundary-editor.spec.ts
+++ b/tests/e2e/territory-boundary-editor.spec.ts
@@ -120,9 +120,50 @@ test('keeps Save Boundary above the fixed primary navigation at a short viewport
   const save = page.getByRole('button', { name: 'Save Boundary' });
   await page.getByRole('button', { name: 'Delete' }).last().focus();
   await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: 'Finish Shape' })).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: 'Clear' })).toBeFocused();
+  await page.keyboard.press('Tab');
   await expect(save).toBeFocused();
   await save.press('Enter');
   await expect(page.getByText('Territory boundary updated')).toBeVisible();
+});
+
+test('keeps Finish Shape and Clear reachable while the mobile point list scrolls', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openPopulatedBoundaryEditor(page);
+
+  const scrollBody = page.getByTestId('territory-boundary-editor-scroll');
+  const finish = page.getByRole('button', { name: 'Finish Shape' });
+  const clear = page.getByRole('button', { name: 'Clear' });
+  const navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+  const initialFinishBox = await finish.boundingBox();
+  const initialClearBox = await clear.boundingBox();
+
+  expect(initialFinishBox).not.toBeNull();
+  expect(initialClearBox).not.toBeNull();
+  await scrollBody.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+
+  await expect(finish).toBeVisible();
+  await expect(clear).toBeVisible();
+  const [scrolledFinishBox, scrolledClearBox, navigationBox] = await Promise.all([
+    finish.boundingBox(),
+    clear.boundingBox(),
+    navigation.boundingBox(),
+  ]);
+  expect(scrolledFinishBox).not.toBeNull();
+  expect(scrolledClearBox).not.toBeNull();
+  expect(navigationBox).not.toBeNull();
+  expect(scrolledFinishBox!.y).toBe(initialFinishBox!.y);
+  expect(scrolledClearBox!.y).toBe(initialClearBox!.y);
+  expect(scrolledFinishBox!.y + scrolledFinishBox!.height).toBeLessThanOrEqual(navigationBox!.y);
+  expect(scrolledClearBox!.y + scrolledClearBox!.height).toBeLessThanOrEqual(navigationBox!.y);
+
+  await finish.click();
+  await clear.click();
+  await expect(page.getByText('0 points captured')).toBeVisible();
 });
 
 for (const viewport of [


### PR DESCRIPTION
Closes #171\n\n## Why\nOn phone-sized map views, Finish Shape and Clear scrolled away with the point list and could sit behind the fixed bottom action/menu stack.\n\n## What changed\n- Moved Finish Shape and Clear into the fixed territory action footer above Save Boundary.\n- Preserved 44px portrait touch targets and added a compact short-height layout.\n- Extended keyboard traversal through Finish Shape, Clear, and Save Boundary.\n- Added a 390x844 regression that scrolls the point list, verifies both actions remain stationary above navigation, and clicks both controls.\n\n## Out of scope\n- Territory geometry, persistence, permissions, and APIs.\n- Broader map navigation redesign.\n\n## Validation\n- RED before source edits: Finish Shape moved from y=663 to y=81 after scrolling.\n- Focused territory Playwright: 5 passed.\n- npm run verify: lint, typecheck, 159 unit tests, Prisma validation, and build passed after rebase.\n- Full Playwright: 28 passed after rebase.\n- Visual proof captured at 390x844 and 1800x1280.\n\n## Risk\nFrontend-only and localized to the existing territory sheet. The short-height footer is covered at 844x390.