### PR TITLE
fix: keep territory header visible in Safari

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -4,7 +4,7 @@
 
 - GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/175
 - Branch: `codex/175-safari-territory-header`
-- Draft PR: pending initial session commit
+- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/176
 
 ## Scope
 
@@ -37,4 +37,13 @@
 
 ## Current state
 
-Production Safari evidence confirms the profile header is present in the accessibility tree but visually clipped above the Map/List switch. Source diagnosis is in progress; no non-test source file has been edited.
+RED reproduced the asymmetric desktop shell contract: the AppShell header started at `y=0` even though the shell height already reserved 24px. The fix moves that allowance into symmetric desktop `py-3` and lets the inner shell fill the padded content box; mobile remains edge-to-edge.
+
+- Focused Safari viewport regressions: 2 passed at 1226x768 and zoom-equivalent 981x614.
+- Complete territory regression set: 12 passed serially. One parallel subway reload timed out once, then passed 4/4 in isolation and 12/12 in the serial territory run.
+- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
+- Full E2E: 35 passed serially on a clean Playwright-owned server.
+- Real-browser Map to List to Map interaction passed with current local territory data.
+- Browser bounds at 981x614: header top 12, header bottom 66.5, primary navigation top 518, navigation bottom 614, `scrollY` 0.
+- Mobile bounds at 390x844: header top 0, navigation bottom 844, `scrollY` 0.
+- Screenshot proof: `test-results/territory-shell-fit-keeps--aa8a8-below-Safari-browser-chrome-chromium/territory-shell-safari-desktop.png` and `test-results/territory-shell-fit-keeps--8d94a-lent-short-desktop-viewport-chromium/territory-shell-safari-zoom-equivalent.png`.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,43 +1,40 @@
-# Session: Issue 173 Territory Editor Minimization
+# Session: Issue 175 Safari Territory Header Clipping
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/173
-- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/174
-- Branch: `codex/173-territory-editor-minimize`
-- Design: `docs/superpowers/specs/2026-08-14-territory-editor-minimize-design.md`
-- Plan: `docs/superpowers/plans/2026-08-15-territory-editor-minimize.md`
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/175
+- Branch: `codex/175-safari-territory-header`
+- Draft PR: pending initial session commit
 
 ## Scope
 
-- Add a visible minimize control to the territory boundary editor.
-- Collapse to a one-row drawing bar above primary navigation.
-- Keep map-tap drawing active and preserve the entire unsaved draft.
-- Keep point count, Undo, and Expand usable while minimized.
-- Add mobile browser coverage for drawing, undo, and restore.
+- Keep the AppShell profile header and territory Map/List switch inside the visible viewport at the reported Safari-like desktop size.
+- Preserve the map's remaining-height layout and fixed primary navigation.
+- Add focused browser regression coverage and screenshot proof.
 
 ## Out of scope
 
-- Draggable or resizable sheets.
-- Persisting minimized state across editor sessions.
-- Territory API, geometry, persistence, or navigation changes.
+- Google Maps provider, controls, routing, or territory-data behavior.
+- API, persistence, schema, auth, environment, or production-data changes.
+- Browser preference changes or a territory-toolbar redesign.
 - Changes to `/Users/brycejohnson/Code/map-app`.
 
-## Constraints
+## Constraints and architecture check
 
-- RED-first browser test before production code.
-- Local presentation state only; do not duplicate territory draft state.
-- Start each newly opened editor expanded.
-- Preserve the fixed Finish, Clear, and Save action footer when expanded.
-- Keep the unrelated untracked `.agents/account-detail-redirect-ai-tab.png` untouched.
+- Surgical presentation fix against the existing `AppShell` and `TerritoryMobile` flex layout.
+- No new state or service boundary.
+- Keep the current mobile-first PWA shell and existing design-system spacing/control vocabulary.
+- Preserve the unrelated untracked `.agents/account-detail-redirect-ai-tab.png`.
+- Open PRs checked: #166, #144, #135, and #82. None owns the territory shell or territory E2E paths.
 
 ## Validation plan
 
-- At 390x844, minimize and verify the compact bar clears the map and bottom navigation.
-- While minimized, tap the map, observe point-count growth, Undo, and observe the count revert.
-- Expand and verify draft fields, points, drawing mode, and fixed actions are preserved.
-- Run focused territory Playwright, `npm run verify`, and full E2E.
+- RED first: reproduce the 1226x768 reported Safari-like viewport and assert the profile header, Map/List switch, map, and primary navigation all fit within the viewport.
+- Add a second short-desktop/zoom-resistant fit check if diagnosis confirms CSS-pixel scaling is involved.
+- Re-run existing mobile portrait, landscape, territory-editor, and subway-control coverage.
+- Run focused Playwright, `npm run verify`, and full `npm run test:e2e`.
+- Capture final desktop and mobile screenshots and inspect them visually.
 
 ## Current state
 
-RED failed waiting for the missing `Minimize territory editor` control. GREEN proves a real Google Map tap changes the minimized counter from 8 to 9 points, compact Undo returns it to 8, and Expand restores the full draft and drawing mode. Independent review findings were fixed with exact scroll restoration, focus transfer in both directions, and a polite live point-count status. After rebasing onto current `main`, the focused territory suite passes 6 tests; `npm run verify` passes with 202 unit tests and a production build; all 33 Playwright tests pass. Mobile proof: `test-results/territory-boundary-editor--373e4-mized-territory-drawing-bar-chromium/territory-minimized-mobile.png`. PR checks, merge, and production proof remain.
+Production Safari evidence confirms the profile header is present in the accessibility tree but visually clipped above the Map/List switch. Source diagnosis is in progress; no non-test source file has been edited.

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -74,9 +74,9 @@ export function AppShell({
   return (
     <AppAccessProvider value={access}>
       <InteractionTracker />
-      <div className="h-[100dvh] overflow-hidden bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.55),transparent_34%),linear-gradient(180deg,#d7d8dc_0%,#c9cacf_100%)] px-0 md:px-3 lg:px-5">
+      <div className="h-[100dvh] overflow-hidden bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.55),transparent_34%),linear-gradient(180deg,#d7d8dc_0%,#c9cacf_100%)] px-0 md:px-3 md:py-3 lg:px-5">
         {commandMounted ? <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} /> : null}
-        <div className="mx-auto flex h-[100dvh] max-w-[var(--app-shell-max)] flex-col overflow-hidden bg-[#e6e6e9] shadow-[0_0_0_1px_rgba(0,0,0,0.12)] md:h-[calc(100dvh-24px)] md:rounded-[28px] md:shadow-[0_20px_60px_rgba(31,35,43,0.18)]">
+        <div className="mx-auto flex h-full max-w-[var(--app-shell-max)] flex-col overflow-hidden bg-[#e6e6e9] shadow-[0_0_0_1px_rgba(0,0,0,0.12)] md:rounded-[28px] md:shadow-[0_20px_60px_rgba(31,35,43,0.18)]">
           <header className="sticky top-0 z-[3000] flex items-center justify-between gap-3 border-b border-[#d7dde7] bg-[linear-gradient(180deg,rgba(249,251,255,0.96)_0%,rgba(241,245,250,0.94)_100%)] px-3 py-2 text-[#1f232b] backdrop-blur-xl">
             <div className="flex items-center gap-2">
               <div className="rounded-2xl border border-[#d7dde7] bg-white px-3 py-2 shadow-[0_8px_24px_rgba(31,35,43,0.06)]">

--- a/tests/e2e/territory-shell-fit.spec.ts
+++ b/tests/e2e/territory-shell-fit.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function mockTerritory(page: Page) {
+  await page.route('**/api/territory/stores**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        stores: [],
+        filters: {
+          statuses: [],
+          reps: [],
+          pppStatuses: [],
+          headsetConnectionStatuses: [],
+          preferredPartners: [],
+          referralSources: [],
+          locationAvailability: [],
+          vendorDayStatuses: [],
+        },
+        meta: {
+          dataSource: 'notion-live-cache',
+          lastEditedMax: null,
+          recordsRead: 0,
+          unresolvedLocationCount: 0,
+          geocodedThisRequest: 0,
+          syncedAt: null,
+          stale: false,
+          syncing: false,
+          syncError: null,
+        },
+      }),
+    }),
+  );
+  await page.route('**/api/territory/boundaries', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ boundaries: [] }) }),
+  );
+  await page.route('**/api/territory/markers', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ markers: [] }) }),
+  );
+  await page.route('**/api/territory/saved-routes', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ routes: [] }) }),
+  );
+}
+
+test('keeps the complete territory shell below Safari browser chrome', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1226, height: 768 });
+  await mockTerritory(page);
+  await page.goto('/territory');
+
+  const appHeader = page.getByText('PiCC New York', { exact: true }).locator('xpath=ancestor::header[1]');
+  const mapTab = page.getByRole('button', { name: 'Map', exact: true });
+  const listTab = page.getByRole('button', { name: 'List', exact: true });
+  const map = page.locator('.gm-style').first();
+  const navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+
+  await expect(appHeader).toBeVisible();
+  await expect(mapTab).toBeVisible();
+  await expect(listTab).toBeVisible();
+  await expect(map).toBeVisible();
+  await expect(navigation).toBeVisible();
+
+  const [headerBox, mapTabBox, listTabBox, mapBox, navigationBox] = await Promise.all([
+    appHeader.boundingBox(),
+    mapTab.boundingBox(),
+    listTab.boundingBox(),
+    map.boundingBox(),
+    navigation.boundingBox(),
+  ]);
+
+  for (const box of [headerBox, mapTabBox, listTabBox, mapBox, navigationBox]) {
+    expect(box).not.toBeNull();
+  }
+
+  expect(headerBox!.y).toBeGreaterThanOrEqual(12);
+  expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(mapTabBox!.y);
+  expect(mapTabBox!.y).toBe(listTabBox!.y);
+  expect(mapTabBox!.y + mapTabBox!.height).toBeLessThanOrEqual(mapBox!.y);
+  expect(navigationBox!.y + navigationBox!.height).toBeLessThanOrEqual(768);
+  expect(mapBox!.y).toBeLessThan(navigationBox!.y);
+  expect(mapBox!.y + mapBox!.height).toBeGreaterThanOrEqual(navigationBox!.y);
+
+  await page.screenshot({ path: testInfo.outputPath('territory-shell-safari-desktop.png') });
+});
+
+test('keeps the territory shell visible at a zoom-equivalent short desktop viewport', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 981, height: 614 });
+  await mockTerritory(page);
+  await page.goto('/territory');
+
+  const appHeader = page.getByText('PiCC New York', { exact: true }).locator('xpath=ancestor::header[1]');
+  const mapTab = page.getByRole('button', { name: 'Map', exact: true });
+  const listTab = page.getByRole('button', { name: 'List', exact: true });
+  const navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+
+  await expect(appHeader).toBeVisible();
+  await expect(mapTab).toBeVisible();
+  await expect(listTab).toBeVisible();
+  await expect(navigation).toBeVisible();
+
+  const [headerBox, mapTabBox, navigationBox] = await Promise.all([
+    appHeader.boundingBox(),
+    mapTab.boundingBox(),
+    navigation.boundingBox(),
+  ]);
+
+  expect(headerBox).not.toBeNull();
+  expect(mapTabBox).not.toBeNull();
+  expect(navigationBox).not.toBeNull();
+  expect(headerBox!.y).toBeGreaterThanOrEqual(12);
+  expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(mapTabBox!.y);
+  expect(navigationBox!.y + navigationBox!.height).toBeLessThanOrEqual(614);
+
+  await page.screenshot({ path: testInfo.outputPath('territory-shell-safari-zoom-equivalent.png') });
+});


### PR DESCRIPTION
Closes #175

## Why

Safari with normal browser chrome could render the desktop territory shell flush against the top of the visual viewport. The shell already subtracted 24px from its height but left the entire allowance below it, making the profile header vulnerable to clipping at the top edge.

## What changed

- Converted the existing desktop-only 24px height allowance into symmetric 12px top/bottom shell padding.
- Let the inner app shell fill that padded content box.
- Added viewport-fit browser tests for the reported 1226x768 size and a 981x614 zoom-equivalent short desktop size.
- Preserved the edge-to-edge mobile shell.

## What did not change

- No Google Maps behavior, territory data, APIs, schema, auth, environment, or production data.
- No toolbar, navigation, or territory-editor redesign.
- No Map-APP changes.

## Owned paths and overlap

- `components/layout/app-shell.tsx`
- `tests/e2e/territory-shell-fit.spec.ts`
- `SESSION.md`

Checked open PRs #166, #144, #135, and #82. None owns these runtime/test paths.

## Validation

- RED: desktop AppShell header bounding box began at `y=0`, failing the intended 12px desktop top clearance.
- Focused Safari viewport tests: 2 passed.
- Territory regression set: 12 passed serially.
- `npm run verify`: lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build passed.
- Full Playwright suite: 35 passed serially on a clean server.
- Real-browser Map to List to Map interaction passed.
- 981x614 bounds: header top 12, navigation bottom 614, `scrollY=0`.
- 390x844 bounds: mobile header top 0, navigation bottom 844, `scrollY=0`.

## Browser proof

Local screenshots were reviewed for the reported desktop, zoom-equivalent desktop, and mobile viewports. They are intentionally not uploaded to this public repository because workspace policy keeps private PICC UI screenshots off public GitHub.

## Risk and rollback

Low-risk presentation-only change. Reverting commit `0ca66d7` restores the prior shell geometry.