### PR TITLE
Fix Safari compositing the app header under browser chrome

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -3,8 +3,8 @@
 ## Linked work
 
 - GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/175
-- Branch: `codex/175-safari-territory-header`
-- Draft PR: https://github.com/brycejohnson1417/Picc-web-app/pull/176
+- Branch: `codex/175-safari-retained-scroll`
+- First PR: https://github.com/brycejohnson1417/Picc-web-app/pull/176 (merged; live Safari proof exposed a remaining sticky-header issue)
 
 ## Scope
 
@@ -38,6 +38,15 @@
 ## Current state
 
 RED reproduced the asymmetric desktop shell contract: the AppShell header started at `y=0` even though the shell height already reserved 24px. The fix moves that allowance into symmetric desktop `py-3` and lets the inner shell fill the padded content box; mobile remains edge-to-edge.
+
+Production Safari verification after PR #176 showed that WebKit still composited the AppShell's sticky frame header underneath browser chrome while leaving its space in the document flow. Follow-up RED coverage now requires the frame header to remain non-sticky because `main` already owns page scrolling.
+
+Follow-up validation:
+
+- RED: both focused regressions rejected the AppShell header's computed `position: sticky`.
+- GREEN: both Safari-sized viewport regressions pass with the frame header in normal flow.
+- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
+- Full E2E: 35 passed serially.
 
 - Focused Safari viewport regressions: 2 passed at 1226x768 and zoom-equivalent 981x614.
 - Complete territory regression set: 12 passed serially. One parallel subway reload timed out once, then passed 4/4 in isolation and 12/12 in the serial territory run.

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -77,7 +77,7 @@ export function AppShell({
       <div className="h-[100dvh] overflow-hidden bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.55),transparent_34%),linear-gradient(180deg,#d7d8dc_0%,#c9cacf_100%)] px-0 md:px-3 md:py-3 lg:px-5">
         {commandMounted ? <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} /> : null}
         <div className="mx-auto flex h-full max-w-[var(--app-shell-max)] flex-col overflow-hidden bg-[#e6e6e9] shadow-[0_0_0_1px_rgba(0,0,0,0.12)] md:rounded-[28px] md:shadow-[0_20px_60px_rgba(31,35,43,0.18)]">
-          <header className="sticky top-0 z-[3000] flex items-center justify-between gap-3 border-b border-[#d7dde7] bg-[linear-gradient(180deg,rgba(249,251,255,0.96)_0%,rgba(241,245,250,0.94)_100%)] px-3 py-2 text-[#1f232b] backdrop-blur-xl">
+          <header className="z-[3000] flex items-center justify-between gap-3 border-b border-[#d7dde7] bg-[linear-gradient(180deg,rgba(249,251,255,0.96)_0%,rgba(241,245,250,0.94)_100%)] px-3 py-2 text-[#1f232b] backdrop-blur-xl">
             <div className="flex items-center gap-2">
               <div className="rounded-2xl border border-[#d7dde7] bg-white px-3 py-2 shadow-[0_8px_24px_rgba(31,35,43,0.06)]">
                 <p className="text-[13px] font-semibold tracking-[0.01em] text-[#18212d]">PiCC New York</p>

--- a/tests/e2e/territory-shell-fit.spec.ts
+++ b/tests/e2e/territory-shell-fit.spec.ts
@@ -59,6 +59,12 @@ test('keeps the complete territory shell below Safari browser chrome', async ({ 
   await expect(map).toBeVisible();
   await expect(navigation).toBeVisible();
 
+  // Safari can pin a nested sticky header to the browser window rather than the
+  // app's clipped viewport, placing it underneath the tab/favorites chrome.
+  // The shell already owns scrolling in <main>, so its frame header must stay
+  // in normal flow.
+  await expect(appHeader).toHaveCSS('position', 'static');
+
   const [headerBox, mapTabBox, listTabBox, mapBox, navigationBox] = await Promise.all([
     appHeader.boundingBox(),
     mapTab.boundingBox(),
@@ -96,6 +102,7 @@ test('keeps the territory shell visible at a zoom-equivalent short desktop viewp
   await expect(mapTab).toBeVisible();
   await expect(listTab).toBeVisible();
   await expect(navigation).toBeVisible();
+  await expect(appHeader).toHaveCSS('position', 'static');
 
   const [headerBox, mapTabBox, navigationBox] = await Promise.all([
     appHeader.boundingBox(),


### PR DESCRIPTION
Closes #175

## Why

PR #176 added symmetric viewport spacing, but verification in the user's signed-in production Safari window exposed a WebKit-specific remaining failure: the AppShell's sticky frame header was composited underneath Safari's tab/favorites chrome while its layout space remained reserved.

## What changed

- Keep the AppShell profile header in normal flex flow instead of making it sticky.
- Retain the existing internal scrolling boundary on `<main>`.
- Extend the Safari-sized desktop regressions to require the frame header to be non-sticky.
- Preserve all territory map controls, mobile behavior, and fixed bottom navigation.

## What did not change

- No API, data, schema, auth, provider, or production-state changes.
- No Google Maps or territory workflow changes.
- No changes to `map-app`.

## Validation

- RED: focused tests failed on computed `position: sticky`.
- GREEN: 2 focused Safari-sized viewport tests passed.
- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
- Full Playwright E2E: 35/35 passed serially.
- Production Safari verification will be repeated after deployment.

## Risk

Low and narrowly scoped. The AppShell header no longer follows the browser viewport, but page scrolling already happens inside `<main>`, so the frame header remains visible while avoiding Safari's sticky compositing bug.