### PR TITLE
Fix contacts directory dark-surface regression

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -34,4 +34,13 @@
 
 ## Current state
 
-Issue claimed; implementation has not started.
+Implemented the light operational surface in the shared CRM data table. Explicit stale dark-mode row, header, hover, and mobile-card utilities were removed; the table now owns white/light-slate backgrounds and dark readable text under either device preference. Mobile Contacts actions now show the Email, Text, and Call labels instead of icons alone.
+
+Validation:
+
+- RED browser proof: the header rendered `oklch(0.208 0.042 265.755)` from `dark:bg-slate-900` under a dark device preference.
+- GREEN focused appearance regression: passed desktop and mobile under an emulated dark device preference.
+- Complete Contacts browser suite: 7 passed serially.
+- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
+- Full browser suite: 34 passed serially; two unrelated territory tests could not create `.gm-style` because Google Maps did not load in this local environment. The Contacts suite and all non-map coverage passed.
+- Visual proof inspected with three isolated local contact records, then the local fixture was removed: `contacts-light-surface-desktop.png` and `contacts-light-surface-mobile.png`.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,58 +1,37 @@
-# Session: Issue 175 Safari Territory Header Clipping
+# Session: Issue 178 Contacts Light Surfaces
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/175
-- Branch: `codex/175-safari-retained-scroll`
-- First PR: https://github.com/brycejohnson1417/Picc-web-app/pull/176 (merged; live Safari proof exposed a remaining sticky-header issue)
+- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/178
+- Branch: `codex/178-contacts-light-surfaces`
 
 ## Scope
 
-- Keep the AppShell profile header and territory Map/List switch inside the visible viewport at the reported Safari-like desktop size.
-- Preserve the map's remaining-height layout and fixed primary navigation.
-- Add focused browser regression coverage and screenshot proof.
+- Keep Contacts directory records, table headers, and mobile cards on light operational surfaces even when the device prefers dark appearance.
+- Preserve immediate visibility of contact name, account, email, phone, status, and email/text/call actions.
+- Correct the same shared CRM table contradiction for Accounts so both directories follow the app design system.
+- Add browser regression coverage for dark device preferences.
 
 ## Out of scope
 
-- Google Maps provider, controls, routing, or territory-data behavior.
-- API, persistence, schema, auth, environment, or production-data changes.
-- Browser preference changes or a territory-toolbar redesign.
-- Changes to `/Users/brycejohnson/Code/map-app`.
+- Contact records, Gmail behavior, follow-up logic, schema, auth, provider configuration, or production data.
+- Contact profile and Account Details redesigns.
+- Changes to `/Users/brycejohnson/Code/map-app`; reusable Trap Map product ideas will be reported separately.
 
 ## Constraints and architecture check
 
-- Surgical presentation fix against the existing `AppShell` and `TerritoryMobile` flex layout.
-- No new state or service boundary.
-- Keep the current mobile-first PWA shell and existing design-system spacing/control vocabulary.
-- Preserve the unrelated untracked `.agents/account-detail-redirect-ai-tab.png`.
-- Open PRs checked: #166, #144, #135, and #82. None owns the territory shell or territory E2E paths.
+- Surgical presentation fix in the existing shared `AdvancedDataTable`; no new state or service boundary.
+- Follow `DESIGN-SYSTEM.md`: compact white/slate operational surfaces, clear status, and first-viewport actions.
+- No new dependencies.
+- Open PRs checked: #166, #144, #135, and #82. None actively owns the runtime paths in this issue; #144 is a stale broad architecture proposal that conflicts with the current canonical app direction.
 
 ## Validation plan
 
-- RED first: reproduce the 1226x768 reported Safari-like viewport and assert the profile header, Map/List switch, map, and primary navigation all fit within the viewport.
-- Add a second short-desktop/zoom-resistant fit check if diagnosis confirms CSS-pixel scaling is involved.
-- Re-run existing mobile portrait, landscape, territory-editor, and subway-control coverage.
-- Run focused Playwright, `npm run verify`, and full `npm run test:e2e`.
-- Capture final desktop and mobile screenshots and inspect them visually.
+- RED first: emulate a dark device preference in the Contacts browser flow and assert the rendered row/card/header backgrounds stay light with dark readable text.
+- Verify email, text, and call actions remain visible and interactive.
+- Run focused Playwright coverage, `npm run verify`, and full `npm run test:e2e`.
+- Capture mobile and desktop screenshot proof and inspect it visually.
 
 ## Current state
 
-RED reproduced the asymmetric desktop shell contract: the AppShell header started at `y=0` even though the shell height already reserved 24px. The fix moves that allowance into symmetric desktop `py-3` and lets the inner shell fill the padded content box; mobile remains edge-to-edge.
-
-Production Safari verification after PR #176 showed that WebKit still composited the AppShell's sticky frame header underneath browser chrome while leaving its space in the document flow. Follow-up RED coverage now requires the frame header to remain non-sticky because `main` already owns page scrolling.
-
-Follow-up validation:
-
-- RED: both focused regressions rejected the AppShell header's computed `position: sticky`.
-- GREEN: both Safari-sized viewport regressions pass with the frame header in normal flow.
-- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
-- Full E2E: 35 passed serially.
-
-- Focused Safari viewport regressions: 2 passed at 1226x768 and zoom-equivalent 981x614.
-- Complete territory regression set: 12 passed serially. One parallel subway reload timed out once, then passed 4/4 in isolation and 12/12 in the serial territory run.
-- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
-- Full E2E: 35 passed serially on a clean Playwright-owned server.
-- Real-browser Map to List to Map interaction passed with current local territory data.
-- Browser bounds at 981x614: header top 12, header bottom 66.5, primary navigation top 518, navigation bottom 614, `scrollY` 0.
-- Mobile bounds at 390x844: header top 0, navigation bottom 844, `scrollY` 0.
-- Screenshot proof: `test-results/territory-shell-fit-keeps--aa8a8-below-Safari-browser-chrome-chromium/territory-shell-safari-desktop.png` and `test-results/territory-shell-fit-keeps--8d94a-lent-short-desktop-viewport-chromium/territory-shell-safari-zoom-equivalent.png`.
+Issue claimed; implementation has not started.

--- a/components/crm/advanced-data-table.tsx
+++ b/components/crm/advanced-data-table.tsx
@@ -82,7 +82,7 @@ export function AdvancedDataTable<TData, TValue>({
             className="h-11 min-w-0 flex-1 border-[#cbd3df] bg-white text-[#18212d] placeholder:text-[#929baa] sm:max-w-[360px] dark:bg-white dark:text-[#18212d] dark:placeholder:text-[#929baa]"
           />
           {onExportCsv ? (
-            <Button variant="outline" className="h-11 min-w-[44px] shrink-0" onClick={onExportCsv} aria-label="Export CSV">
+            <Button variant="outline" className="h-11 min-w-[44px] shrink-0 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa]" onClick={onExportCsv} aria-label="Export CSV">
               <Download className="h-4 w-4" />
               <span className="hidden sm:inline">Export</span>
             </Button>
@@ -94,21 +94,21 @@ export function AdvancedDataTable<TData, TValue>({
         <div className="flex flex-col gap-2 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 sm:flex-row sm:items-center sm:justify-between">
           <span>{selectedCount} selected</span>
           <div className="flex gap-2">
-            <Button size="sm" variant="secondary" className="min-h-11">Tag</Button>
-            <Button size="sm" variant="secondary" className="min-h-11">Assign</Button>
+            <Button size="sm" variant="secondary" className="min-h-11 bg-white text-[#263242] hover:bg-[#edf2f7]">Tag</Button>
+            <Button size="sm" variant="secondary" className="min-h-11 bg-white text-[#263242] hover:bg-[#edf2f7]">Assign</Button>
             <Button size="sm" variant="danger" className="min-h-11">Delete</Button>
           </div>
         </div>
       )}
 
-      <div className="space-y-2 md:hidden">
+      <div className="space-y-2 text-[#18212d] md:hidden" data-testid="crm-directory-mobile">
         {table.getRowModel().rows?.length ? (
           table.getRowModel().rows.map((row) => {
             const rowHref = getRowHref?.(row.original);
             return (
               <article
                 key={row.id}
-                className={`space-y-2 rounded-xl border bg-white p-3 dark:bg-slate-950 ${rowHref ? 'cursor-pointer active:bg-slate-50 dark:active:bg-slate-900' : ''}`}
+                className={`space-y-2 rounded-xl border border-[#d8dee8] bg-white p-3 text-[#18212d] shadow-[0_1px_2px_rgba(24,33,45,0.04)] ${rowHref ? 'cursor-pointer transition-colors hover:bg-[#f8fafc] active:bg-[#eef3f8]' : ''}`}
                 role={rowHref ? 'link' : undefined}
                 tabIndex={rowHref ? 0 : undefined}
                 aria-label={rowHref ? rowAriaLabel?.(row.original) : undefined}
@@ -140,18 +140,18 @@ export function AdvancedDataTable<TData, TValue>({
             );
           })
         ) : (
-          <div className="rounded-xl border p-6 text-center text-slate-500">No results.</div>
+          <div className="rounded-xl border border-[#d8dee8] bg-white p-6 text-center text-[#697486]">No results.</div>
         )}
       </div>
 
-      <div className="hidden overflow-hidden rounded-xl border md:block">
-        <div className="max-h-[560px] overflow-auto">
+      <div className="hidden overflow-hidden rounded-xl border border-[#d8dee8] bg-white text-[#18212d] shadow-[0_1px_2px_rgba(24,33,45,0.04)] md:block" data-testid="crm-directory-desktop">
+        <div className="max-h-[560px] overflow-auto bg-white">
           <table className="w-full text-sm">
-            <thead className="sticky top-0 z-10 bg-slate-100 dark:bg-slate-900">
+            <thead className="sticky top-0 z-10 bg-[#f1f5f9] text-[#344052]">
               {table.getHeaderGroups().map((headerGroup) => (
                 <tr key={headerGroup.id}>
                   {headerGroup.headers.map((header) => (
-                    <th key={header.id} className="whitespace-nowrap border-b px-3 py-2 text-left font-semibold">
+                    <th key={header.id} className="whitespace-nowrap border-b border-[#d8dee8] px-3 py-2.5 text-left font-semibold">
                       {header.isPlaceholder
                         ? null
                         : flexRender(header.column.columnDef.header, header.getContext())}
@@ -169,8 +169,8 @@ export function AdvancedDataTable<TData, TValue>({
                       key={row.id}
                       data-state={row.getIsSelected() && 'selected'}
                       className={[
-                        idx % 2 === 0 ? 'bg-white dark:bg-slate-950' : 'bg-slate-50/50 dark:bg-slate-900/30',
-                        rowHref ? 'cursor-pointer hover:bg-slate-100/80 dark:hover:bg-slate-800/70' : '',
+                        idx % 2 === 0 ? 'bg-white' : 'bg-[#f8fafc]',
+                        rowHref ? 'cursor-pointer transition-colors hover:bg-[#eef3f8]' : '',
                       ].join(' ')}
                       role={rowHref ? 'link' : undefined}
                       tabIndex={rowHref ? 0 : undefined}
@@ -188,7 +188,7 @@ export function AdvancedDataTable<TData, TValue>({
                       }
                     >
                       {row.getVisibleCells().map((cell) => (
-                        <td key={cell.id} className="border-b px-3 py-2 align-top">
+                        <td key={cell.id} className="border-b border-[#e2e7ee] px-3 py-2.5 align-top">
                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </td>
                       ))}
@@ -212,10 +212,10 @@ export function AdvancedDataTable<TData, TValue>({
           Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount() || 1}
         </p>
         <div className="grid grid-cols-2 gap-2">
-          <Button variant="outline" size="sm" className="min-h-11" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          <Button variant="outline" size="sm" className="min-h-11 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa]" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
             Previous
           </Button>
-          <Button variant="outline" size="sm" className="min-h-11" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          <Button variant="outline" size="sm" className="min-h-11 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa]" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
             Next
           </Button>
         </div>

--- a/components/crm/advanced-data-table.tsx
+++ b/components/crm/advanced-data-table.tsx
@@ -82,7 +82,7 @@ export function AdvancedDataTable<TData, TValue>({
             className="h-11 min-w-0 flex-1 border-[#cbd3df] bg-white text-[#18212d] placeholder:text-[#929baa] sm:max-w-[360px] dark:bg-white dark:text-[#18212d] dark:placeholder:text-[#929baa]"
           />
           {onExportCsv ? (
-            <Button variant="outline" className="h-11 min-w-[44px] shrink-0 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa]" onClick={onExportCsv} aria-label="Export CSV">
+            <Button variant="outline" className="h-11 min-w-[44px] shrink-0 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa] dark:border-[#cbd3df] dark:bg-white dark:text-[#263242] dark:hover:bg-[#f3f6fa]" onClick={onExportCsv} aria-label="Export CSV">
               <Download className="h-4 w-4" />
               <span className="hidden sm:inline">Export</span>
             </Button>
@@ -94,8 +94,8 @@ export function AdvancedDataTable<TData, TValue>({
         <div className="flex flex-col gap-2 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 sm:flex-row sm:items-center sm:justify-between">
           <span>{selectedCount} selected</span>
           <div className="flex gap-2">
-            <Button size="sm" variant="secondary" className="min-h-11 bg-white text-[#263242] hover:bg-[#edf2f7]">Tag</Button>
-            <Button size="sm" variant="secondary" className="min-h-11 bg-white text-[#263242] hover:bg-[#edf2f7]">Assign</Button>
+            <Button size="sm" variant="secondary" className="min-h-11 bg-white text-[#263242] hover:bg-[#edf2f7] dark:bg-white dark:text-[#263242] dark:hover:bg-[#edf2f7]">Tag</Button>
+            <Button size="sm" variant="secondary" className="min-h-11 bg-white text-[#263242] hover:bg-[#edf2f7] dark:bg-white dark:text-[#263242] dark:hover:bg-[#edf2f7]">Assign</Button>
             <Button size="sm" variant="danger" className="min-h-11">Delete</Button>
           </div>
         </div>
@@ -212,10 +212,10 @@ export function AdvancedDataTable<TData, TValue>({
           Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount() || 1}
         </p>
         <div className="grid grid-cols-2 gap-2">
-          <Button variant="outline" size="sm" className="min-h-11 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa]" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          <Button variant="outline" size="sm" className="min-h-11 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa] dark:border-[#cbd3df] dark:bg-white dark:text-[#263242] dark:hover:bg-[#f3f6fa]" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
             Previous
           </Button>
-          <Button variant="outline" size="sm" className="min-h-11 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa]" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          <Button variant="outline" size="sm" className="min-h-11 border-[#cbd3df] bg-white text-[#263242] hover:bg-[#f3f6fa] dark:border-[#cbd3df] dark:bg-white dark:text-[#263242] dark:hover:bg-[#f3f6fa]" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
             Next
           </Button>
         </div>

--- a/components/crm/contacts-table.tsx
+++ b/components/crm/contacts-table.tsx
@@ -93,7 +93,7 @@ export function ContactsTable({ rows, accounts }: { rows: ContactTableRow[]; acc
             <p className="break-all">{row.email}</p>
             <p>{row.phone}</p>
           </div>
-          <ContactQuickActions contact={row} accounts={accountsFor(row)} className="pt-1" />
+          <ContactQuickActions contact={row} accounts={accountsFor(row)} className="pt-1" labels="always" />
         </>
       )}
     />

--- a/tests/e2e/contact-workspace.spec.ts
+++ b/tests/e2e/contact-workspace.spec.ts
@@ -278,6 +278,34 @@ test('reviews Gmail suggestions before quick-adding a prefilled contact', async 
   await expect(dialog.getByLabel('Email')).toHaveValue('taylor@example.com');
 });
 
+test('keeps the contacts directory light and readable under dark device preferences', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await page.goto('/contacts');
+
+  const table = page.getByRole('table');
+  const header = table.locator('thead');
+  const desktopSurface = page.getByTestId('crm-directory-desktop');
+
+  await expect(table).toBeVisible();
+  await expect(desktopSurface).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await expect(desktopSurface).toHaveCSS('color', 'rgb(24, 33, 45)');
+  await expect(header).toHaveCSS('background-color', 'rgb(241, 245, 249)');
+  if (process.env.PICC_EVIDENCE_DIR) {
+    await page.screenshot({ path: `${process.env.PICC_EVIDENCE_DIR}/contacts-light-surface-desktop.png`, fullPage: true });
+  }
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileSurface = page.getByTestId('crm-directory-mobile');
+  const mobileRecordSurface = mobileSurface.locator(':scope > *').first();
+  await expect(mobileSurface).toHaveCSS('color', 'rgb(24, 33, 45)');
+  await expect(mobileRecordSurface).toBeVisible();
+  await expect(mobileRecordSurface).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  if (process.env.PICC_EVIDENCE_DIR) {
+    await page.screenshot({ path: `${process.env.PICC_EVIDENCE_DIR}/contacts-light-surface-mobile.png`, fullPage: true });
+  }
+});
+
 test('lets the signed-in rep inspect and explicitly disconnect their Gmail', async ({ page }) => {
   let connected = true;
   await page.route('**/api/integrations/gmail', async (route) => {

--- a/tests/e2e/contact-workspace.spec.ts
+++ b/tests/e2e/contact-workspace.spec.ts
@@ -291,6 +291,11 @@ test('keeps the contacts directory light and readable under dark device preferen
   await expect(desktopSurface).toHaveCSS('background-color', 'rgb(255, 255, 255)');
   await expect(desktopSurface).toHaveCSS('color', 'rgb(24, 33, 45)');
   await expect(header).toHaveCSS('background-color', 'rgb(241, 245, 249)');
+  const nextPageButton = page.getByRole('button', { name: 'Next', exact: true });
+  await expect(nextPageButton).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await nextPageButton.evaluate((button) => button.removeAttribute('disabled'));
+  await nextPageButton.hover();
+  await expect(nextPageButton).toHaveCSS('background-color', 'rgb(243, 246, 250)');
   if (process.env.PICC_EVIDENCE_DIR) {
     await page.screenshot({ path: `${process.env.PICC_EVIDENCE_DIR}/contacts-light-surface-desktop.png`, fullPage: true });
   }


### PR DESCRIPTION
## Why
Closes #178. The shared CRM table still applies explicit dark-mode backgrounds even though the PICC operational design system is intentionally light, causing Contacts to render with near-black headers and rows on dark-preference devices.

## Scope
- Shared CRM directory surface styling
- Contacts scanability and action contrast
- Browser regression coverage for dark device preferences

## Out of scope
- Contact data, Gmail, follow-up logic, schema, auth, provider settings, and production data
- Contact profile or Account Details redesigns
- Trap Map code

## Test plan
- RED browser assertion under emulated dark appearance
- Focused Contacts Playwright flow
- `npm run verify`
- Full `npm run test:e2e`
- Mobile and desktop screenshot inspection

## Architecture check
Surgical fix in the existing shared `AdvancedDataTable`; no new state, dependency, service, API, or data boundary.

## Ownership
Owned paths: `components/crm/advanced-data-table.tsx`, `components/crm/contacts-table.tsx` if needed, `tests/e2e/contact-workspace.spec.ts`, `SESSION.md`. Checked open PRs #166, #144, #135, and #82; none actively owns these runtime paths.