### PR TITLE
fix: allow authenticated daily briefing scheduler through middleware

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,46 +1,36 @@
-# Session: Issue 178 Contacts Light Surfaces
+# Session: Daily Briefing Cron Middleware Fix
 
 ## Linked work
 
-- GitHub issue: https://github.com/brycejohnson1417/Picc-web-app/issues/178
-- Branch: `codex/178-contacts-light-surfaces`
+- GitHub issue: intentionally skipped by explicit user direction after the public issue safety gate blocked incident-detail disclosure.
+- Branch: `codex/daily-briefing-middleware`
+- Production evidence: GitHub Actions run #36 exited with curl code 22; Vercel runtime logs returned `404` from edge middleware for `/api/cron/daily-briefing`.
 
 ## Scope
 
-- Keep Contacts directory records, table headers, and mobile cards on light operational surfaces even when the device prefers dark appearance.
-- Preserve immediate visibility of contact name, account, email, phone, status, and email/text/call actions.
-- Correct the same shared CRM table contradiction for Accounts so both directories follow the app design system.
-- Add browser regression coverage for dark device preferences.
+- Allow `/api/cron/daily-briefing` through the existing machine-to-machine cron middleware boundary.
+- Preserve the route's fail-closed `CRON_SECRET` bearer authorization.
+- Add focused regression coverage that fails on current `main` and passes with the fix.
 
 ## Out of scope
 
-- Contact records, Gmail behavior, follow-up logic, schema, auth, provider configuration, or production data.
-- Contact profile and Account Details redesigns.
-- Changes to `/Users/brycejohnson/Code/map-app`; reusable Trap Map product ideas will be reported separately.
+- Clerk provider, user-role, browser-session, or interactive sign-in changes.
+- Secret values, Vercel environment changes, SendGrid configuration, or production data writes.
+- Briefing ranking, timing, recipients, email content, schema, or database migrations.
+- Changes to `/Users/brycejohnson/Code/map-app`.
 
 ## Constraints and architecture check
 
-- Surgical presentation fix in the existing shared `AdvancedDataTable`; no new state or service boundary.
-- Follow `DESIGN-SYSTEM.md`: compact white/slate operational surfaces, clear status, and first-viewport actions.
-- No new dependencies.
-- Open PRs checked: #166, #144, #135, and #82. None actively owns the runtime paths in this issue; #144 is a stale broad architecture proposal that conflicts with the current canonical app direction.
+- Surgical route-classification change in the existing middleware; no new auth abstraction.
+- The middleware may bypass Clerk only for the exact cron route. The route handler remains responsible for bearer-secret authorization.
+- Authentication-boundary change is approval-lane work and must not merge without the required PR approval comment and user reply.
+- Owned paths: `middleware.ts`, focused middleware test, `SESSION.md`.
+- Open PRs checked: #166, #144, #135, and #82. None owns middleware or daily-briefing cron paths.
 
 ## Validation plan
 
-- RED first: emulate a dark device preference in the Contacts browser flow and assert the rendered row/card/header backgrounds stay light with dark readable text.
-- Verify email, text, and call actions remain visible and interactive.
-- Run focused Playwright coverage, `npm run verify`, and full `npm run test:e2e`.
-- Capture mobile and desktop screenshot proof and inspect it visually.
-
-## Current state
-
-Implemented the light operational surface in the shared CRM data table. Explicit stale dark-mode row, header, hover, and mobile-card utilities were removed; the table now owns white/light-slate backgrounds and dark readable text under either device preference. Mobile Contacts actions now show the Email, Text, and Call labels instead of icons alone.
-
-Validation:
-
-- RED browser proof: the header rendered `oklch(0.208 0.042 265.755)` from `dark:bg-slate-900` under a dark device preference.
-- GREEN focused appearance regression: passed desktop and mobile under an emulated dark device preference.
-- Complete Contacts browser suite: 7 passed serially.
-- `npm run verify`: passed lint, typecheck, 46 Vitest files / 202 tests, Prisma validation, and production build.
-- Full browser suite: 34 passed serially; two unrelated territory tests could not create `.gm-style` because Google Maps did not load in this local environment. The Contacts suite and all non-map coverage passed.
-- Visual proof inspected with three isolated local contact records, then the local fixture was removed: `contacts-light-surface-desktop.png` and `contacts-light-surface-mobile.png`.
+- RED: prove `/api/cron/daily-briefing` is currently passed to Clerk protection instead of reaching the route.
+- GREEN: add the exact route to the existing cron exemption and rerun the focused test.
+- Re-run cron authorization tests to confirm missing and incorrect secrets still fail closed.
+- Run `npm run verify`.
+- After an approved merge/deploy, verify a production scheduler invocation before claiming the incident resolved.

--- a/SESSION.md
+++ b/SESSION.md
@@ -34,3 +34,10 @@
 - Re-run cron authorization tests to confirm missing and incorrect secrets still fail closed.
 - Run `npm run verify`.
 - After an approved merge/deploy, verify a production scheduler invocation before claiming the incident resolved.
+
+## Current state
+
+- RED: the focused middleware regression observed `auth.protect()` called once for `/api/cron/daily-briefing` on the pre-fix implementation.
+- GREEN: the daily-briefing path now shares the existing exact cron-route exemption; focused middleware and cron-secret coverage pass (2 files, 5 tests).
+- `npm run verify`: passed lint, typecheck, 47 Vitest files / 203 tests, Prisma validation, and the production build.
+- Production remains unchanged pending approval-lane merge and deployment verification.

--- a/lib/auth/middleware.test.ts
+++ b/lib/auth/middleware.test.ts
@@ -1,0 +1,40 @@
+import { NextRequest, type NextFetchEvent } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { protect } = vi.hoisted(() => ({ protect: vi.fn() }));
+
+vi.mock('@clerk/nextjs/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@clerk/nextjs/server')>();
+
+  return {
+    ...actual,
+    clerkMiddleware:
+      (handler: (auth: { protect: typeof protect }, request: NextRequest) => Promise<void>) =>
+      async (request: NextRequest) =>
+        handler({ protect }, request),
+  };
+});
+
+describe('middleware cron route boundary', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_live_test');
+    vi.stubEnv('CLERK_SECRET_KEY', 'sk_live_test');
+    vi.stubEnv('NODE_ENV', 'production');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('lets the daily briefing scheduler reach its bearer-authorized route without a Clerk session', async () => {
+    const { default: middleware } = await import('../../middleware');
+
+    await middleware(
+      new NextRequest('https://piccnewyork.org/api/cron/daily-briefing'),
+      {} as NextFetchEvent,
+    );
+
+    expect(protect).not.toHaveBeenCalled();
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,7 +14,7 @@ const isProtectedRoute = createRouteMatcher([
   '/api/(.*)',
 ]);
 const isApiRoute = createRouteMatcher(['/api/(.*)']);
-const isCronSyncRoute = createRouteMatcher(['/api/cron/notion-sync', '/api/cron/nabis-sync']);
+const isCronSyncRoute = createRouteMatcher(['/api/cron/notion-sync', '/api/cron/nabis-sync', '/api/cron/daily-briefing']);
 const isPublicWebhookRoute = createRouteMatcher(['/api/webhooks/notion']);
 const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
 const secretKey = process.env.CLERK_SECRET_KEY ?? '';


### PR DESCRIPTION
## Why

The daily briefing scheduler cannot reach its route because the machine-triggered request is intercepted by the browser-session middleware boundary.

Issue creation was intentionally skipped at the user's explicit direction after the public incident-detail issue was blocked by the safety gate.

## What changed

- Added the exact `/api/cron/daily-briefing` path to the existing machine-triggered cron middleware exemption.
- Added a focused middleware regression test proving Clerk protection is not invoked for that route.
- Preserved the route's independent fail-closed bearer-secret authorization.

## What did not change

- No Clerk provider, user-role, or interactive sign-in behavior.
- No schema, production-data, secret-value, email-provider, briefing-content, or scheduling behavior.
- Existing Notion and Nabis cron exemptions are unchanged.

## Owned paths and overlap

- `middleware.ts`
- `lib/auth/middleware.test.ts`
- `SESSION.md`

Open PRs #166, #144, #135, and #82 were checked; none owns these paths.

## Validation

- RED: focused regression failed because `auth.protect()` was called once for `/api/cron/daily-briefing` on the pre-fix implementation.
- GREEN: focused middleware plus cron-secret tests pass — 2 files, 5 tests.
- `npm run verify` passes:
  - ESLint
  - TypeScript
  - Vitest: 47 files, 203 tests
  - Prisma schema validation
  - Next.js production build, including `/api/cron/daily-briefing`

## Architecture and remaining risk

This is a narrow authentication-boundary classification change. The route remains fail-closed behind its bearer-secret check. Production is unchanged until merge/deploy. After deployment, the scheduler still needs a live run and production-log readback before the incident can be considered resolved.

Because this changes an auth boundary, this PR remains in the approval lane and will not merge without the required explicit approval reply.