### PR TITLE
chore: disable scheduled daily briefing

### DIFF
--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -1,8 +1,6 @@
 name: daily-briefing
 
 on:
-  schedule:
-    - cron: '7 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #183

## Why
The `daily-briefing` workflow has failed on every scheduled run and is generating repeated GitHub failure emails.

## What changed
- Removed the hourly `schedule` trigger.
- Kept `workflow_dispatch` so the job can only be run manually if it is intentionally investigated later.

## What did not change
- No application code, production data, auth, secrets, email-provider configuration, or other workflow was changed.

## Validation
- `git diff --check`
- Confirmed exactly one `workflow_dispatch` trigger remains.
- Confirmed no `schedule` or `cron` entry remains.

## Production proof
After merge, read back `.github/workflows/daily-briefing.yml` from `main` and verify scheduled triggers are absent.

## Remaining risk
A user can still manually dispatch the workflow, but GitHub cannot schedule it automatically.