### PR TITLE
fix: refresh shared partner pricing catalog

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,43 +1,10 @@
-# Session: Daily Briefing Cron Middleware Fix
+# Pricing catalog correction
 
-## Linked work
+Issue: https://github.com/brycejohnson1417/Picc-web-app/issues/185
+Branch: codex/185-refresh-pricing
 
-- GitHub issue: intentionally skipped by explicit user direction after the public issue safety gate blocked incident-detail disclosure.
-- Branch: `codex/daily-briefing-middleware`
-- Production evidence: GitHub Actions run #36 exited with curl code 22; Vercel runtime logs returned `404` from edge middleware for `/api/cron/daily-briefing`.
-
-## Scope
-
-- Allow `/api/cron/daily-briefing` through the existing machine-to-machine cron middleware boundary.
-- Preserve the route's fail-closed `CRON_SECRET` bearer authorization.
-- Add focused regression coverage that fails on current `main` and passes with the fix.
-
-## Out of scope
-
-- Clerk provider, user-role, browser-session, or interactive sign-in changes.
-- Secret values, Vercel environment changes, SendGrid configuration, or production data writes.
-- Briefing ranking, timing, recipients, email content, schema, or database migrations.
-- Changes to `/Users/brycejohnson/Code/map-app`.
-
-## Constraints and architecture check
-
-- Surgical route-classification change in the existing middleware; no new auth abstraction.
-- The middleware may bypass Clerk only for the exact cron route. The route handler remains responsible for bearer-secret authorization.
-- Authentication-boundary change is approval-lane work and must not merge without the required PR approval comment and user reply.
-- Owned paths: `middleware.ts`, focused middleware test, `SESSION.md`.
-- Open PRs checked: #166, #144, #135, and #82. None owns middleware or daily-briefing cron paths.
-
-## Validation plan
-
-- RED: prove `/api/cron/daily-briefing` is currently passed to Clerk protection instead of reaching the route.
-- GREEN: add the exact route to the existing cron exemption and rerun the focused test.
-- Re-run cron authorization tests to confirm missing and incorrect secrets still fail closed.
-- Run `npm run verify`.
-- After an approved merge/deploy, verify a production scheduler invocation before claiming the incident resolved.
-
-## Current state
-
-- RED: the focused middleware regression observed `auth.protect()` called once for `/api/cron/daily-briefing` on the pre-fix implementation.
-- GREEN: the daily-briefing path now shares the existing exact cron-route exemption; focused middleware and cron-secret coverage pass (2 files, 5 tests).
-- `npm run verify`: passed lint, typecheck, 47 Vitest files / 203 tests, Prisma validation, and the production build.
-- Production remains unchanged pending approval-lane merge and deployment verification.
+Scope: refresh three superseded catalog entries and regression-test the shared pricing/comparison consumers.
+Owned paths: lib/preferred-partner/pricing.ts, lib/preferred-partner/pricing.test.ts, lib/server/preferred-partner-savings.test.ts, lib/server/preferred-partner-proposal.test.ts, SESSION.md.
+Out of scope: order/payment mutations, external-system writes, schema/auth, account-specific policies, redesign.
+Architecture: retain shared domain catalog; existing browser comparison/proposal flows consume its results.
+Validation: RED regression before catalog edit, focused tests, npm run verify, authenticated browser check when available.

--- a/lib/preferred-partner/pricing.test.ts
+++ b/lib/preferred-partner/pricing.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { matchPreferredPartnerPrice } from './pricing';
+import { calculatePreferredPartnerOrdersFromRows } from '@/lib/server/preferred-partner-savings';
+
+describe('updated partner catalog', () => {
+  it.each([
+    ['SMACK. | Infused Pre-roll | .5G SINGLE | OG Punch', 4.5, 3.6],
+    ['SMACK. | Infused Pre-roll | 1G SINGLE | Banana Runtz', 6.75, 5.4],
+    ['CHOPSTICKS | Uninfused Pre-roll | .5G 2-PACK (1G) | Blueberry', 5.5, 4.4],
+  ])('uses approved rates for %s in SKU matching and savings', (skuName, standardWholesale, preferredWholesale) => {
+    expect(matchPreferredPartnerPrice({ skuName })).toMatchObject({ standardWholesale, preferredWholesale });
+    const [order] = calculatePreferredPartnerOrdersFromRows([{
+      order: 'catalog-regression', createdTimestamp: '2026-09-08T12:00:00Z',
+      skuName, units: 10, pricePerUnit: standardWholesale,
+      taxInclusiveLineItemSubtotal: standardWholesale * 10,
+      orderTotal: standardWholesale * 10,
+    }]);
+    expect(order.preferredTotal).toBe(preferredWholesale * 10);
+    expect(order.savings).toBe(Math.round((standardWholesale - preferredWholesale) * 1000) / 100);
+  });
+});

--- a/lib/preferred-partner/pricing.ts
+++ b/lib/preferred-partner/pricing.ts
@@ -8,13 +8,13 @@ export type PreferredPartnerPrice = {
 };
 
 export const PREFERRED_PARTNER_PRICING: PreferredPartnerPrice[] = [
-  { brand: 'Chopsticks', displayBrand: 'Chopsticks 2-Pk', size: '2 (.5g)', weight: '1g', standardWholesale: 5, preferredWholesale: 4 },
+  { brand: 'Chopsticks', displayBrand: 'Chopsticks 2-Pk', size: '2 (.5g)', weight: '1g', standardWholesale: 5.5, preferredWholesale: 4.4 },
   { brand: 'Ichi-Roll', displayBrand: 'Ichi Single', size: 'Single', weight: '1g', standardWholesale: 5, preferredWholesale: 4 },
   { brand: 'Ichi-Roll', displayBrand: 'Ichi Pack', size: '4-Pack', weight: '4g', standardWholesale: 16, preferredWholesale: 12.8 },
   { brand: '#Juan-Roll', displayBrand: '#Juan Single', size: 'Single', weight: '1g', standardWholesale: 5, preferredWholesale: 4 },
   { brand: '#Juan-Roll', displayBrand: '#Juan Pack', size: '4-Pack', weight: '4g', standardWholesale: 16, preferredWholesale: 12.8 },
-  { brand: 'Smack.', displayBrand: 'Smack Mini Single', size: 'Mini', weight: '0.5g', standardWholesale: 4.25, preferredWholesale: 3.4 },
-  { brand: 'Smack.', displayBrand: 'Smack Single', size: 'Single', weight: '1g', standardWholesale: 6.25, preferredWholesale: 5 },
+  { brand: 'Smack.', displayBrand: 'Smack Mini Single', size: 'Mini', weight: '0.5g', standardWholesale: 4.5, preferredWholesale: 3.6 },
+  { brand: 'Smack.', displayBrand: 'Smack Single', size: 'Single', weight: '1g', standardWholesale: 6.75, preferredWholesale: 5.4 },
   { brand: 'O-Yeah', displayBrand: 'O-Yeah Single', size: 'Single', weight: '1g', standardWholesale: 7.5, preferredWholesale: 6 },
   { brand: 'O-Yeah', displayBrand: 'O-Yeah Pack', size: '5-Pack', weight: '2.5g', standardWholesale: 17.5, preferredWholesale: 14 },
   { brand: 'State of Mind', displayBrand: 'State of Mind Single', size: 'Single', weight: '1g', standardWholesale: 10, preferredWholesale: 8 },

--- a/lib/server/preferred-partner-proposal.test.ts
+++ b/lib/server/preferred-partner-proposal.test.ts
@@ -88,7 +88,7 @@ describe('calculatePreferredPartnerProposalDraft', () => {
           skuInventoryClass: 'PRE_ROLL',
           skuInventoryCategory: 'SINGLE',
           skuCasePackSize: 10,
-          skuPricePerUnit: '3.40',
+          skuPricePerUnit: '3.60',
           warehouseCounts: [{ warehouseId: 'warehouse-a', available: 220, updatedAt: '2026-04-22T10:00:00.000Z' }],
         },
         {
@@ -113,12 +113,12 @@ describe('calculatePreferredPartnerProposalDraft', () => {
     expect(draft.lines.find((line) => line.sourceKind === 'demand')).toMatchObject({
       sourceKind: 'demand',
       quantity: 170,
-      unitPrice: 3.4,
+      unitPrice: 3.6,
     });
     expect(draft.breakdownRows).toHaveLength(2);
-    expect(draft.summary.currentPromoTotal).toBe(803);
+    expect(draft.summary.currentPromoTotal).toBe(837);
     expect(draft.summary.creditMemo).toBe(25);
-    expect(draft.summary.totalBalanceDue).toBe(778);
+    expect(draft.summary.totalBalanceDue).toBe(812);
     expect(draft.inputSummary.unmatchedRowCount).toBe(0);
   });
 

--- a/lib/server/preferred-partner-savings.test.ts
+++ b/lib/server/preferred-partner-savings.test.ts
@@ -102,7 +102,7 @@ describe('Preferred Partner savings math', () => {
       matchPreferredPartnerPrice({
         skuName: 'SMACK. | Infused Pre-roll | 1G SINGLE | Banana Runtz',
       }),
-    ).toMatchObject({ brand: 'Smack.', size: 'Single', preferredWholesale: 5 });
+    ).toMatchObject({ brand: 'Smack.', size: 'Single', preferredWholesale: 5.4 });
 
     expect(
       matchPreferredPartnerPrice({
@@ -116,13 +116,13 @@ describe('Preferred Partner savings math', () => {
       matchPreferredPartnerPrice({
         skuName: 'CHOPSTIX | Infused Pre-roll | .5G SINGLE | OG Kush (S)',
       }),
-    ).toMatchObject({ brand: 'Chopsticks', size: '2 (.5g)', preferredWholesale: 4 });
+    ).toMatchObject({ brand: 'Chopsticks', size: '2 (.5g)', preferredWholesale: 4.4 });
 
     expect(
       matchPreferredPartnerPrice({
         skuName: 'CHOPSTICKS | Infused Pre-roll | .5G SINGLE | OG Kush (S)',
       }),
-    ).toMatchObject({ brand: 'Chopsticks', size: '2 (.5g)', preferredWholesale: 4 });
+    ).toMatchObject({ brand: 'Chopsticks', size: '2 (.5g)', preferredWholesale: 4.4 });
   });
 
   it('uses tax-inclusive order total, ignores credit memos, and excludes surcharge', () => {
@@ -256,9 +256,9 @@ describe('Preferred Partner savings math', () => {
 
     expect(order.paidTotal).toBe(47.5);
     expect(order.currentPromoTotal).toBe(47.5);
-    expect(order.savings).toBe(13.5);
-    expect(order.preferredTotal).toBe(34);
-    expect(order.standardWholesaleDiscount).toBe(8.5);
+    expect(order.savings).toBe(11.5);
+    expect(order.preferredTotal).toBe(36);
+    expect(order.standardWholesaleDiscount).toBe(9);
   });
 
   it.each(randomInvoiceCases)('$label', (testCase) => {


### PR DESCRIPTION
Closes #185

The shared catalog contained superseded rates, so existing browser savings and proposal tables calculated against outdated prices. Updates the three affected catalog entries and regression expectations; all consumers continue using the existing shared domain catalog.

Validation: three regression cases failed on the original catalog, then passed with the fix. `npm run verify` passed lint, typecheck, 48 test files / 206 tests, Prisma validation, and production build. `git diff --check` passed. No layout or interaction code changed. Signed-in browser verification remains pending: the available PICC browser session opens at sign-in.

No schema, auth, external-system writes, order changes, or payment-processing logic changed. Five files; owned paths: lib/preferred-partner/pricing.ts, lib/preferred-partner/pricing.test.ts, lib/server/preferred-partner-savings.test.ts, lib/server/preferred-partner-proposal.test.ts, SESSION.md.

Checked PRs #182, #166, #144, #135, #82. No active pricing implementation overlap. SESSION.md is an administrative handoff overlap to preserve on rebase; broad structural PR #144 must rebase if this surgical fix lands first.

Remaining risk: live authenticated UI verification and deployment confirmation are outstanding. The catalog remains a current-price comparison, not an effective-dated historical price schedule.